### PR TITLE
Add variables to the Turtle demo

### DIFF
--- a/blocklydemo/src/main/assets/turtle/definitions.json
+++ b/blocklydemo/src/main/assets/turtle/definitions.json
@@ -176,5 +176,153 @@
     "nextStatement": null,
     "colour": 120,
     "tooltip": "Do some statements several times."
+  },
+  {
+    "id": "math_number",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "NUM",
+        "text": "5"
+      }
+    ],
+    "output": "Number",
+    "colour": 230,
+    "tooltip": "A number output."
+  },
+  {
+    "id": "colour_picker",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_colour",
+        "name": "COLOUR",
+        "colour": "#ff0000"
+      }
+    ],
+    "output": "Colour",
+    "colour": 20
+  },
+  {
+    "id": "turtle_move",
+    "message0": "%1 %2",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "DIR",
+        "options": [
+          [
+            "move forward",
+            "moveForward"
+          ],
+          [
+            "move backward",
+            "moveBackward"
+          ]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "VALUE"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 160,
+    "tooltip": "Move the turtle forward or backward",
+    "helpUrl": "https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#metkk9"
+  },
+  {
+    "id": "turtle_turn",
+    "message0": "%1 %2",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "DIR",
+        "options": [
+          [
+            "turn right ↻",
+            "turnLeft"
+          ],
+          [
+            "turn left ↺",
+            "turnRight"
+          ]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "VALUE"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 160,
+    "tooltip": "",
+    "helpUrl": "https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#nwzsuj"
+  },
+  {
+    "id": "turtle_width",
+    "message0": "set width to %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "WIDTH"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 160,
+    "tooltip": "",
+    "helpUrl": "https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#wkz8h4"
+  },
+  {
+    "id": "turtle_colour",
+    "message0": "set colour to %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "COLOUR"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 20,
+    "tooltip": "",
+    "helpUrl": "https://blockly-demo.appspot.com/static/demos/blockfactory/index.html#wkz8h4"
+  },
+  {
+    "id": "variables_get",
+    "message0": "get %1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "item"
+      }
+    ],
+    "output": null,
+    "colour": 160,
+    "tooltip": "Get the value stored in a variable."
+  },
+  {
+    "id": "variables_set",
+    "message0": "set %1 %2",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "item"
+      },
+      {
+        "type": "input_value",
+        "name": "VALUE"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 160,
+    "tooltip": "Set a variable to a new value."
   }
 ]

--- a/blocklydemo/src/main/assets/turtle/generators.js
+++ b/blocklydemo/src/main/assets/turtle/generators.js
@@ -75,3 +75,62 @@ Blockly.JavaScript['turtle_font'] = function(block) {
       block.getFieldValue('FONTSTYLE') + '\', \'block_id_' +
       block.id + '\');\n';
 };
+
+Blockly.JavaScript['math_number'] = function(block) {
+  // Numeric value.
+  var code = parseFloat(block.getFieldValue('NUM'));
+  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+};
+
+Blockly.JavaScript['colour_picker'] = function(block) {
+  // Colour picker.
+  var code = '\'' + block.getFieldValue('COLOUR') + '\'';
+  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+};
+
+Blockly.JavaScript['turtle_move'] = function(block) {
+  // Generate JavaScript for moving forward or backwards.
+  var value = Blockly.JavaScript.valueToCode(block, 'VALUE',
+      Blockly.JavaScript.ORDER_NONE) || '0';
+  return 'Turtle.' + block.getFieldValue('DIR') +
+      '(' + value + ', \'block_id_' + block.id + '\');\n';
+};
+
+Blockly.JavaScript['turtle_turn'] = function(block) {
+  // Generate JavaScript for turning left or right.
+  var value = Blockly.JavaScript.valueToCode(block, 'VALUE',
+      Blockly.JavaScript.ORDER_NONE) || '0';
+  return 'Turtle.' + block.getFieldValue('DIR') +
+      '(' + value + ', \'block_id_' + block.id + '\');\n';
+};
+
+Blockly.JavaScript['turtle_width'] = function(block) {
+  // Generate JavaScript for setting the width.
+  var width = Blockly.JavaScript.valueToCode(block, 'WIDTH',
+      Blockly.JavaScript.ORDER_NONE) || '1';
+  return 'Turtle.penWidth(' + width + ', \'block_id_' + block.id + '\');\n';
+};
+
+Blockly.JavaScript['turtle_colour'] = function(block) {
+  // Generate JavaScript for setting the colour.
+  var colour = Blockly.JavaScript.valueToCode(block, 'COLOUR',
+      Blockly.JavaScript.ORDER_NONE) || '\'#000000\'';
+  return 'Turtle.penColour(' + colour + ', \'block_id_' +
+      block.id + '\');\n';
+};
+
+Blockly.JavaScript['variables_get'] = function(block) {
+  // Variable getter.
+  var code = Blockly.JavaScript.variableDB_.getName(block.getFieldValue('VAR'),
+      Blockly.Variables.NAME_TYPE);
+  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+};
+
+Blockly.JavaScript['variables_set'] = function(block) {
+  // Variable setter.
+  var argument0 = Blockly.JavaScript.valueToCode(block, 'VALUE',
+      Blockly.JavaScript.ORDER_ASSIGNMENT) || '0';
+  var varName = Blockly.JavaScript.variableDB_.getName(
+      block.getFieldValue('VAR'), Blockly.Variables.NAME_TYPE);
+  return varName + ' = ' + argument0 + ';\n';
+};

--- a/blocklydemo/src/main/assets/turtle/toolbox_all.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_all.xml
@@ -22,18 +22,52 @@
         <block type="turtle_turn_internal">
             <field name="VALUE">90</field>
         </block>
+        <block type="turtle_move">
+            <value name="VALUE">
+                <block type="math_number">
+                    <field name="NUM">50</field>
+                </block>
+            </value>
+        </block>
+        <block type="turtle_turn">
+            <value name="VALUE">
+                <block type="math_number">
+                    <field name="NUM">90</field>
+                </block>
+            </value>
+        </block>
+    </category>
+    <category name="Pen">
         <block type="turtle_pen">
             <field name="PEN">penUp</field>
         </block>
-    </category>
-    <category name="Colour">
         <block type="turtle_colour_internal">
             <field name="COLOUR">#ff0000</field>
         </block>
+        <block type="turtle_colour">
+            <value name="COLOUR">
+                <block type="colour_picker">
+                    <field name="COLOUR">#ff0000</field>
+                </block>
+            </value>
+        </block>
+        <block type="turtle_width">
+            <value name="WIDTH">
+                <block type="math_number">
+                    <field name="NUM">4</field>
+                </block>
+            </value>
+        </block>
+        <block type="colour_picker"></block>
     </category>
     <category name="Loops">
         <block type="controls_repeat_ext">
             <field name="TIMES">4</field>
         </block>
+    </category>
+    <category name="Variables">
+        <block type="math_number"></block>
+        <block type="variables_get"></block>
+        <block type="variables_set"></block>
     </category>
 </xml>

--- a/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/demo/TurtleActivity.java
@@ -16,6 +16,7 @@
 package com.google.blockly.demo;
 
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -73,6 +74,17 @@ public class TurtleActivity extends BlocklySectionsActivity {
                     });
                 }
             };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        // TODO: (#22) Remove this override when variables are supported properly
+        super.onCreate(savedInstanceState);
+        getController().addVariable("item");
+        getController().addVariable("leo");
+        getController().addVariable("don");
+        getController().addVariable("mike");
+        getController().addVariable("raf");
+    }
 
     @NonNull
     @Override

--- a/blocklylib/src/main/assets/background_compiler.html
+++ b/blocklylib/src/main/assets/background_compiler.html
@@ -45,6 +45,17 @@
 
 <script>
     function generate(blocklyxml) {
+      // TODO: (blockly/#265) Remove variables hack once variable fields are handled correctly.
+      if (Blockly.Blocks['variables_set']) {
+        Blockly.Blocks['variables_set'].getVars = function() {
+          return [this.getFieldValue('VAR')];
+        };
+      }
+      if (Blockly.Blocks['variables_get']) {
+        Blockly.Blocks['variables_get'].getVars = function() {
+          return [this.getFieldValue('VAR')];
+        };
+      }
       // Parse the XML into a tree.
       var xmlText = blocklyxml;
       var dom;


### PR DESCRIPTION
This does the minimum neccessary to add variables to the Turtle demo. This
includes a hack in background_compiler to make the variables_set and
variables_get blocks work correctly, though no other blocks with variables
will generate correctly until issue #265 in google/blockly is fixed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/24)

<!-- Reviewable:end -->
