### PR TITLE
Make spinners and field inputs styleable

### DIFF
--- a/blocklylib/src/androidTest/java/com/google/blockly/ui/fieldview/FieldInputViewTest.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/ui/fieldview/FieldInputViewTest.java
@@ -40,7 +40,6 @@ public class FieldInputViewTest extends MockitoAndroidTestCase {
     // Verify setting text in the view propagates to the field.
     public void testViewUpdatesField() {
         final FieldInputView view = makeFieldInputView();
-
         view.setText(SET_TEXT_VALUE);
         assertEquals(SET_TEXT_VALUE, mFieldInput.getText());
     }
@@ -55,6 +54,8 @@ public class FieldInputViewTest extends MockitoAndroidTestCase {
 
     @NonNull
     private FieldInputView makeFieldInputView() {
-        return new FieldInputView(getContext(), mFieldInput, mMockWorkspaceHelper);
+        FieldInputView view = new FieldInputView(getContext());
+        view.setField(mFieldInput);
+        return view;
     }
 }

--- a/blocklylib/src/main/java/com/google/blockly/ToolboxFragment.java
+++ b/blocklylib/src/main/java/com/google/blockly/ToolboxFragment.java
@@ -185,7 +185,7 @@ public class ToolboxFragment extends BlockDrawerFragment {
         mBlockListView.setLayoutManager(createLinearLayoutManager());
         mBlockListView.addItemDecoration(new BlocksItemDecoration());
         mBlockListView.setBackgroundColor(
-                getResources().getColor(R.color.blockly_toolbox_bg, null));  // Replace with attrib
+                getResources().getColor(R.color.blockly_toolbox_bg));  // Replace with attrib
         mBlockListView.setVisibility(View.GONE);  // Start closed.
         mCategoryTabs = new CategoryTabs(getContext());
         mCategoryTabs.setLabelAdapter(onCreateLabelAdapter());

--- a/blocklylib/src/main/java/com/google/blockly/TrashFragment.java
+++ b/blocklylib/src/main/java/com/google/blockly/TrashFragment.java
@@ -87,7 +87,7 @@ public class TrashFragment extends BlockDrawerFragment {
         mBlockListView = new BlockListView(getContext());
         mBlockListView.setLayoutManager(createLinearLayoutManager());
         mBlockListView.setBackgroundColor(
-                getResources().getColor(R.color.blockly_trash_bg, null));  // Replace with attribute
+                getResources().getColor(R.color.blockly_trash_bg));  // Replace with attribute
 
         maybeUpdateTouchHandler();
 

--- a/blocklylib/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib/src/main/java/com/google/blockly/model/Field.java
@@ -363,6 +363,9 @@ public abstract class Field implements Cloneable {
          * @param text The text to replace the field content with.
          */
         public void setText(String text) {
+            if (TextUtils.equals(text, mText)) {
+                return;
+            }
             mText = text;
             if (mView != null) {
                 ((FieldInputView) mView).setText(mText);

--- a/blocklylib/src/main/java/com/google/blockly/ui/InputView.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/InputView.java
@@ -398,41 +398,7 @@ public class InputView extends NonPropagatingViewGroup {
     private void initViews(Context context) {
         List<Field> fields = mInput.getFields();
         for (int j = 0; j < fields.size(); j++) {
-            // TODO: create the appropriate field type
-            // TODO: add a way to pass the field styles through
-            FieldView view = null;
-            switch (fields.get(j).getType()) {
-                case Field.TYPE_LABEL:
-                    view = new FieldLabelView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_CHECKBOX:
-                    view = new FieldCheckboxView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_DATE:
-                    view = new FieldDateView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_DROPDOWN:
-                    view = new FieldDropdownView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_ANGLE:
-                    view = new FieldAngleView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_COLOUR:
-                    view = new FieldColourView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_INPUT:
-                    view = new FieldInputView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_IMAGE:
-                    view = new FieldImageView(context, fields.get(j), mHelper);
-                    break;
-                case Field.TYPE_VARIABLE:
-                    view = new FieldVariableView(context, fields.get(j), mHelper);
-                    break;
-                default:
-                    Log.w(TAG, "Unknown field type.");
-                    break;
-            }
+            FieldView view = mHelper.buildFieldView(fields.get(j));
             if (view != null) {
                 addView((View) view);
                 mFieldViews.add(view);

--- a/blocklylib/src/main/java/com/google/blockly/ui/WorkspaceHelper.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/WorkspaceHelper.java
@@ -23,6 +23,7 @@ import android.os.Build;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -32,11 +33,20 @@ import android.widget.BaseAdapter;
 import com.google.blockly.R;
 import com.google.blockly.control.ConnectionManager;
 import com.google.blockly.model.Block;
+import com.google.blockly.model.Field;
 import com.google.blockly.model.Input;
 import com.google.blockly.model.NameManager;
 import com.google.blockly.model.WorkspacePoint;
+import com.google.blockly.ui.fieldview.FieldAngleView;
+import com.google.blockly.ui.fieldview.FieldCheckboxView;
 import com.google.blockly.ui.fieldview.FieldColourView;
+import com.google.blockly.ui.fieldview.FieldDateView;
+import com.google.blockly.ui.fieldview.FieldDropdownView;
+import com.google.blockly.ui.fieldview.FieldImageView;
+import com.google.blockly.ui.fieldview.FieldInputView;
+import com.google.blockly.ui.fieldview.FieldLabelView;
 import com.google.blockly.ui.fieldview.FieldVariableView;
+import com.google.blockly.ui.fieldview.FieldView;
 
 import java.util.List;
 
@@ -85,6 +95,7 @@ public class WorkspaceHelper {
     private final ViewPoint mTempViewPoint = new ViewPoint();
     private final int[] mTempIntArray2 = new int[2];
     private final Context mContext;
+    private final LayoutInflater mLayoutInflater;
     private final PatchManager mPatchManager;
     private WorkspaceView mWorkspaceView;
     private float mDensity;
@@ -93,6 +104,7 @@ public class WorkspaceHelper {
     private int mFieldStyle;
     private int mSpinnerLayout;
     private int mSpinnerDropDownLayout;
+    private int mFieldInputLayout;
     private BaseAdapter mVariableAdapter;
 
     /**
@@ -115,6 +127,7 @@ public class WorkspaceHelper {
      */
     public WorkspaceHelper(Context context, int workspaceStyle) {
         mContext = context;
+        mLayoutInflater = LayoutInflater.from(context);
         final Resources res = mContext.getResources();
         mDensity = res.getDisplayMetrics().density;
         if (mDensity == 0) {
@@ -306,6 +319,52 @@ public class WorkspaceHelper {
         }
 
         return blockView;
+    }
+
+    /**
+     * Builds a view for the specified field using this helper's configuration.
+     *
+     * @param field The field to build a view for.
+     * @return A FieldView for the field or null if the field type is not known.
+     */
+    public FieldView buildFieldView(Field field) {
+        FieldView view = null;
+        switch (field.getType()) {
+            case Field.TYPE_LABEL:
+                view = new FieldLabelView(mContext, field, this);
+                break;
+            case Field.TYPE_CHECKBOX:
+                view = new FieldCheckboxView(mContext, field, this);
+                break;
+            case Field.TYPE_DATE:
+                view = new FieldDateView(mContext, field, this);
+                break;
+            case Field.TYPE_DROPDOWN:
+                view = new FieldDropdownView(mContext, field, this);
+                break;
+            case Field.TYPE_ANGLE:
+                view = new FieldAngleView(mContext, field, this);
+                break;
+            case Field.TYPE_COLOUR:
+                view = new FieldColourView(mContext, field, this);
+                break;
+            case Field.TYPE_INPUT:
+                FieldInputView fiv = (FieldInputView) mLayoutInflater
+                        .inflate(mFieldInputLayout, null);
+                fiv.setField(field);
+                view = fiv;
+                break;
+            case Field.TYPE_IMAGE:
+                view = new FieldImageView(mContext, field, this);
+                break;
+            case Field.TYPE_VARIABLE:
+                view = new FieldVariableView(mContext, field, this);;
+                break;
+            default:
+                Log.w(TAG, "Unknown field type.");
+                break;
+        }
+        return view;
     }
 
     /**
@@ -572,10 +631,13 @@ public class WorkspaceHelper {
                 styles = context.obtainStyledAttributes(R.styleable.BlocklyFieldView);
             }
             mSpinnerLayout = styles.getResourceId(R.styleable.BlocklyFieldView_spinnerItem,
-                    android.R.layout.simple_spinner_item);
+                    R.layout.default_spinner_item);
             mSpinnerDropDownLayout = styles.getResourceId(
                     R.styleable.BlocklyFieldView_spinnerItemDropDown,
-                    android.R.layout.simple_spinner_dropdown_item);
+                    R.layout.default_spinner_drop_down);
+            mFieldInputLayout = styles.getResourceId(
+                    R.styleable.BlocklyFieldView_fieldInputLayout,
+                    R.layout.default_field_input);
             if (DEBUG) {
                 Log.d(TAG, "BlockStyle=" + mBlockStyle + ", FieldStyle=" + mFieldStyle
                         + ", SpinnerLayout=" + mSpinnerLayout + ", SpinnerDropdown="

--- a/blocklylib/src/main/java/com/google/blockly/ui/fieldview/FieldInputView.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/fieldview/FieldInputView.java
@@ -18,7 +18,9 @@ package com.google.blockly.ui.fieldview;
 import android.content.ClipDescription;
 import android.content.Context;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.AttributeSet;
 import android.view.DragEvent;
 import android.widget.EditText;
 
@@ -31,54 +33,49 @@ import com.google.blockly.ui.WorkspaceView;
  * Renders editable text as part of a {@link com.google.blockly.ui.InputView}.
  */
 public class FieldInputView extends EditText implements FieldView {
-    private final Field.FieldInput mInput;
-    private final WorkspaceHelper mWorkspaceHelper;
-    private final FieldWorkspaceParams mWorkspaceParams;
+    private Field.FieldInput mInput;
 
-    public FieldInputView(Context context, Field input, WorkspaceHelper helper) {
-        super(context);
+    public FieldInputView(Context context) {
+        super(context, null);
+    }
 
-        mInput = (Field.FieldInput) input;
-        mWorkspaceHelper = helper;
-        mWorkspaceParams = new FieldWorkspaceParams(mInput, mWorkspaceHelper);
+    public FieldInputView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
 
-        setBackground(null);
-        setText(mInput.getText());
-        mInput.setView(this);
+    public FieldInputView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr, 0);
+    }
 
-        addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            }
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-            }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                mInput.updateTextFromView(s.toString());
-            }
-        });
+    public FieldInputView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
     }
 
     @Override
-    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        mWorkspaceParams.setMeasuredDimensions(getMeasuredWidth(), getMeasuredHeight());
+    public void setText(CharSequence text, BufferType type) {
+        super.setText(text, type);
+        if (mInput != null) {
+            mInput.setText(text.toString());
+        }
     }
 
-    @Override
-    public void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (changed) {
-            mWorkspaceParams.updateFromView(this);
+    public void setField(Field input) {
+        if (mInput != null) {
+            mInput.setView(null);
+        }
+        if (input != null) {
+            mInput = (Field.FieldInput) input;
+            setText(mInput.getText());
+            mInput.setView(this);
+        } else {
+            mInput = null;
+            setText("");
         }
     }
 
     @Override
     public FieldWorkspaceParams getWorkspaceParams() {
-        return mWorkspaceParams;
+        return null;
     }
 
     /**
@@ -105,7 +102,9 @@ public class FieldInputView extends EditText implements FieldView {
 
     @Override
     public void unlinkModel() {
-        mInput.setView(null);
-        // TODO(#381): Remove model from view. Set mInput to null, and handle null cases above.
+        if (mInput != null) {
+            mInput.setView(null);
+            mInput = null;
+        }
     }
 }

--- a/blocklylib/src/main/res/layout/default_field_input.xml
+++ b/blocklylib/src/main/res/layout/default_field_input.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright 2016 Google Inc. All Rights Reserved.
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<com.google.blockly.ui.fieldview.FieldInputView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/field_input"
+        style="@style/DefaultEditTextStyle"
+        android:singleLine="true"
+        android:padding="4dip"
+        android:layout_marginLeft="8dip"
+        android:layout_marginRight="8dip"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>

--- a/blocklylib/src/main/res/layout/default_spinner_drop_down.xml
+++ b/blocklylib/src/main/res/layout/default_spinner_drop_down.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright 2016 Google Inc. All Rights Reserved.
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:id="@android:id/text1"
+          style="@style/DefaultSpinnerDropDownStyle"
+          android:singleLine="true"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="marquee"
+          android:textAlignment="inherit"/>

--- a/blocklylib/src/main/res/layout/default_spinner_item.xml
+++ b/blocklylib/src/main/res/layout/default_spinner_item.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright 2016 Google Inc. All Rights Reserved.
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:id="@android:id/text1"
+          style="@style/DefaultSpinnerStyle"
+          android:singleLine="true"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="marquee"
+          android:textAlignment="inherit"/>

--- a/blocklylib/src/main/res/values/attrs.xml
+++ b/blocklylib/src/main/res/values/attrs.xml
@@ -47,10 +47,15 @@
         <attr name="fieldMinHeight" format="dimension|reference"/>
         <!-- The minimum width for any FieldView -->
         <attr name="fieldMinWidth" format="dimension|reference"/>
-        <!-- The layout to use for spinner items like variables -->
+        <!-- The layout to use for spinner items like variables. Must contain a TextView
+                as the only element. -->
         <attr name="spinnerItem" format="reference" />
-        <!-- The drop down layout to use for spinner items like variables -->
+        <!-- The drop down layout to use for spinner items like variables. Must contain a TextView
+                as the only element. -->
         <attr name="spinnerItemDropDown" format="reference" />
+        <!-- The layout to use for field inputs text entry. Must contain a FieldInputView as the
+                only element -->
+        <attr name="fieldInputLayout" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="BlocklyFieldLabelView">

--- a/blocklylib/src/main/res/values/colors.xml
+++ b/blocklylib/src/main/res/values/colors.xml
@@ -5,4 +5,6 @@
 
     <color name="blockly_toolbox_bg">#80FFFFFF</color>
     <color name="blockly_trash_bg">#80808080</color>
+    <color name="blockly_edit_text_bg">#80ffffff</color>
+    <color name="blockly_spinner_dropdown_bg">#ffeeeeee</color>
 </resources>

--- a/blocklylib/src/main/res/values/styles.xml
+++ b/blocklylib/src/main/res/values/styles.xml
@@ -35,14 +35,29 @@
         <item name="textAppearance">@style/TextAppearance.AppCompat.Large</item>
         <item name="fieldMinHeight">24dip</item>
         <item name="fieldMinWidth">24dip</item>
-        <item name="spinnerItem">@android:layout/simple_spinner_item</item>
-        <item name="spinnerItemDropDown">@android:layout/simple_spinner_dropdown_item</item>
+        <item name="spinnerItem">@layout/default_spinner_item</item>
+        <item name="spinnerItemDropDown">@layout/default_spinner_drop_down</item>
     </style>
 
     <style name="DefaultCategoryLabelStyle">
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">20sp</item>
         <item name="android:textColor">#fff</item>
+    </style>
+
+    <style name="DefaultSpinnerStyle"
+           parent="@style/TextAppearance.AppCompat.Widget.TextView.SpinnerItem">
+        <item name="android:textSize">@dimen/abc_text_size_large_material</item>
+        <item name="android:background">@android:drawable/btn_dropdown</item>
+    </style>
+    <style name="DefaultSpinnerDropDownStyle">
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Large</item>
+        <item name="android:background">@color/blockly_spinner_dropdown_bg</item>
+        <item name="android:padding">4dip</item>
+    </style>
+    <style name="DefaultEditTextStyle">
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Large</item>
+        <item name="android:background">@color/blockly_edit_text_bg</item>
     </style>
 
     <style name="CategoryLabelStyle" parent="DefaultCategoryLabelStyle">


### PR DESCRIPTION
This adds attributes for picking a layout to inflate for spinner items,
spinner dropdowns, and field inputs. It also adds some default layouts and
styles to make them a little bit cleaner and moves FieldView creation to
the WorkspaceHelper.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/48)

<!-- Reviewable:end -->
