### PR TITLE
Removing mView from the Block model class.

### DIFF
--- a/blocklylib/src/androidTest/java/com/google/blockly/control/BlocklyControllerTest.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/control/BlocklyControllerTest.java
@@ -21,7 +21,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
     BlocklyController mController;
     BlockFactory mBlockFactory;
     Workspace mWorkspace;
-    WorkspaceHelper mWorkspaceHelper;
+    WorkspaceHelper mHelper;
     ConnectionManager mConnectionManager;
     WorkspaceView mWorkspaceView;
 
@@ -34,7 +34,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
                 .build();
         mBlockFactory = mController.getBlockFactory();
         mWorkspace = mController.getWorkspace();
-        mWorkspaceHelper = mController.getWorkspaceHelper();
+        mHelper = mController.getWorkspaceHelper();
         mConnectionManager = mController.getWorkspace().getConnectionManager();
 
         mWorkspaceView = new WorkspaceView(getContext());
@@ -59,12 +59,12 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
             mController.initWorkspaceView(mWorkspaceView);
 
             // Validate initial view state.
-            BlockView targetView = target.getView();
-            BlockView sourceView = source.getView();
+            BlockView targetView = mHelper.getView(target);
+            BlockView sourceView = mHelper.getView(source);
             assertNotNull(targetView);
             assertNotNull(sourceView);
-            assertNotSame(mWorkspaceHelper.getRootBlockGroup(target),
-                    mWorkspaceHelper.getRootBlockGroup(source));
+            assertNotSame(mHelper.getRootBlockGroup(target),
+                    mHelper.getRootBlockGroup(source));
         }
 
         // Perform test: connection source's output to target's input.
@@ -78,9 +78,9 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
 
         if (withViews) {
             // Validate view changes
-            BlockGroup targetGroup = mWorkspaceHelper.getParentBlockGroup(target);
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(source));
+            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
+            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
         }
     }
 
@@ -128,15 +128,15 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertNull(tail.getOutputConnection().getTargetBlock());
 
         if (withViews) {
-            BlockGroup targetGroup = mWorkspaceHelper.getParentBlockGroup(target);
-            BlockGroup tailGroup = mWorkspaceHelper.getParentBlockGroup(tail);
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(source));
-            assertSame(tailGroup, mWorkspaceHelper.getRootBlockGroup(tail));
+            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+            BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
+            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
+            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
+            assertSame(tailGroup, mHelper.getRootBlockGroup(tail));
             assertNotSame(targetGroup, tailGroup);
 
             // Check that tail has been bumped far enough away.
-            assertTrue(mWorkspaceHelper.getMaxSnapDistance() <=
+            assertTrue(mHelper.getMaxSnapDistance() <=
                     tail.getOutputConnection().distanceFrom(source.getOutputConnection()));
         }
     }
@@ -179,13 +179,13 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertTrue(mWorkspace.isRootBlock(tail));
 
         if (withViews) {
-            BlockGroup targetGroup = mWorkspaceHelper.getParentBlockGroup(target);
-            BlockGroup tailGroup = mWorkspaceHelper.getParentBlockGroup(tail);
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(source));
-            assertSame(tailGroup, mWorkspaceHelper.getRootBlockGroup(tail));
+            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+            BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
+            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
+            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
+            assertSame(tailGroup, mHelper.getRootBlockGroup(tail));
             assertNotSame(targetGroup, tailGroup);
-            assertTrue(mWorkspaceHelper.getMaxSnapDistance() <=
+            assertTrue(mHelper.getMaxSnapDistance() <=
                     source.getOutputConnection().distanceFrom(tail.getOutputConnection()));
         }
     }
@@ -225,10 +225,10 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(source, tail.getOutputConnection().getTargetBlock());
 
         if (withViews) {
-            BlockGroup targetGroup = mWorkspaceHelper.getParentBlockGroup(target);
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(tail));
-            assertSame(targetGroup, mWorkspaceHelper.getRootBlockGroup(source));
+            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
+            assertSame(targetGroup, mHelper.getRootBlockGroup(tail));
+            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
         }
     }
 
@@ -244,10 +244,16 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         // setup
         Block target = mBlockFactory.obtainBlock("statement_no_input", "target");
         Block source = mBlockFactory.obtainBlock("statement_no_input", "source");
+        BlockView targetView = null, sourceView = null;
         mController.addRootBlock(target);
         mController.addRootBlock(source);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            targetView = mHelper.getView(target);
+            sourceView = mHelper.getView(source);
+
+            assertNotNull(targetView);
+            assertNotNull(sourceView);
         }
 
         // Connect source after target. No prior connection to bump or splice.
@@ -260,11 +266,11 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(target, source.getPreviousBlock());
 
         if (withViews) {
-            BlockGroup rootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(source));
-            assertSame(target.getView(), rootGroup.getChildAt(0));
-            assertSame(source.getView(), rootGroup.getChildAt(1));
+            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
+            assertSame(rootGroup, mHelper.getParentBlockGroup(source));
+            assertSame(targetView, rootGroup.getChildAt(0));
+            assertSame(sourceView, rootGroup.getChildAt(1));
         }
     }
 
@@ -281,6 +287,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         Block target = mBlockFactory.obtainBlock("statement_no_input", "target");
         Block tail = mBlockFactory.obtainBlock("statement_no_input", "tail");
         Block source = mBlockFactory.obtainBlock("statement_no_input", "source");
+        BlockView targetView = null, tailView = null, sourceView = null;
 
         tail.getPreviousConnection().connect(target.getNextConnection());
 
@@ -288,6 +295,13 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(source);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            targetView = mHelper.getView(target);
+            tailView = mHelper.getView(tail);
+            sourceView = mHelper.getView(source);
+
+            assertNotNull(targetView);
+            assertNotNull(tailView);
+            assertNotNull(sourceView);
         }
 
         // Connect source after target, where tail is currently attached, causing a splice.
@@ -298,13 +312,13 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(source, tail.getPreviousBlock());
 
         if (withViews) {
-            BlockGroup rootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(tail));
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(source));
-            assertSame(target.getView(), rootGroup.getChildAt(0));
-            assertSame(source.getView(), rootGroup.getChildAt(1));  // Spliced in between.
-            assertSame(tail.getView(), rootGroup.getChildAt(2));
+            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
+            assertSame(rootGroup, mHelper.getParentBlockGroup(tail));
+            assertSame(rootGroup, mHelper.getParentBlockGroup(source));
+            assertSame(targetView, rootGroup.getChildAt(0));
+            assertSame(sourceView, rootGroup.getChildAt(1));  // Spliced in between.
+            assertSame(tailView, rootGroup.getChildAt(2));
         }
     }
 
@@ -322,6 +336,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         Block tail1 = mBlockFactory.obtainBlock("statement_no_input", "tail1");
         Block tail2 = mBlockFactory.obtainBlock("statement_no_input", "tail2");
         Block source = mBlockFactory.obtainBlock("statement_no_next", "source");
+        BlockView targetView = null, tailView1 = null, tailView2 = null, sourceView = null;
 
         // Create a sequence of target, tail1, and tail2.
         tail1.getPreviousConnection().connect(target.getNextConnection());
@@ -331,6 +346,15 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(source);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            targetView = mHelper.getView(target);
+            tailView1 = mHelper.getView(tail1);
+            tailView2 = mHelper.getView(tail2);
+            sourceView = mHelper.getView(source);
+
+            assertNotNull(targetView);
+            assertNotNull(tailView1);
+            assertNotNull(tailView2);
+            assertNotNull(sourceView);
         }
 
         // Run test: Connect source after target, where tail is currently attached.
@@ -351,19 +375,19 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(tail1, tail2.getRootBlock());
 
         if (withViews) {
-            BlockGroup targetRootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            BlockGroup tailRootGroup = mWorkspaceHelper.getRootBlockGroup(tail1);
-            assertSame(targetRootGroup, mWorkspaceHelper.getParentBlockGroup(target));
-            assertSame(targetRootGroup, mWorkspaceHelper.getRootBlockGroup(source));
+            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+            BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail1);
+            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
+            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
             assertNotSame(targetRootGroup, tailRootGroup);
-            assertSame(tailRootGroup, mWorkspaceHelper.getRootBlockGroup(tail2));
-            assertSame(target.getView(), targetRootGroup.getChildAt(0));
-            assertSame(source.getView(), targetRootGroup.getChildAt(1));
-            assertSame(tail1.getView(), tailRootGroup.getChildAt(0));
-            assertSame(tail2.getView(), tailRootGroup.getChildAt(1));
+            assertSame(tailRootGroup, mHelper.getRootBlockGroup(tail2));
+            assertSame(targetView, targetRootGroup.getChildAt(0));
+            assertSame(sourceView, targetRootGroup.getChildAt(1));
+            assertSame(tailView1, tailRootGroup.getChildAt(0));
+            assertSame(tailView2, tailRootGroup.getChildAt(1));
 
             // Check that tail has been bumped far enough away.
-            assertTrue(mWorkspaceHelper.getMaxSnapDistance() <=
+            assertTrue(mHelper.getMaxSnapDistance() <=
                     tail1.getPreviousConnection().distanceFrom(target.getNextConnection()));
         }
     }
@@ -395,9 +419,9 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(target, source.getPreviousBlock());
 
         if (withViews) {
-            BlockGroup rootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mWorkspaceHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mWorkspaceHelper.getRootBlockGroup(source));
+            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
+            assertSame(rootGroup, mHelper.getRootBlockGroup(source));
         }
     }
 
@@ -414,6 +438,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         Block target = mBlockFactory.obtainBlock("statement_statement_input", "target");
         Block tail = mBlockFactory.obtainBlock("statement_statement_input", "tail");
         Block source = mBlockFactory.obtainBlock("statement_statement_input", "source");
+        BlockView targetView = null, tailView = null, sourceView = null;
 
         // Connect the tail inside target.
         target.getInputByName("statement input").getConnection()
@@ -423,6 +448,13 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(source);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            targetView = mHelper.getView(target);
+            tailView = mHelper.getView(tail);
+            sourceView = mHelper.getView(source);
+
+            assertNotNull(targetView);
+            assertNotNull(tailView);
+            assertNotNull(sourceView);
         }
 
         // Run test: Connect source inside target, where tail is attached, resulting in a splice.
@@ -437,13 +469,13 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertSame(source, tail.getPreviousBlock());
 
         if (withViews) {
-            BlockGroup rootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            BlockGroup secondGroup = mWorkspaceHelper.getParentBlockGroup(tail);
-            assertSame(rootGroup, mWorkspaceHelper.getRootBlockGroup(tail));
+            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+            BlockGroup secondGroup = mHelper.getParentBlockGroup(tail);
+            assertSame(rootGroup, mHelper.getRootBlockGroup(tail));
             assertNotSame(rootGroup, secondGroup);
-            assertSame(secondGroup, mWorkspaceHelper.getParentBlockGroup(source));
-            assertSame(source.getView(), secondGroup.getChildAt(0));
-            assertSame(tail.getView(), secondGroup.getChildAt(1));
+            assertSame(secondGroup, mHelper.getParentBlockGroup(source));
+            assertSame(sourceView, secondGroup.getChildAt(0));
+            assertSame(tailView, secondGroup.getChildAt(1));
         }
     }
 
@@ -459,6 +491,7 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         Block target = mBlockFactory.obtainBlock("statement_statement_input", "target");
         Block tail = mBlockFactory.obtainBlock("statement_statement_input", "tail");
         Block source = mBlockFactory.obtainBlock("statement_no_next", "source");
+        BlockView sourceView = null;
 
         // Connect tail inside target.
         target.getInputByName("statement input").getConnection()
@@ -468,6 +501,8 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(source);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            sourceView = mHelper.getView(source);
+            assertNotNull(sourceView);
         }
 
         // Connect source inside target, where tail is attached.  Source does not have a next, so
@@ -484,16 +519,16 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertNull(tail.getPreviousBlock());
 
         if (withViews) {
-            BlockGroup targetRootGroup = mWorkspaceHelper.getRootBlockGroup(target);
-            BlockGroup tailRootGroup = mWorkspaceHelper.getRootBlockGroup(tail);
-            BlockGroup sourceGroup = mWorkspaceHelper.getParentBlockGroup(source);
-            assertSame(targetRootGroup, mWorkspaceHelper.getParentBlockGroup(target));
+            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+            BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail);
+            BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
+            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
             assertNotSame(targetRootGroup, tailRootGroup);
-            assertSame(tailRootGroup, mWorkspaceHelper.getParentBlockGroup(tail));
-            assertSame(targetRootGroup, mWorkspaceHelper.getRootBlockGroup(source));
+            assertSame(tailRootGroup, mHelper.getParentBlockGroup(tail));
+            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
             assertSame(sourceGroup.getParent(), target.getInputByName("statement input").getView());
-            assertSame(source.getView(), sourceGroup.getChildAt(0));
-            assertTrue(mWorkspaceHelper.getMaxSnapDistance() <=
+            assertSame(sourceView, sourceGroup.getChildAt(0));
+            assertTrue(mHelper.getMaxSnapDistance() <=
                     source.getPreviousConnection().distanceFrom(tail.getPreviousConnection()));
         }
     }
@@ -526,8 +561,8 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertTrue(mWorkspace.getRootBlocks().contains(block));
 
         if (withViews) {
-            BlockGroup firstGroup = mWorkspaceHelper.getParentBlockGroup(block);
-            assertSame(firstGroup, mWorkspaceHelper.getRootBlockGroup(block));
+            BlockGroup firstGroup = mHelper.getParentBlockGroup(block);
+            assertSame(firstGroup, mHelper.getRootBlockGroup(block));
         }
     }
 
@@ -547,16 +582,14 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(first);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            assertNotNull(mHelper.getView(first));
+            assertNotNull(mHelper.getView(second));
         }
 
         // Check preconditions
         List<Block> rootBlocks = mWorkspace.getRootBlocks();
         assertEquals(rootBlocks.size(), 1);
         assertEquals(rootBlocks.get(0), first);
-        if (withViews) {
-            assertNotNull(first.getView());
-            assertNotNull(second.getView());
-        }
 
         // Run test: Extract second out from under first.
         mController.extractBlockAsRoot(second);
@@ -569,9 +602,9 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertFalse(second.getOutputConnection().isConnected());
 
         if (withViews) {
-            BlockGroup firstGroup = mWorkspaceHelper.getParentBlockGroup(first);
+            BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
             assertNotNull(firstGroup);
-            BlockGroup secondGroup = mWorkspaceHelper.getParentBlockGroup(second);
+            BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
             assertNotNull(secondGroup);
             assertNotSame(secondGroup, firstGroup);
         }
@@ -593,6 +626,8 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(first);
         if (withViews) {
             mController.initWorkspaceView(mWorkspaceView);
+            assertNotNull(mHelper.getView(first));
+            assertNotNull(mHelper.getView(second));
         }
 
         // Check preconditions
@@ -601,10 +636,8 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertEquals(rootBlocks.get(0), first);
         assertEquals(second, first.getNextConnection().getTargetBlock());
         if (withViews) {
-            assertNotNull(first.getView());
-            assertNotNull(second.getView());
-            assertSame(mWorkspaceHelper.getParentBlockGroup(first),
-                    mWorkspaceHelper.getParentBlockGroup(second));
+            assertSame(mHelper.getParentBlockGroup(first),
+                    mHelper.getParentBlockGroup(second));
         }
 
         // Run test: Extract second out from under first.
@@ -619,9 +652,9 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         assertFalse(second.getPreviousConnection().isConnected());
 
         if (withViews) {
-            BlockGroup firstGroup = mWorkspaceHelper.getParentBlockGroup(first);
+            BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
             assertNotNull(firstGroup);
-            BlockGroup secondGroup = mWorkspaceHelper.getParentBlockGroup(second);
+            BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
             assertNotNull(secondGroup);
             assertNotSame(secondGroup, firstGroup);
         }

--- a/blocklylib/src/androidTest/java/com/google/blockly/control/DraggerTest.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/control/DraggerTest.java
@@ -205,8 +205,8 @@ public class DraggerTest extends MockitoAndroidTestCase {
 
         // Layout never happens during this test, so we're forcing the connection locations
         // to be set from the block positions before we try to use them.
-        first.getView().updateConnectorLocations();
-        second.getView().updateConnectorLocations();
+        mWorkspaceHelper.getView(first).updateConnectorLocations();
+        mWorkspaceHelper.getView(second).updateConnectorLocations();
     }
 
     /**
@@ -221,7 +221,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
     }
 
     private void dragTouch(Block toDrag, Block stationary) {
-        BlockView bv = toDrag.getView();
+        BlockView bv = mWorkspaceHelper.getView(toDrag);
         // This is how far we need to move the block by
         int diffX = mWorkspaceHelper.workspaceToVirtualViewUnits(
                 stationary.getPosition().x - toDrag.getPosition().x);
@@ -240,7 +240,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
     }
 
     private void dragMove(Block toDrag, Block stationary) {
-        BlockView bv = toDrag.getView();
+        BlockView bv = mWorkspaceHelper.getView(toDrag);
         long time = dragStartTime + 10L;
         MotionEvent me = MotionEvent.obtain(time, time, MotionEvent.ACTION_MOVE, 30, -10, 0);
         mDragger.onTouchBlock(bv, me);
@@ -248,7 +248,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
     }
 
     private void dragRelease(Block toDrag, Block stationary) {
-        BlockView bv = toDrag.getView();
+        BlockView bv = mWorkspaceHelper.getView(toDrag);
         // Pretend to be the last DragEvent that registers, which should be right by the
         // stationary block.
         // getX() returns float, even though we'll cast back to int immediately.
@@ -259,7 +259,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
 
         // Force the connector locations to update before the call to finishDragging().
         bv.updateConnectorLocations();
-        stationary.getView().updateConnectorLocations();
+        mWorkspaceHelper.getView(stationary).updateConnectorLocations();
 
         mDragger.finishDragging();
     }

--- a/blocklylib/src/androidTest/java/com/google/blockly/ui/BlockViewInActivityTest.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/ui/BlockViewInActivityTest.java
@@ -25,6 +25,7 @@ public class BlockViewInActivityTest
     private TestWorkspaceViewActivity mActivity;
     private Instrumentation mInstrumentation;
     private BlockFactory mBlockFactory;
+    private WorkspaceHelper mHelper;
 
     // Block hierarchy, loaded from "controls_whileUntil".
     private ArrayList<Block> mBlocks;
@@ -54,6 +55,8 @@ public class BlockViewInActivityTest
 
         mBlockFactory = new BlockFactory(mActivity, new int[]{R.raw.test_blocks});
         mBlocks = new ArrayList<>();
+
+        mHelper = mActivity.mWorkspaceHelper;
     }
 
     public void loadWhileUtilBlocksIntoWorkspaceView() {
@@ -66,11 +69,11 @@ public class BlockViewInActivityTest
         mRootBlock.getInputByName("NAME").getConnection()
                 .connect(mChildStatementBlock.getPreviousConnection());
 
-        mActivity.mWorkspaceHelper.buildBlockGroupTree(mRootBlock, mMockConnectionManager, null);
-        mRootView = mRootBlock.getView();
+        mHelper.buildBlockGroupTree(mRootBlock, mMockConnectionManager, null);
+        mRootView = mHelper.getView(mRootBlock);
         mFieldView = (View) mRootBlock.getFieldByName("MODE").getView();
-        mChildInputBlockView = mChildInputBlock.getView();
-        mChildStatementBlockView = mChildStatementBlock.getView();
+        mChildInputBlockView = mHelper.getView(mChildInputBlock);
+        mChildStatementBlockView = mHelper.getView(mChildStatementBlock);
 
         BlockGroup rootBlockGroup = (BlockGroup) mRootView.getParent();
         mActivity.mWorkspaceView.addView(rootBlockGroup);
@@ -87,9 +90,9 @@ public class BlockViewInActivityTest
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildInputBlockView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildStatementBlockView, mRootBlock.getView()));
+        assertTrue(isDescendentOf(mFieldView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildInputBlockView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildStatementBlockView, mHelper.getView(mRootBlock)));
 
         assertFalse(mRootView.isActivated());
         assertFalse(mFieldView.isActivated());
@@ -122,9 +125,9 @@ public class BlockViewInActivityTest
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildInputBlockView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildStatementBlockView, mRootBlock.getView()));
+        assertTrue(isDescendentOf(mFieldView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildInputBlockView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildStatementBlockView, mHelper.getView(mRootBlock)));
 
         assertFalse(mRootView.isPressed());
         assertFalse(mFieldView.isPressed());
@@ -157,9 +160,9 @@ public class BlockViewInActivityTest
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildInputBlockView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildStatementBlockView, mRootBlock.getView()));
+        assertTrue(isDescendentOf(mFieldView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildInputBlockView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildStatementBlockView, mHelper.getView(mRootBlock)));
 
         assertFalse(mRootView.isFocused());
         assertFalse(mFieldView.isFocused());
@@ -192,9 +195,9 @@ public class BlockViewInActivityTest
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildInputBlockView, mRootBlock.getView()));
-        assertTrue(isDescendentOf(mChildStatementBlockView, mRootBlock.getView()));
+        assertTrue(isDescendentOf(mFieldView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildInputBlockView, mHelper.getView(mRootBlock)));
+        assertTrue(isDescendentOf(mChildStatementBlockView, mHelper.getView(mRootBlock)));
 
         assertFalse(mRootView.isSelected());
         assertFalse(mFieldView.isSelected());

--- a/blocklylib/src/androidTest/java/com/google/blockly/ui/BlockViewTest.java
+++ b/blocklylib/src/androidTest/java/com/google/blockly/ui/BlockViewTest.java
@@ -49,7 +49,6 @@ public class BlockViewTest extends MockitoAndroidTestCase {
 
         // Verify Block and BlockView are linked both ways.
         assertSame(mMockBlock, blockView.getBlock());
-        Mockito.verify(mMockBlock, Mockito.times(1)).setView(blockView);
     }
 
 
@@ -62,7 +61,6 @@ public class BlockViewTest extends MockitoAndroidTestCase {
 
         final BlockGroup bg = new BlockGroup(getContext(), mMockWorkspaceHelper);
         assertSame(block, blockView.getBlock());
-        assertSame(blockView, block.getView());
 
         // One InputView per Input?
         assertEquals(3, blockView.getInputViewCount());

--- a/blocklylib/src/main/java/com/google/blockly/control/BlocklyController.java
+++ b/blocklylib/src/main/java/com/google/blockly/control/BlocklyController.java
@@ -67,6 +67,7 @@ public class BlocklyController {
     private final WorkspaceHelper mHelper;
 
     private final Workspace mWorkspace;
+
     private final ViewPoint mTempViewPoint = new ViewPoint();
 
     private WorkspaceView mWorkspaceView;
@@ -375,9 +376,9 @@ public class BlocklyController {
         }
         boolean isPartOfWorkspace = mWorkspace.isRootBlock(rootBlock);
 
-        BlockView bv = block.getView();
+        BlockView bv = mHelper.getView(block);
         BlockGroup bg = (bv == null) ? null : (BlockGroup) bv.getParent();
-        BlockGroup rootBlockGroup = (mWorkspaceView == null) ? null
+        BlockGroup originalRootBlockGroup = (mWorkspaceView == null) ? null
                 : mHelper.getRootBlockGroup(block);
 
         // Child block
@@ -411,8 +412,8 @@ public class BlocklyController {
             }
         }
 
-        if (rootBlockGroup != null) {
-            rootBlockGroup.requestLayout();
+        if (originalRootBlockGroup != null) {
+            originalRootBlockGroup.requestLayout();
         }
         if (isPartOfWorkspace) {
             // Only add back to the workspace if the original tree is part of the workspace model.
@@ -503,7 +504,7 @@ public class BlocklyController {
     public void addBlockFromToolbox(Block block, MotionEvent event) {
         addRootBlock(block, null, true);
         // let the workspace view know that this is the block we want to drag
-        mDragger.setTouchedBlock(block.getView(), event);
+        mDragger.setTouchedBlock(mHelper.getView(block), event);
         // Adjust the event's coordinates from the {@link BlockView}'s coordinate system to
         // {@link WorkspaceView} coordinates.
         mHelper.workspaceToVirtualViewCoordinates(block.getPosition(), mTempViewPoint);
@@ -624,7 +625,7 @@ public class BlocklyController {
      * @param block The root block of the tree to unlink.
      */
     public void unlinkViews(Block block) {
-        BlockView view = block.getView();
+        BlockView view = mHelper.getView(block);
         if (view == null) {
             return;  // No view to unlink.
         }
@@ -637,7 +638,7 @@ public class BlocklyController {
 
         BlockGroup parentGroup = mHelper.getParentBlockGroup(block);
         if (parentGroup != null) {
-            if (parentGroup.getChildAt(0) != block.getView()) {
+            if (parentGroup.getChildAt(0) != mHelper.getView(block)) {
                 // If it doesn't have a parent, this Block view should have been first.
                 throw new IllegalStateException("BlockGroup does not match model");
             }
@@ -710,7 +711,7 @@ public class BlocklyController {
     private boolean removeRootBlock(Block block, boolean cleanupStats) {
         boolean rootFoundAndRemoved = mWorkspace.removeRootBlock(block, cleanupStats);
         if (rootFoundAndRemoved) {
-            BlockView bv = block.getView();
+            BlockView bv = mHelper.getView(block);
             if (bv != null) {
                 BlockGroup group = bv.getParentBlockGroup();
                 if (group != null) {

--- a/blocklylib/src/main/java/com/google/blockly/control/Dragger.java
+++ b/blocklylib/src/main/java/com/google/blockly/control/Dragger.java
@@ -242,7 +242,7 @@ public class Dragger {
         Pair<Connection, Connection> connectionCandidate =
                 findBestConnection(mTouchedBlockView.getBlock());
         if (connectionCandidate != null) {
-            mHighlightedBlockView = connectionCandidate.second.getBlock().getView();
+            mHighlightedBlockView = mWorkspaceHelper.getView(connectionCandidate.second.getBlock());
             mHighlightedBlockView.setHighlightedConnection(connectionCandidate.second);
         }
 

--- a/blocklylib/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib/src/main/java/com/google/blockly/model/Block.java
@@ -19,7 +19,6 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.google.blockly.ui.BlockView;
 import com.google.blockly.utils.Colours;
 
 import org.json.JSONArray;
@@ -67,9 +66,6 @@ public class Block {
 
     /** Position of the block in the workspace. Only serialized for the root block. */
     private WorkspacePoint mPosition;
-
-    // These values are only used for drawing
-    private BlockView mView;
 
     private Block(@Nullable String uuid, String name, int category, int colour,
                   Connection outputConnection, Connection nextConnection,
@@ -330,20 +326,6 @@ public class Block {
     @Nullable
     public Connection getNextConnection() {
         return mNextConnection;
-    }
-
-    /**
-     * @return The view that renders this block.
-     */
-    public BlockView getView() {
-        return mView;
-    }
-
-    /**
-     * Sets the view that renders this block.
-     */
-    public void setView(BlockView view) {
-        mView = view;
     }
 
     public Block deepCopy() {

--- a/blocklylib/src/main/java/com/google/blockly/ui/BlockGroup.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/BlockGroup.java
@@ -165,8 +165,9 @@ public class BlockGroup extends NonPropagatingViewGroup {
     public void moveBlocksFrom(BlockGroup from, Block firstBlock) {
         Block cur = firstBlock;
         while (cur != null) {
-            from.removeView(cur.getView());
-            this.addView(cur.getView());
+            BlockView blockView = mWorkspaceHelper.getView(cur);
+            from.removeView(blockView);
+            this.addView(blockView);
             cur = cur.getNextBlock();
         }
     }

--- a/blocklylib/src/main/java/com/google/blockly/ui/BlockView.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/BlockView.java
@@ -140,7 +140,6 @@ public class BlockView extends NonPropagatingViewGroup {
         setClickable(true);
         setFocusable(true);
 
-        block.setView(this);
         createInputViews();  // BlockView is responsible for creating InputViews.
 
         setWillNotDraw(false);
@@ -338,7 +337,7 @@ public class BlockView extends NonPropagatingViewGroup {
         }
         mTouchHandler = null;  // Recursive via the calls InputView calls.
         removeAllViews();
-        mBlock.setView(null);
+        mHelper.unlinkView(this);
         // TODO(#45): Remove model from view. Set mBlock to null, and handle all null cases.
     }
 

--- a/blocklylib/src/main/java/com/google/blockly/ui/WorkspaceHelper.java
+++ b/blocklylib/src/main/java/com/google/blockly/ui/WorkspaceHelper.java
@@ -30,6 +30,9 @@ import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
 
 import com.google.blockly.R;
+import com.google.blockly.ToolboxFragment;
+import com.google.blockly.TrashFragment;
+import com.google.blockly.WorkspaceFragment;
 import com.google.blockly.control.ConnectionManager;
 import com.google.blockly.model.Block;
 import com.google.blockly.model.Field;
@@ -47,7 +50,11 @@ import com.google.blockly.ui.fieldview.FieldLabelView;
 import com.google.blockly.ui.fieldview.FieldVariableView;
 import com.google.blockly.ui.fieldview.FieldView;
 
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides helper methods for views and coordinate conversions.
@@ -96,6 +103,10 @@ public class WorkspaceHelper {
     private final Context mContext;
     private final LayoutInflater mLayoutInflater;
     private final PatchManager mPatchManager;
+
+    private final Map<String,WeakReference<BlockView>> mBlockIdToView
+            = Collections.synchronizedMap(new HashMap<String,WeakReference<BlockView>>());
+
     private WorkspaceView mWorkspaceView;
     private float mDensity;
     private boolean mRtl;
@@ -155,6 +166,22 @@ public class WorkspaceHelper {
     }
 
     /**
+     * This returns the view constructed to represent {@link Block}.  Each block is only allowed
+     * one view instance among the view managed by this helper (including {@link WorkspaceFragment},
+     * {@link ToolboxFragment}, and {@link TrashFragment}. Views are constructed in
+     * {@link #buildBlockViewTree}, either directly or via recursion.  If the block view has not
+     * been constructed, this method will return null.
+     *
+     * @param block The Block to view.
+     * @return The view that was constructed for a given Block object, if any.
+     */
+    @Nullable
+    public BlockView getView(Block block) {
+        WeakReference<BlockView> viewRef = mBlockIdToView.get(block.getId());
+        return viewRef == null ? null : viewRef.get();
+    }
+
+    /**
      * @return The {@link PatchManager} for drawing Blocks using 9-patches.
      */
     public PatchManager getPatchManager() {
@@ -197,7 +224,6 @@ public class WorkspaceHelper {
         // TODO(#62): Adapt to WorkspaceView zoom, if connected.
         return DEFAULT_MAX_SNAP_DISTANCE;
     }
-
 
     /**
      * Scales a value in workspace coordinate units to virtual view pixel units.
@@ -294,8 +320,13 @@ public class WorkspaceHelper {
     public BlockView buildBlockViewTree(Block block, BlockGroup parentGroup,
                                         ConnectionManager connectionManager,
                                         BlockTouchHandler touchHandler) {
+        BlockView blockView = getView(block);
+        if (blockView != null) {
+            throw new IllegalStateException("BlockView already created.");
+        }
+
         // TODO(#88): Refactor to use a BlockViewFactory to instantiate and combine all the views.
-        BlockView blockView = new BlockView(mContext, block, this, connectionManager, touchHandler);
+        blockView = new BlockView(mContext, block, this, connectionManager, touchHandler);
         List<Input> inputs = block.getInputs();
         for (int i = 0; i < inputs.size(); i++) {
             Input in = inputs.get(i);
@@ -317,6 +348,7 @@ public class WorkspaceHelper {
             // Recursively calls buildBlockViewTree(..) for the rest of the sequence.
         }
 
+        mBlockIdToView.put(block.getId(), new WeakReference<BlockView>(blockView));
         return blockView;
     }
 
@@ -461,8 +493,9 @@ public class WorkspaceHelper {
      *
      * @return The highest {@link BlockGroup} found.
      */
+    @Nullable
     public BlockGroup getRootBlockGroup(Block block) {
-        BlockView bv = block.getRootBlock().getView();
+        BlockView bv = getView(block.getRootBlock());
         return (bv == null) ? null : (BlockGroup) bv.getParent();
     }
 
@@ -476,7 +509,7 @@ public class WorkspaceHelper {
      */
     @Nullable
     public BlockGroup getParentBlockGroup(Block block) {
-        BlockView blockView = block.getView();
+        BlockView blockView = getView(block);
         if (blockView != null) {
             BlockGroup bg = blockView.getParentBlockGroup();
             if (bg == null) {
@@ -586,6 +619,21 @@ public class WorkspaceHelper {
                 mContext, mSpinnerLayout);
         adapter.setDropDownViewResource(mSpinnerDropDownLayout);
         return adapter;
+    }
+
+    /**
+     * Clears the view reference to this view from its block.
+     *
+     * @param view The BlockView to deassociate from its Block model.
+     */
+    void unlinkView(BlockView view) {
+        String id = view.getBlock().getId();
+        WeakReference<BlockView> viewRef = mBlockIdToView.get(id);
+        if (viewRef != null) {
+            if (viewRef.get() == view) {
+                mBlockIdToView.remove(id);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
WorksapceHelper.getView(block) now provides this functionality, backed by a HashMap with weak values.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/127)

<!-- Reviewable:end -->
