### PR TITLE
Blockly standard blocks: loops, numbers, and variables

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_1/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_1/toolbox.xml
@@ -16,7 +16,7 @@
     <block type="controls_repeat_ext">
         <value name="TIMES">
             <block type="math_number">
-                <field name="NUM">0</field>
+                <field name="NUM">10</field>
             </block>
         </value>
     </block>
@@ -32,6 +32,6 @@
     <block type="statement_statement_input"></block>
     <block type="output_no_input"></block>
     <block type="statement_no_next"></block>
-    <block type="set_var"></block>
-    <block type="get_var"></block>
+    <block type="variables_set"></block>
+    <block type="variables_get"></block>
 </xml>

--- a/blocklydemo/src/main/assets/sample_sections/level_2/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_2/toolbox.xml
@@ -29,7 +29,7 @@
         <block type="statement_value_input"></block>
     </category>
     <category name="Variables">
-        <block type="set_var"></block>
-        <block type="get_var"></block>
+        <block type="variables_set"></block>
+        <block type="variables_get"></block>
     </category>
 </xml>

--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -30,7 +30,7 @@
         <block type="controls_repeat_ext">
             <value name="TIMES">
                 <block type="math_number">
-                    <field name="NUM">0</field>
+                    <field name="NUM">10</field>
                 </block>
             </value>
         </block>
@@ -44,7 +44,7 @@
         <block type="statement_value_input"></block>
     </category>
     <category name="Variables">
-        <block type="set_var"></block>
-        <block type="get_var"></block>
+        <block type="variables_set"></block>
+        <block type="variables_get"></block>
     </category>
 </xml>

--- a/blocklydemo/src/main/assets/turtle/generators.js
+++ b/blocklydemo/src/main/assets/turtle/generators.js
@@ -75,3 +75,6 @@ Blockly.JavaScript['turtle_font'] = function(block) {
       block.getFieldValue('FONTSTYLE') + '\', \'block_id_' +
       block.id + '\');\n';
 };
+
+Blockly.JavaScript['turtle_repeat_internal'] =
+    Blockly.JavaScript['controls_repeat'];

--- a/blocklydemo/src/main/assets/turtle/toolbox_all.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_all.xml
@@ -33,7 +33,18 @@
     </category>
     <category name="Loops">
         <block type="controls_repeat_ext">
-            <field name="TIMES">4</field>
+            <value name="TIMES">
+                <block type="math_number">
+                    <field name="NUM">10</field>
+                </block>
+            </value>
         </block>
+    </category>
+    <category name="Math">
+        <block type="math_number" />
+    </category>
+    <category name="Variables">
+        <block type="variables_set" />
+        <block type="variables_get" />
     </category>
 </xml>

--- a/blocklydemo/src/main/assets/turtle/toolbox_basic.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_basic.xml
@@ -24,7 +24,7 @@
         </block>
     </category>
     <category name="Loops">
-        <block type="controls_repeat_ext">
+        <block type="turtle_repeat_internal">
             <field name="TIMES">4</field>
         </block>
     </category>

--- a/blocklydemo/src/main/assets/turtle/toolbox_colour.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_colour.xml
@@ -29,7 +29,7 @@
         </block>
     </category>
     <category name="Loops">
-        <block type="controls_repeat_ext">
+        <block type="turtle_repeat_internal">
             <field name="TIMES">4</field>
         </block>
     </category>

--- a/blocklydemo/src/main/assets/turtle/toolbox_colour_pen.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_colour_pen.xml
@@ -32,7 +32,7 @@
         </block>
     </category>
     <category name="Loops">
-        <block type="controls_repeat_ext">
+        <block type="turtle_repeat_internal">
             <field name="TIMES">4</field>
         </block>
     </category>

--- a/blocklydemo/src/main/assets/turtle/turtle_blocks.json
+++ b/blocklydemo/src/main/assets/turtle/turtle_blocks.json
@@ -139,7 +139,7 @@
     "tooltip": "Changes the colour of the pen."
   },
   {
-    "id": "controls_repeat_ext",
+    "id": "turtle_repeat_internal",
     "message0": "repeat %1 times %2 %3",
     "args0": [
       {

--- a/blocklydemo/src/main/java/com/google/blockly/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/DevTestsActivity.java
@@ -29,6 +29,8 @@ import com.google.blockly.utils.CodeGenerationRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -37,6 +39,14 @@ import java.util.List;
  */
 public class DevTestsActivity extends BlocklySectionsActivity {
     private static final String TAG = "DevTestsActivity";
+
+    private static final List<String> BLOCK_DEFINITIONS = Collections.unmodifiableList(
+            Arrays.asList(new String[]{
+                    "default/loop_blocks.json",
+                    "default/math_blocks.json",
+                    "default/variable_blocks.json",
+                    "default/test_blocks.json"
+            }));
 
     private static int CARPET_SIZE = 1000;
 
@@ -114,8 +124,8 @@ public class DevTestsActivity extends BlocklySectionsActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
-        return "default/toolbox_blocks.json";
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return BLOCK_DEFINITIONS;
     }
 
     @Override

--- a/blocklydemo/src/main/java/com/google/blockly/demo/SimpleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/SimpleActivity.java
@@ -20,6 +20,8 @@ import com.google.blockly.AbstractBlocklyActivity;
 import com.google.blockly.LoggingCodeGeneratorCallback;
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import java.util.List;
+
 /**
  * Simplest implementation of AbstractBlocklyActivity.
  */
@@ -31,8 +33,8 @@ public class SimpleActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
-        return "turtle/definitions.json";
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return TurtleActivity.TURTLE_BLOCK_DEFINITIONS;
     }
 
     @NonNull

--- a/blocklydemo/src/main/java/com/google/blockly/demo/SplitActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/SplitActivity.java
@@ -24,6 +24,8 @@ import android.widget.TextView;
 import com.google.blockly.AbstractBlocklyActivity;
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import java.util.List;
+
 
 /**
  * Demo activity that programmatically adds a view to split the screen between the Blockly workspace
@@ -64,8 +66,8 @@ public class SplitActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
-        return "turtle/definitions.json";
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return TurtleActivity.TURTLE_BLOCK_DEFINITIONS;
     }
 
     @NonNull

--- a/blocklydemo/src/main/java/com/google/blockly/demo/StylesActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/StylesActivity.java
@@ -20,6 +20,8 @@ import com.google.blockly.AbstractBlocklyActivity;
 import com.google.blockly.LoggingCodeGeneratorCallback;
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import java.util.List;
+
 /**
  * Basic implementation of AbstractBlocklyActivity that demonstrates applying styles. This demo
  * uses an Activity style defined in the manifest XML. Alternatively, Activities can override
@@ -33,8 +35,8 @@ public class StylesActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
-        return "turtle/definitions.json";
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return TurtleActivity.TURTLE_BLOCK_DEFINITIONS;
     }
 
     @NonNull

--- a/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
@@ -20,7 +20,6 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.View;
-import android.webkit.ConsoleMessage;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.ArrayAdapter;
@@ -31,12 +30,24 @@ import com.google.blockly.BlocklySectionsActivity;
 import com.google.blockly.util.JavascriptUtil;
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 
 /**
  * Demo app with the Blockly Games turtle game in a webview.
  */
 public class TurtleActivity extends BlocklySectionsActivity {
     private static final String TAG = "TurtleActivity";
+
+    static final List<String> TURTLE_BLOCK_DEFINITIONS = Collections.unmodifiableList(
+            Arrays.asList(new String[]{
+                    "default/loop_blocks.json",
+                    "default/math_blocks.json",
+                    "default/variable_blocks.json",
+                    "turtle/turtle_blocks.json"
+            }));
 
     private static final int MAX_LEVELS = 10;
     private static final String[] LEVEL_TOOLBOX = new String[MAX_LEVELS];
@@ -76,11 +87,11 @@ public class TurtleActivity extends BlocklySectionsActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
+    protected List<String> getBlockDefinitionsJsonPaths() {
         // Use the same blocks for all the levels. This lets the user's block code carry over from
         // level to level. The set of blocks shown in the toolbox for each level is defined by the
         // toolbox path below.
-        return "turtle/definitions.json";
+        return TURTLE_BLOCK_DEFINITIONS;
     }
 
     @NonNull
@@ -88,6 +99,11 @@ public class TurtleActivity extends BlocklySectionsActivity {
     protected String getToolboxContentsXmlPath() {
         // Expose a different set of blocks to the user at each level.
         return "turtle/" + LEVEL_TOOLBOX[getCurrentSectionIndex()];
+    }
+
+    @Override
+    protected void onInitBlankWorkspace() {
+        mController.addVariable("item");
     }
 
     @NonNull

--- a/blocklylib/src/androidTest/java/com/google/blockly/BlocklyTestActivity.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/BlocklyTestActivity.java
@@ -18,11 +18,23 @@ import android.support.annotation.NonNull;
 
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Simplest implementation of AbstractBlocklyActivity. Does not load a workspace at start.
  */
 public class BlocklyTestActivity extends AbstractBlocklyActivity {
-    private static final String TAG = "SimpleActivity";
+    private static final String TAG = "BlocklyTestActivity";
+
+    private static final List<String> BLOCK_DEFINITIONS = Collections.unmodifiableList(
+            Arrays.asList(new String[]{
+                    "default/loop_blocks.json",
+                    "default/math_blocks.json",
+                    "default/variable_blocks.json",
+                    "default/test_blocks.json"
+            }));
 
     CodeGenerationRequest.CodeGeneratorCallback mCodeGeneratorCallback =
             new LoggingCodeGeneratorCallback(this, TAG);
@@ -35,14 +47,14 @@ public class BlocklyTestActivity extends AbstractBlocklyActivity {
 
     @NonNull
     @Override
-    protected String getBlockDefinitionsJsonPath() {
-        return "default/toolbox_blocks.json";
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return BLOCK_DEFINITIONS;
     }
 
     @NonNull
     @Override
     protected String getGeneratorJsPath() {
-        return "sample_sections/generators.js";
+        return "fake/generator.js";  // Never executed in tests.
     }
 
     @NonNull

--- a/blocklylib/src/main/assets/default/loop_blocks.json
+++ b/blocklylib/src/main/assets/default/loop_blocks.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "controls_repeat_ext",
+    "message0": "repeat %1 times %2 %3",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "TIMES"
+      },
+      {
+        "type": "input_dummy"
+      },
+      {
+        "type": "input_statement",
+        "name": "DO"
+      }
+    ],
+    "colour": 120,
+    "inputsInline": true,
+    "tooltip": "Do some statements several times.",
+    "helpUrl": "https://en.wikipedia.org/wiki/For_loop"
+  }
+]

--- a/blocklylib/src/main/assets/default/math_blocks.json
+++ b/blocklylib/src/main/assets/default/math_blocks.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "math_number",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "NUM",
+        "text": "0"
+      }
+    ],
+    "colour": 230,
+    "output": "Number",
+    "tooltip": "A number.",
+    "helpUrl": "https://en.wikipedia.org/wiki/Number"
+  }
+]

--- a/blocklylib/src/main/assets/default/test_blocks.json
+++ b/blocklylib/src/main/assets/default/test_blocks.json
@@ -1,25 +1,5 @@
 [
   {
-    "id": "controls_repeat_ext",
-    "message0": "repeat %1 times %2 %3",
-    "args0": [
-      {
-        "type": "input_value",
-        "name": "TIMES"
-      },
-      {
-        "type": "input_dummy"
-      },
-      {
-        "type": "input_statement",
-        "name": "DO"
-      }
-    ],
-    "inputsInline": true,
-    "tooltip": "",
-    "helpUrl": "http://www.example.com/"
-  },
-  {
     "id": "controls_whileUntil",
     "message0": "repeat %1 %2 %3",
     "args0": [
@@ -47,21 +27,6 @@
       }
     ],
     "tooltip": "",
-    "helpUrl": "http://www.example.com/"
-  },
-  {
-    "id": "math_number",
-    "message0": "%1",
-    "args0": [
-      {
-        "type": "field_input",
-        "name": "NUM",
-        "text": "0"
-      }
-    ],
-    "output": "Number",
-    "tooltip": "",
-    "colour": 120,
     "helpUrl": "http://www.example.com/"
   },
   {
@@ -162,41 +127,6 @@
     "message0": "test block",
     "args0": [],
     "previousStatement": null,
-    "tooltip": "",
-    "helpUrl": "http://www.example.com/"
-  },
-  {
-    "id": "get_var",
-    "message0": "get %1",
-    "args0": [
-      {
-        "type": "field_variable",
-        "name": "VARIABLE",
-        "variable": "item"
-      }
-    ],
-    "output": null,
-    "colour": 160,
-    "tooltip": "",
-    "helpUrl": "http://www.example.com/"
-  },
-  {
-    "id": "set_var",
-    "message0": "set %1 %2",
-    "args0": [
-      {
-        "type": "field_variable",
-        "name": "VARIABLE",
-        "variable": "item"
-      },
-      {
-        "type": "input_value",
-        "name": "VALUE"
-      }
-    ],
-    "previousStatement": null,
-    "nextStatement": null,
-    "colour": 160,
     "tooltip": "",
     "helpUrl": "http://www.example.com/"
   }

--- a/blocklylib/src/main/assets/default/variable_blocks.json
+++ b/blocklylib/src/main/assets/default/variable_blocks.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "variables_get",
+    "message0": "get %1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "item"
+      }
+    ],
+    "output": null,
+    "colour": 330,
+    "tooltip": "Returns the value of this variable.",
+    "helpUrl": "https://github.com/google/blockly/wiki/Variables#get"
+  },
+  {
+    "id": "variables_set",
+    "message0": "set %1 to %2",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "item"
+      },
+      {
+        "type": "input_value",
+        "name": "VALUE"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "inputsInline": true,
+    "colour": 330,
+    "tooltip": "Sets this variable to be equal to the input.",
+    "helpUrl": "https://github.com/google/blockly/wiki/Variables#get"
+  }
+]

--- a/blocklylib/src/main/java/com/google/blockly/CodeGeneratorService.java
+++ b/blocklylib/src/main/java/com/google/blockly/CodeGeneratorService.java
@@ -30,9 +30,16 @@ import android.webkit.WebViewClient;
 
 import com.google.blockly.utils.CodeGenerationRequest;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Background service that uses a WebView to statically load the Web Blockly libraries and use them
@@ -50,7 +57,7 @@ public class CodeGeneratorService extends Service {
     private WebView mWebview;
     private CodeGenerationRequest.CodeGeneratorCallback mCallback;
     private Handler mHandler;
-    private String mDefinitions = "";
+    private List<String> mDefinitions = new ArrayList<>();
     private String mGenerators = "";
 
     @Override
@@ -109,11 +116,11 @@ public class CodeGeneratorService extends Service {
                     @Override
                     public void run() {
                         mCallback = request.getCallback();
-                        if (!request.getBlockDefinitionsFilename().equals(mDefinitions)
+                        if (!equalsPriorDefintions(mDefinitions)
                                 || !request.getBlockGeneratorsFilename().equals(mGenerators)) {
                              //Reload the page with the new block definitions.  Push the request
                              //back onto the queue until the page is loaded.
-                            mDefinitions = request.getBlockDefinitionsFilename();
+                            mDefinitions = request.getBlockDefinitionsFilenames();
                             mGenerators = request.getBlockGeneratorsFilename();
                             mRequestQueue.addFirst(request);
                             mWebview.loadUrl(BLOCKLY_COMPILER_PAGE);
@@ -148,23 +155,79 @@ public class CodeGeneratorService extends Service {
 
         @JavascriptInterface
         public String getBlockDefinitions() {
-            try {
-                InputStream blockIs = getAssets().open(mDefinitions);
-                int size = blockIs.available();
-                byte[] buffer = new byte[size];
-                blockIs.read(buffer);
-
-                return new String(buffer, "UTF-8");
-            } catch (IOException e) {
-                Log.e(TAG, "Couldn't find block definitions file " + mDefinitions);
+            if (mDefinitions.isEmpty()) {
+                return "";
             }
-            return "";
+            if (mDefinitions.size() == 1) {
+                // Pass in contents without parsing.
+                String filename = mDefinitions.get(0);
+                try {
+                    return loadAssetAsUtf8(filename);
+                } catch (IOException e) {
+                    Log.e(TAG, "Couldn't find block definitions file \"" + filename + "\"");
+                    return "";
+                }
+            } else {
+                // Concatenate all definitions into a single stream.
+                JSONArray allBlocks = new JSONArray();
+                String filename = null;
+                try {
+                    if (mDefinitions != null) {
+                        Iterator<String> iter = mDefinitions.iterator();
+                        while (iter.hasNext()) {
+                            filename = iter.next();
+                            String contents = loadAssetAsUtf8(filename);
+                            JSONArray fileBlocks = new JSONArray(contents);
+                            for (int i = 0; i < fileBlocks.length(); ++i) {
+                                allBlocks.put(fileBlocks.getJSONObject(i));
+                            }
+                        }
+                    }
+                } catch (IOException|JSONException e) {
+                    Log.e(TAG, "Error reading block definitions file \"" + filename + "\"");
+                    return "";
+                }
+                return allBlocks.toString();
+            }
         }
     }
 
     public class CodeGeneratorBinder extends Binder {
         CodeGeneratorService getService() {
             return CodeGeneratorService.this;
+        }
+    }
+
+    private boolean equalsPriorDefintions(List<String> newDefinitions) {
+        LinkedList<String> oldDefinitions = new LinkedList<>(mDefinitions);
+        for (String filename : newDefinitions) {
+            if (!oldDefinitions.remove(filename)) {
+                return false;
+            }
+        }
+        return oldDefinitions.isEmpty(); // If it is empty, all filenames were found / matched.
+    }
+
+    private String loadAssetAsUtf8(String filename) throws IOException {
+        InputStream input = null;
+        try {
+            input = getAssets().open(filename);
+
+            int size = input.available();
+            byte[] buffer = new byte[size];
+            input.read(buffer);
+
+            return new String(buffer, "UTF-8");
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Couldn't find asset file \"" + mDefinitions + "\"");
+        } finally {
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    Log.w(TAG, "Unable to close asset file \"" + filename + "\"", e);
+                }
+            }
         }
     }
 }

--- a/blocklylib/src/main/java/com/google/blockly/control/BlocklyController.java
+++ b/blocklylib/src/main/java/com/google/blockly/control/BlocklyController.java
@@ -48,6 +48,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 
@@ -964,14 +965,13 @@ public class BlocklyController {
         }
 
         /**
-         * Add a set of block definitions to load from an asset file. These will be added to the set
-         * of all known blocks, but will not appear in the user's toolbox unless they are also
+         * Add a set of block definitions to load from a JSON asset file. These will be added to the
+         * set of all known blocks, but will not appear in the user's toolbox unless they are also
          * defined in the toolbox configuration via {@link #setToolboxConfigurationResId(int)}.
          * <p/>
          * The asset name must be a path to a file in the assets directory. If the file contains
-         * blocks that were previously defined they will be overridden.
-         * <p/>
-         * A duplicate block is any block with the same {@link Block#getName() name}.
+         * blocks that were previously defined, they will be overridden. A duplicate block is any
+         * block with the same {@link Block#getName() name}.
          *
          * @param assetName the path of the asset to load from.
          * @return this
@@ -981,6 +981,24 @@ public class BlocklyController {
             return this;
         }
 
+        /**
+         * Add sets of block definitions to load from multiple JSON asset file. These will be added
+         * to the set of all known blocks, but will not appear in the user's toolbox unless they are
+         * also defined in the toolbox configuration via {@link #setToolboxConfigurationResId(int)}.
+         * <p/>
+         * The asset names must be a path to files in the assets directory. If the files contain
+         * blocks that were previously defined, they will be overridden. A duplicate block is any
+         * block with the same {@link Block#getName() name}.
+         *
+         * @param assetNames The paths of the assets to load.
+         * @return this
+         */
+        public Builder addBlockDefinitionsFromAssets(List<String> assetNames) {
+            for (String assetName : assetNames) {
+                mBlockDefAssets.add(assetName);
+            }
+            return this;
+        }
         /**
          * Adds a list of blocks to the set of all known blocks. These will be added to the set of
          * all known blocks, but will not appear in the user's toolbox unless they are also defined
@@ -1072,6 +1090,7 @@ public class BlocklyController {
             }
             for (int i = 0; i < mBlockDefAssets.size(); i++) {
                 try {
+                    Log.d(TAG, "mBlockDefAssets #" + i + ": " + mBlockDefAssets.get(i));
                     factory.addBlocks(mAssetManager.open(mBlockDefAssets.get(i)));
                 } catch (IOException e) {
                     throw new IllegalArgumentException("Failed to load block definitions "

--- a/blocklylib/src/main/java/com/google/blockly/utils/CodeGenerationRequest.java
+++ b/blocklylib/src/main/java/com/google/blockly/utils/CodeGenerationRequest.java
@@ -17,13 +17,15 @@ package com.google.blockly.utils;
 
 import com.google.blockly.CodeGeneratorService;
 
+import java.util.List;
+
 /**
  * Container for the information needed to generate code through the {@link CodeGeneratorService}.
  */
 public class CodeGenerationRequest {
     private final CodeGeneratorCallback mCallback;
     private final String mBlocklyXml;
-    private final String mBlockDefinitionsFilename;
+    private final List<String> mBlockDefinitionsFilenames;
     private final String mBlockGeneratorsFilename;
 
     /**
@@ -31,20 +33,20 @@ public class CodeGenerationRequest {
      *
      * @param xml The xml of a full workspace for which code should be generated.
      * @param callback A callback specifying what to do with the generated code.
-     * @param blockDefinitionsFilename The path of the js file containing block definitions,
+     * @param blockDefinitionsFilenames The paths of the js files containing block definitions,
      * relative to file:///android_assets/background_compiler.html.
      * @param blockGeneratorsFilename The path of the js file containing block generators, relative
      * to file:///android_assets/background_compiler.html.
      */
     public CodeGenerationRequest(String xml, CodeGeneratorCallback callback,
-            String blockDefinitionsFilename, String blockGeneratorsFilename) {
+            List<String> blockDefinitionsFilenames, String blockGeneratorsFilename) {
         if (xml == null || xml.isEmpty()) {
             throw new IllegalArgumentException("The blockly workspace string must not be empty " +
                     "or null.");
         }
         mCallback = callback;
         mBlocklyXml = xml;
-        mBlockDefinitionsFilename = blockDefinitionsFilename;
+        mBlockDefinitionsFilenames = blockDefinitionsFilenames;
         mBlockGeneratorsFilename = blockGeneratorsFilename;
     }
 
@@ -56,8 +58,8 @@ public class CodeGenerationRequest {
         return mBlocklyXml;
     }
 
-    public String getBlockDefinitionsFilename() {
-        return mBlockDefinitionsFilename;
+    public List<String> getBlockDefinitionsFilenames() {
+        return mBlockDefinitionsFilenames;
     }
 
     public String getBlockGeneratorsFilename() {


### PR DESCRIPTION
Starting to organize the Blockly standard blocks in the required JSON format.  Sharing definitions between Turtle and DevTests.  This adds numbers, variables, and arbitrary repetition loops to Turtle.

`AbstractBlocklyActivity` now handles multiple block definition files, and has a new onInitBlankWorkspace() hook.

Changed variable block ids to match standard blockly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/23)

<!-- Reviewable:end -->
