### PR TITLE
Add UI support for shadow blocks

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -29,9 +29,9 @@
     <category name="Outputs">
         <block type="controls_repeat_ext">
             <value name="TIMES">
-                <block type="math_number">
+                <shadow type="math_number">
                     <field name="NUM">10</field>
-                </block>
+                </shadow>
             </value>
         </block>
         <block type="controls_whileUntil">

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
@@ -29,6 +29,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -235,7 +236,12 @@ public class ToolboxFragment extends BlockDrawerFragment {
                     return false;
                 }
 
-                Block copiedModel = blockView.getBlock().getRootBlock().deepCopy();
+                Block original = blockView.getBlock().getRootBlock();
+                if (!original.isDraggable()) {
+                    Log.w(TAG, "A block group in the Toolbox cannot be dragged!");
+                    return false;
+                }
+                Block copiedModel = original.deepCopy();
 
                 // Make the pointer be in the same relative position on the block as it was in the
                 // toolbox.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/TrashFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/TrashFragment.java
@@ -18,6 +18,7 @@ package com.google.blockly.android;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -66,6 +67,7 @@ import java.util.List;
  * @attr ref com.google.blockly.R.styleable#BlockDrawerFragment_scrollOrientation
  */
 public class TrashFragment extends BlockDrawerFragment {
+    private static final String TAG = "TrashFragment";
     private BlocklyController mController;
     private WorkspaceHelper mHelper;
     private BlockListView mBlockListView;
@@ -185,7 +187,10 @@ public class TrashFragment extends BlockDrawerFragment {
                     }
 
                     Block rootBlock = blockView.getBlock().getRootBlock();
-                    // TODO(#77): Optimize to avoid copying the model and view trees.
+                    if (!rootBlock.isDraggable()) {
+                        Log.w(TAG, "A block group in the Trash cannot be dragged!");
+                        return false;
+                    }
                     Block copiedModel = rootBlock.deepCopy();
 
                     // Make the pointer be in the same relative position on the block as it was in

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -404,7 +404,7 @@ public class BlocklyController {
                 // Disconnect view.
                 InputView inView = in.getView();
                 if (inView != null) {
-                    inView.disconnectBlockGroup();
+                    inView.setConnectedBlockGroup(null);
                 }
             }
             block.getPreviousConnection().disconnect();
@@ -417,7 +417,7 @@ public class BlocklyController {
             // Disconnect view.
             InputView inView = in.getView();
             if (inView != null) {
-                inView.disconnectBlockGroup();
+                inView.setConnectedBlockGroup(null);
             }
         }
 
@@ -748,7 +748,7 @@ public class BlocklyController {
             parentStatementConnection.disconnect();
             InputView parentInputView = parentStatementConnection.getInputView();
             if (parentInputView != null) {
-                parentInputView.disconnectBlockGroup();
+                parentInputView.setConnectedBlockGroup(null);
             }
 
             // Try to reconnect the remainder to the end of the new sequence.
@@ -843,7 +843,7 @@ public class BlocklyController {
             previousTargetConnection = parentConn.getTargetConnection();
             parentConn.disconnect();
             if (parentInputView != null) {
-                parentInputView.disconnectBlockGroup();
+                parentInputView.setConnectedBlockGroup(null);
             }
         }
         parentConn.connect(childConn);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
@@ -43,6 +43,8 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
 
     // The view of the blocks connected to this input.
     protected BlockGroup mConnectedGroup = null;
+    // The view of the shadow blocks connected to this input.
+    protected BlockGroup mConnectedShadowGroup = null;
 
     /**
      * Constructs a base implementation of an {@link InputView}.
@@ -92,7 +94,8 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
     }
 
     /**
-     * Set the view of the blocks whose output port is connected to this input.
+     * Sets the view of the blocks whose output/previous connector is connected to this input.
+     * Setting it to null will remove any set block group.
      *
      * @param blockGroup The {@link BlockGroup} to attach to this input. The {@code childView} will
      *                  be added to the layout hierarchy for the current view via a call to
@@ -103,38 +106,72 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
      * @throws IllegalArgumentException if the method argument is {@code null}.
      */
     public void setConnectedBlockGroup(BlockGroup blockGroup) {
+        if (blockGroup == null) {
+            if (mConnectedGroup != null) {
+                removeView(mConnectedGroup);
+                mConnectedGroup = null;
+                if (mConnectedShadowGroup != null) {
+                    mConnectedShadowGroup.setVisibility(View.VISIBLE);
+                }
+                requestLayout();
+            }
+            return;
+        }
         if (mConnectedGroup != null) {
             throw new IllegalStateException("Input is already connected; must disconnect first.");
         }
 
-        if (blockGroup == null) {
-            throw new IllegalArgumentException("Cannot use setChildView with a null child. " +
-                    "Use disconnectBlockGroup to remove a child view.");
-        }
         mConnectedGroup = blockGroup;
+        if (mConnectedShadowGroup != null) {
+            mConnectedShadowGroup.setVisibility(View.GONE);
+        }
 
         addView(blockGroup);
         requestLayout();
     }
 
     /**
-     * Disconnect the currently-connected child view from this input.
-     * <p/>
-     * This method also removes the child view from the view hierarchy by calling
-     * {@link ViewGroup#removeView(View)}.
-     *
-     * @return The removed child view, if any. Otherwise, null.
+     * @return The {@link BlockGroup} containing the shadow blocks connected to this input port,
+     * if any.
      */
-    // TODO(#136): setConnectedBlockGroup(null)?
-    public BlockGroup disconnectBlockGroup() {
-        BlockGroup result = mConnectedGroup;
-        if (mConnectedGroup != null) {
-            removeView(mConnectedGroup);
-            mConnectedGroup = null;
-            requestLayout();
+    @Override
+    @Nullable
+    public BlockGroup getConnectedShadowGroup() {
+        return mConnectedShadowGroup;
+    }
+
+    /**
+     * Sets the view of the shadow blocks whose output/previous connector is connected to this
+     * input. Setting it to null will remove the connected group instead.
+     *
+     * @param blockGroup The {@link BlockGroup} to attach to this input. The {@code childView} will
+     *                  be added to the layout hierarchy for the current view via a call to
+     *                  {@link ViewGroup#addView(View)}.
+     *
+     * @throws IllegalStateException if a child view is already set. The Blockly model requires
+     *         disconnecting a block from an input before a new one can be connected.
+     * @throws IllegalArgumentException if the method argument is {@code null}.
+     */
+    public void setConnectedShadowGroup(BlockGroup blockGroup) {
+        if (blockGroup == null) {
+            if (mConnectedShadowGroup != null) {
+                removeView(mConnectedShadowGroup);
+                mConnectedShadowGroup = null;
+                requestLayout();
+            }
+            return;
+        }
+        if (mConnectedShadowGroup != null) {
+            throw new IllegalStateException("Input is already connected; must disconnect first.");
         }
 
-        return result;
+        mConnectedShadowGroup = blockGroup;
+        if (mConnectedGroup != null) {
+            mConnectedShadowGroup.setVisibility(View.GONE);
+        }
+
+        addView(blockGroup);
+        requestLayout();
     }
 
     /**
@@ -149,7 +186,11 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
         }
         if (mConnectedGroup != null) {
             mConnectedGroup.unlinkModel();
-            disconnectBlockGroup();
+            mConnectedGroup = null;
+        }
+        if (mConnectedShadowGroup != null) {
+            mConnectedShadowGroup.unlinkModel();
+            mConnectedShadowGroup = null;
         }
         removeAllViews();
         mInput.setView(null);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockGroup.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockGroup.java
@@ -189,12 +189,13 @@ public class BlockGroup extends NonPropagatingViewGroup {
     }
 
     /**
-     * Recursively disconnects the model from view, and removes all views.
+     * Recursively disconnects the model from view and unregisters and removes all views.
      */
     public void unlinkModel() {
         int childCount = getChildCount();
         for (int i = childCount - 1; i >= 0; --i) {
-            ((BlockView) getChildAt(i)).unlinkModel();
+            BlockView bv = (BlockView) getChildAt(i);
+            bv.unlinkModel();
         }
         removeAllViews();
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -147,6 +147,13 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
                             targetBlock, connectionManager, touchHandler);
                     inputView.setConnectedBlockGroup(subgroup);
                 }
+                targetBlock = input.getConnection().getTargetShadowBlock();
+                if (targetBlock != null) {
+                    // Blocks connected to inputs live in their own BlockGroups.
+                    BlockGroup subgroup = buildBlockGroupTree(
+                            targetBlock, connectionManager, touchHandler);
+                    inputView.setConnectedShadowGroup(subgroup);
+                }
             }
             inputViews.add(inputView);
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -19,6 +19,7 @@ import android.content.ClipData;
 import android.graphics.Rect;
 import android.support.annotation.IntDef;
 import android.support.v4.view.MotionEventCompat;
+import android.util.Log;
 import android.util.Pair;
 import android.view.DragEvent;
 import android.view.MotionEvent;
@@ -277,6 +278,11 @@ public class Dragger {
      */
     public boolean onTouchBlock(BlockView blockView, MotionEvent event) {
         final int action = MotionEventCompat.getActionMasked(event);
+        blockView = mWorkspaceHelper.getNearestActiveView(blockView);
+        if (blockView == null) {
+            Log.i(TAG, "User touched a stack of blocks that may not be dragged");
+            return false;
+        }
         // Handle the case when the user releases before moving far enough to start a drag.
         if ((action == MotionEvent.ACTION_UP && !mIsDragging)
                 && mTouchedBlockView == blockView) {
@@ -306,6 +312,11 @@ public class Dragger {
      * @return true if a drag has been started, false otherwise.
      */
     public boolean onInterceptTouchEvent(BlockView blockView, MotionEvent motionEvent) {
+        blockView = mWorkspaceHelper.getNearestActiveView(blockView);
+        if (blockView == null) {
+            Log.i(TAG, "User touched a stack of blocks that may not be dragged");
+            return false;
+        }
         final int action = MotionEventCompat.getActionMasked(motionEvent);
         if (action == MotionEvent.ACTION_DOWN) {
             setTouchedBlock(blockView, motionEvent); // regardless of the idle state

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
@@ -19,11 +19,20 @@ public interface InputView {
 
     /**
      * Sets the {@link BlockGroup} containing the block connected to this input and updates the view
-     * hierarchy.
+     * hierarchy. Calling this with null will disconnect the current group.
      *
      * @param group The {@link BlockGroup} to add to this input view.
      */
     void setConnectedBlockGroup(BlockGroup group);
+
+    /**
+     * Sets the {@link BlockGroup} containing the shadow block connected to this input and updates
+     * the view hierarchy. This generally only needs to be done when the view hierarchy is first
+     * created. Calling this with null will disconnect the current group.
+     *
+     * @param group The {@link BlockGroup} to add to this input view.
+     */
+    void setConnectedShadowGroup(BlockGroup group);
 
     /**
      * @return The {@link BlockGroup} connected to this input connection.
@@ -31,12 +40,9 @@ public interface InputView {
     BlockGroup getConnectedBlockGroup();
 
     /**
-     * Unsets the {@link BlockGroup} in this input view and updates the view hierarchy.
-     *
-     * @return The previously set {@link BlockGroup}.
+     * @return The {@link BlockGroup} shadow block connected to this input connection.
      */
-    // TODO(#136): Replace with setConnectedBlockGroup(null).
-    BlockGroup disconnectBlockGroup();
+    BlockGroup getConnectedShadowGroup();
 
     /**
      * Recursively disconnects the view from the model, including all subviews/model subcomponents.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
@@ -139,6 +139,24 @@ public class WorkspaceHelper {
     }
 
     /**
+     * Gets the first block up the hierarchy that can be dragged by the user. If the starting
+     * block can be manipulated it will be returned.
+     *
+     * @param startingView The original view that was touched.
+     * @return The nearest parent block that the user can manipulate.
+     */
+    public BlockView getNearestActiveView(BlockView startingView) {
+        Block block = startingView.getBlock();
+        while (block != null) {
+            if (block.isDraggable()) {
+                return getView(block);
+            }
+            block = block.getParentBlock();
+        }
+        return null;
+    }
+
+    /**
      * Set the offset of the virtual workspace view.
      * <p/>
      * This is the coordinate of the top-left corner of the area of the workspace shown by a

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -338,6 +338,13 @@ public class Block {
     }
 
     /**
+     * @return True if this block can be dragged by the user, false otherwise.
+     */
+    public boolean isDraggable() {
+        return !mIsShadow && mCanMove;
+    }
+
+    /**
      * Creates a copy of this block and all inferior blocks connected to it.
      *
      * @return A new block tree with a copy of this block as the root.
@@ -952,17 +959,17 @@ public class Block {
         private Connection mNextConnection;
         private Connection mPreviousConnection;
         private ArrayList<Input> mInputs;
-        private boolean mInputsInline;
-        private boolean mIsShadow;
         // These values can be changed after creating the block
         private String mTooltip;
         private String mComment;
-        private boolean mHasContextMenu;
-        private boolean mCanDelete;
-        private boolean mCanMove;
-        private boolean mCanEdit;
-        private boolean mCollapsed;
-        private boolean mDisabled;
+        private boolean mHasContextMenu = false;
+        private boolean mInputsInline = false;
+        private boolean mIsShadow = false;
+        private boolean mCanDelete = true;
+        private boolean mCanMove = true;
+        private boolean mCanEdit = true;
+        private boolean mCollapsed = false;
+        private boolean mDisabled = false;
 
         public Builder(String name) {
             mName = name;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
@@ -295,7 +295,6 @@ public class Connection implements Cloneable {
         }
         if (target.getBlock().isShadow()) {
             if (mTargetShadowConnection != null) {
-                Log.w(TAG, "Shadow blocks are not intended to change.");
                 return REASON_MUST_DISCONNECT;
             }
         } else if (mTargetConnection != null) {

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.view.View;
 
+import com.google.blockly.android.ui.BlockGroup;
 import com.google.blockly.model.Input;
 import com.google.blockly.android.ui.AbstractInputView;
 import com.google.blockly.android.ui.BlockView;
@@ -277,12 +278,14 @@ public class InputView extends AbstractInputView {
     private void measureConnectedBlockGroup(int widthMeasureSpec, int heightMeasureSpec) {
         final boolean inputsInline = mInput.getBlock().getInputsInline();
 
-        if (mConnectedGroup != null) {
+        BlockGroup groupToMeasure = mConnectedGroup != null ? mConnectedGroup
+                : mConnectedShadowGroup;
+        if (groupToMeasure != null) {
             // There is a block group connected to this input - measure it and add its size
             // to this InputView's size.
-            mConnectedGroup.measure(widthMeasureSpec, heightMeasureSpec);
-            mConnectedGroupWidth = mConnectedGroup.getMeasuredWidth();
-            mConnectedGroupHeight = mConnectedGroup.getMeasuredHeight();
+            groupToMeasure.measure(widthMeasureSpec, heightMeasureSpec);
+            mConnectedGroupWidth = groupToMeasure.getMeasuredWidth();
+            mConnectedGroupHeight = groupToMeasure.getMeasuredHeight();
 
             // Only add space for decorations around Statement and inline Value inputs.
             switch (mInputType) {
@@ -340,7 +343,9 @@ public class InputView extends AbstractInputView {
      * If there is a child connected to this Input, then layout the child in the correct place.
      */
     private void layoutChild() {
-        if (mConnectedGroup != null) {
+        BlockGroup groupToLayout = mConnectedGroup != null ? mConnectedGroup
+                : mConnectedShadowGroup;
+        if (groupToLayout != null) {
             // Compute offset of child relative to InputView. By default, align top of fields and
             // input, and shift right by left padding plus field width.
             int topOffset = 0;
@@ -369,14 +374,14 @@ public class InputView extends AbstractInputView {
                     // Nothing to do.
             }
 
-            final int width = mConnectedGroup.getMeasuredWidth();
-            final int height = mConnectedGroup.getMeasuredHeight();
+            final int width = groupToLayout.getMeasuredWidth();
+            final int height = groupToLayout.getMeasuredHeight();
 
             if (mHelper.useRtl()) {
                 leftOffset = getMeasuredWidth() - leftOffset - width;
             }
 
-            mConnectedGroup.layout(leftOffset, topOffset, leftOffset + width, topOffset + height);
+            groupToLayout.layout(leftOffset, topOffset, leftOffset + width, topOffset + height);
         }
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractInputViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractInputViewTest.java
@@ -78,27 +78,13 @@ public class AbstractInputViewTest extends MockitoAndroidTestCase {
 
         final BlockGroup mockGroup = Mockito.mock(BlockGroup.class);
         inputView.setConnectedBlockGroup(mockGroup);
-        inputView.disconnectBlockGroup();
+        inputView.setConnectedBlockGroup(null);
         assertNull(inputView.getConnectedBlockGroup());
         assertEquals(0, inputView.getChildCount());
 
         inputView.setConnectedBlockGroup(mockGroup);
         assertSame(mockGroup, inputView.getConnectedBlockGroup());
         assertEquals(1, inputView.getChildCount());
-    }
-
-    // Verify exception is thrown when calling setChildView with null. Use disconnectBlockGroup().
-    public void testSetChildViewNull() {
-        final AbstractInputView inputView = makeDefaultInputView();
-
-        // TODO(#68): Do this using @Rule and ExpectedException; not working with current runner(s).
-        try {
-            inputView.setConnectedBlockGroup(null);
-        } catch (IllegalArgumentException expected) {
-            return;
-        }
-
-        fail("Expected IllegalArgumentException not thrown.");
     }
 
     // Verify exception is thrown when calling setChildView repeatedly without disconnectBlockGroup.


### PR DESCRIPTION
This adds initial UI support for shadow blocks. Shadows are rendered at
50% alpha, though their fields are rendered normally to make them readable.
We will need a pass on the 9-patch layout code as there is some overlap that
makes bits of it less transparent.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/160) &emsp; Multiple assignees:&emsp;<img alt="@AnmAtAnm" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/9916202?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/AnmAtAnm">AnmAtAnm</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
