### PR TITLE
Rename getGeneratorJsFilename to getGeneratorJsPath

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/DevTestsActivity.java
@@ -124,7 +124,7 @@ public class DevTestsActivity extends BlocklySectionsActivity {
     }
 
     @NonNull
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "sample_sections/generators.js";
     }
 

--- a/blocklydemo/src/main/java/com/google/blockly/demo/SimpleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/SimpleActivity.java
@@ -43,7 +43,7 @@ public class SimpleActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "turtle/generators.js";
     }
 

--- a/blocklydemo/src/main/java/com/google/blockly/demo/SplitActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/SplitActivity.java
@@ -76,7 +76,7 @@ public class SplitActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "turtle/generators.js";
     }
 

--- a/blocklydemo/src/main/java/com/google/blockly/demo/StylesActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/StylesActivity.java
@@ -45,7 +45,7 @@ public class StylesActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "turtle/generators.js";
     }
 

--- a/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
@@ -107,7 +107,7 @@ public class TurtleActivity extends BlocklySectionsActivity {
 
     @NonNull
     @Override
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "turtle/generators.js";
     }
 

--- a/blocklylib/src/androidTest/java/com/google/blockly/BlocklyTestActivity.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/BlocklyTestActivity.java
@@ -41,7 +41,7 @@ public class BlocklyTestActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getGeneratorJsFilename() {
+    protected String getGeneratorJsPath() {
         return "sample_sections/generators.js";
     }
 

--- a/blocklylib/src/main/java/com/google/blockly/AbstractBlocklyActivity.java
+++ b/blocklylib/src/main/java/com/google/blockly/AbstractBlocklyActivity.java
@@ -57,7 +57,7 @@ import java.io.IOException;
  * navigation menu.
  * <p/>
  * Configure Block by providing defintions for {@link #getBlockDefinitionsJsonPath()},
- * {@link #getToolboxContentsXmlPath()}, and {@link #getGeneratorJsFilename()}.  An initial
+ * {@link #getToolboxContentsXmlPath()}, and {@link #getGeneratorJsPath()}.  An initial
  * workspace can be defined by overriding {@link #getStartingWorkspacePath()}.
  * <p/>
  * The central app views can be replaced by overloading {@link #onCreateContentView} and the
@@ -424,7 +424,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      * @return The asset file path and name to the generator Javascript.
      */
     @NonNull
-    abstract protected String getGeneratorJsFilename();
+    abstract protected String getGeneratorJsPath();
 
     /**
      * Creates or loads the root content view (by default, {@link R.layout#drawers_and_action_bar})
@@ -580,7 +580,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
                         new CodeGenerationRequest(serialized.toString(),
                                 getCodeGenerationCallback(),
                                 getBlockDefinitionsJsonPath(),
-                                getGeneratorJsFilename()));
+                                getGeneratorJsPath()));
             }
         } catch (BlocklySerializerException e) {
             Log.wtf(TAG, e);


### PR DESCRIPTION
This makes it consistent with the other methods that get a path to a
file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/4)

<!-- Reviewable:end -->
