### PR TITLE
Standardize error handling when loading block definitions.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -50,6 +50,7 @@ import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.model.BlockFactory;
 import com.google.blockly.model.BlocklySerializerException;
 import com.google.blockly.model.Workspace;
+import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.StringOutputStream;
 
 import java.io.FileNotFoundException;
@@ -671,15 +672,17 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
         factory.clear();
 
         String blockDefsPath = null;
-        try {
-            Iterator<String> iter = blockDefsPaths.iterator();
-            while (iter.hasNext()) {
-                blockDefsPath = iter.next();
+        Iterator<String> iter = blockDefsPaths.iterator();
+        while (iter.hasNext()) {
+            blockDefsPath = iter.next();
+            try {
                 factory.addBlocks(assetManager.open(blockDefsPath));
+            } catch (IOException e) {
+                factory.clear();  // Clear any partial loaded block sets.
+                // Compile-time bundled assets are assumed to be valid.
+                throw new IllegalStateException("Failed to load block definitions from asset: "
+                        + blockDefsPath, e);
             }
-        } catch (IOException e) {
-            factory.clear();  // Clear any partial loaded block sets.
-            throw new IllegalArgumentException("Error opening block defs at " + blockDefsPath, e);
         }
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -1082,14 +1082,22 @@ public class BlocklyController {
             }
             BlockFactory factory = new BlockFactory(mContext, null);
             for (int i = 0; i < mBlockDefResources.size(); i++) {
-                factory.addBlocks(mBlockDefResources.get(i));
+                try {
+                    factory.addBlocks(mBlockDefResources.get(i));
+                } catch (Throwable e) {
+                    factory.clear();  // Clear partially loaded resources.
+                    throw e;
+                }
             }
             for (int i = 0; i < mBlockDefAssets.size(); i++) {
+                String assetPath = mBlockDefAssets.get(i);
                 try {
-                    factory.addBlocks(mAssetManager.open(mBlockDefAssets.get(i)));
+                    factory.addBlocks(mAssetManager.open(assetPath));
                 } catch (IOException e) {
-                    throw new IllegalArgumentException("Failed to load block definitions "
-                            + mBlockDefAssets.get(i), e);
+                    factory.clear();  // Clear partially loaded resources.
+                    // Compile-time bundled assets are assumed to always be valid.
+                    throw new IllegalStateException("Failed to load block definitions from asset: "
+                            + assetPath, e);
                 }
             }
             for (int i = 0; i < mBlockDefs.size(); i++) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -20,6 +20,7 @@ import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.Colours;
 
 import org.json.JSONArray;
@@ -603,7 +604,7 @@ public class Block {
      *
      * @return The generated Block.
      */
-    public static Block fromJson(String name, JSONObject json) {
+    public static Block fromJson(String name, JSONObject json) throws BlockLoadingException {
         if (TextUtils.isEmpty(name)) {
             throw new IllegalArgumentException("Block name may not be null or empty.");
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -19,6 +19,8 @@ import android.database.Observable;
 import android.support.annotation.IntDef;
 import android.util.Log;
 
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
@@ -142,12 +144,12 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
      *
      * @throws RuntimeException
      */
-    public static Field fromJson(JSONObject json) {
+    public static Field fromJson(JSONObject json) throws BlockLoadingException {
         String type = null;
         try {
             type = json.getString("type");
         } catch (JSONException e) {
-            throw new RuntimeException("Error getting the field type.", e);
+            throw new BlockLoadingException("Error getting the field type.", e);
         }
 
         // If new fields are added here FIELD_TYPES should also be updated.

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldAngle.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldAngle.java
@@ -15,6 +15,10 @@
 
 package com.google.blockly.model;
 
+import android.text.TextUtils;
+
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -31,10 +35,13 @@ public final class FieldAngle extends Field<FieldAngle.Observer> {
         setAngle(angle);
     }
 
-    public static FieldAngle fromJson(JSONObject json) {
-        return new FieldAngle(
-                json.optString("name", "NAME"),
-                json.optInt("angle", 90));
+    public static FieldAngle fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_angle \"name\" attribute must not be empty.");
+        }
+
+        return new FieldAngle(name, json.optInt("angle", 90));
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
@@ -15,6 +15,10 @@
 
 package com.google.blockly.model;
 
+import android.text.TextUtils;
+
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -31,10 +35,13 @@ public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
         mChecked = checked;
     }
 
-    public static FieldCheckbox fromJson(JSONObject json) {
-        return new FieldCheckbox(
-                json.optString("name", "NAME"),
-                json.optBoolean("checked", true));
+    public static FieldCheckbox fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_checkbox \"name\" attribute must not be empty.");
+        }
+
+        return new FieldCheckbox(name, json.optBoolean("checked", true));
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldColour.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldColour.java
@@ -18,6 +18,8 @@ package com.google.blockly.model;
 import android.graphics.Color;
 import android.text.TextUtils;
 
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -40,8 +42,11 @@ public final class FieldColour extends Field<FieldColour.Observer> {
         setColour(colour);
     }
 
-    public static FieldColour fromJson(JSONObject json) {
-        String name = json.optString("name", "NAME");
+    public static FieldColour fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_colour \"name\" attribute must not be empty.");
+        }
         int colour = DEFAULT_COLOUR;
 
         String colourString = json.optString("colour");

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
@@ -17,6 +17,8 @@ package com.google.blockly.model;
 
 import android.text.TextUtils;
 
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,8 +47,11 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
         mOptions = (options != null) ? options : new ArrayList<Option>(0);
     }
 
-    public static FieldDropdown fromJson(JSONObject json) {
-        String name = json.optString("name", "NAME");
+    public static FieldDropdown fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_dropdown \"name\" attribute must not be empty.");
+        }
 
         JSONArray jsonOptions = json.optJSONArray("options");
         ArrayList<Option> options = null;
@@ -59,18 +64,18 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
                 try {
                     option = jsonOptions.getJSONArray(i);
                 } catch (JSONException e) {
-                    throw new RuntimeException("Error reading dropdown options.", e);
+                    throw new BlockLoadingException("Error reading dropdown options.", e);
                 }
                 if (option != null && option.length() == 2) {
                     try {
                         String displayName = option.getString(0);
                         String value = option.getString(1);
                         if (TextUtils.isEmpty(value)) {
-                            throw new IllegalArgumentException("Option values may not be empty");
+                            throw new BlockLoadingException("Option values may not be empty");
                         }
                         options.add(new Option(value, displayName));
                     } catch (JSONException e) {
-                        throw new RuntimeException("Error reading option values.", e);
+                        throw new BlockLoadingException("Error reading option values.", e);
                     }
                 }
             }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
@@ -17,6 +17,8 @@ package com.google.blockly.model;
 
 import android.text.TextUtils;
 
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -33,11 +35,13 @@ public final class FieldInput extends Field<FieldInput.Observer> {
         mText = text;
     }
 
-    public static FieldInput fromJson(JSONObject json) {
+    public static FieldInput fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_input \"name\" attribute must not be empty.");
+        }
         // TODO: consider replacing default text with string resource
-        return new FieldInput(
-                json.optString("name", "NAME"),
-                json.optString("text", "default"));
+        return new FieldInput(name, json.optString("text", "default"));
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
@@ -17,6 +17,8 @@ package com.google.blockly.model;
 
 import android.text.TextUtils;
 
+import com.google.blockly.utils.BlockLoadingException;
+
 import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -33,9 +35,12 @@ public final class FieldVariable extends Field<FieldVariable.Observer> {
         mVariable = variable;
     }
 
-    public static FieldVariable fromJson(JSONObject json) {
-        return new FieldVariable(
-                json.optString("name", "NAME"), json.optString("variable", "item"));
+    public static FieldVariable fromJson(JSONObject json) throws BlockLoadingException {
+        String name = json.optString("name");
+        if (TextUtils.isEmpty(name)) {
+            throw new BlockLoadingException("field_variable \"name\" attribute must not be empty.");
+        }
+        return new FieldVariable(name, json.optString("variable", "item"));
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlockLoadingException.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlockLoadingException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.blockly.utils;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when Blockly encounters an error loading blocks.
+ */
+public class BlockLoadingException extends IOException {
+    public BlockLoadingException(String mesg) {
+        super(mesg);
+    }
+
+    public BlockLoadingException(Throwable cause) {
+        super(cause);
+    }
+
+    public BlockLoadingException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -19,6 +19,7 @@ import android.test.AndroidTestCase;
 
 import com.google.blockly.android.MockBlocksProvider;
 import com.google.blockly.android.R;
+import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -50,13 +51,8 @@ public class BlockTest extends AndroidTestCase {
         mBlockFactory = new BlockFactory(getContext(), new int[]{R.raw.test_blocks});
     }
 
-    public void testJson() {
-        JSONObject blockDefinitionJson;
-        try {
-            blockDefinitionJson = new JSONObject(BlockTestStrings.TEST_JSON_STRING);
-        } catch (JSONException e) {
-            throw new RuntimeException("Failure parsing test JSON.", e);
-        }
+    public void testJson() throws JSONException, BlockLoadingException {
+        JSONObject blockDefinitionJson = new JSONObject(BlockTestStrings.TEST_JSON_STRING);
         Block block = Block.fromJson("test_block", blockDefinitionJson);
 
         assertNotNull("Block was null after initializing from JSON", block);

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
@@ -23,10 +23,10 @@ import java.util.Date;
  */
 public class FieldDateTest extends AndroidTestCase {
     public void testFieldDate() {
-        FieldDate field = new FieldDate("alphabet", "2015-09-10");
+        FieldDate field = new FieldDate("alphabet", "2015-09-14");
         assertEquals(Field.TYPE_DATE, field.getType());
         assertEquals("alphabet", field.getName());
-        assertEquals("2015-09-10", field.getDateString());
+        assertEquals("2015-09-14", field.getDateString());
 
         Date date = new Date();
         field.setDate(date);
@@ -35,8 +35,8 @@ public class FieldDateTest extends AndroidTestCase {
         field.setTime(date.getTime());
         assertEquals(date, field.getDate());
 
-        assertTrue(field.setFromString("2017-03-03"));
-        assertEquals("2017-03-03", field.getDateString());
+        assertTrue(field.setFromString("2017-03-23"));
+        assertEquals("2017-03-23", field.getDateString());
 
         // xml parsing
         assertFalse(field.setFromString("today"));


### PR DESCRIPTION
Adding BlockLoadingException, which is exposed all the way down to the AbstractBlocklyActivity.
In cases where the block definitions are resource or asset, errors are thrown are IllegalStateExceptions, since such compile-time files are assumed to be correct.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/162) &emsp; Multiple assignees:&emsp;<img alt="@RoboErikG" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/11066279?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/RoboErikG">RoboErikG</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/roboerikg/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
