### PR TITLE
Use older form of Resources.getDrawable(..) for backward compatibility.

### DIFF
--- a/blocklylib/src/main/java/com/google/blockly/ui/fieldview/FieldColourView.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/fieldview/FieldColourView.java
@@ -63,8 +63,7 @@ public class FieldColourView extends View implements FieldView {
         mWorkspaceHelper = helper;
         mWorkspaceParams = new FieldWorkspaceParams(mColourField, mWorkspaceHelper);
 
-        mInsetPatch = (NinePatchDrawable) getResources().getDrawable(
-                R.drawable.inset_field_border, null);
+        mInsetPatch = (NinePatchDrawable) getResources().getDrawable(R.drawable.inset_field_border);
 
         float density = context.getResources().getDisplayMetrics().density;
         setMinimumWidth((int) (DEFAULT_MIN_WIDTH_DP * density));


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/107)

<!-- Reviewable:end -->
