### PR TITLE
Make FieldInputView properly observe FieldInput

### DIFF
--- a/blocklylib/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib/src/main/java/com/google/blockly/model/Field.java
@@ -408,9 +408,6 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
             if (!TextUtils.equals(text, mText)) {
                 String oldText = mText;
                 mText = text;
-                if (mView != null) {
-                    ((FieldInputView) mView).setText(mText);
-                }
                 onTextChanged(oldText, text);
             }
         }


### PR DESCRIPTION
There was a bug in the way FieldInputs were updating the view that caused
the cursor to jump to the start after every character was added. This fixes
it by making the FieldInputView be an observer of the model and only update
if the new value is different than its current value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/130) &emsp; Multiple assignees:&emsp;<img alt="@AnmAtAnm" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/9916202?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/AnmAtAnm">AnmAtAnm</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
