### PR TITLE
Fix #122 Ignore drag events when we're confused

### DIFF
--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "22.0.1"
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         applicationId "com.google.blockly.demo"
@@ -36,6 +36,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:23.3.+'
     compile project(':blocklylib-vertical')
 }

--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 16
@@ -30,7 +30,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:recyclerview-v7:23.0.+'
-    compile 'com.android.support:support-v4:24.0.0-alpha1'
+    compile 'com.android.support:appcompat-v7:23.3.+'
+    compile 'com.android.support:recyclerview-v7:23.3.+'
+    compile 'com.android.support:support-v4:23.3.+'
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -97,7 +97,11 @@ public class Dragger {
                     startDragInternal();
                     return true;    // We want to keep listening for drag events
                 case DragEvent.ACTION_DRAG_LOCATION:
-                    continueDragging(event);
+                    if (mTouchState == TOUCH_STATE_DRAGGING) {
+                        // If we're still finishing up a previous drag we may have missed the
+                        // start of the drag, in which case we shouldn't do anything.
+                        continueDragging(event);
+                    }
                     break;
                 case DragEvent.ACTION_DRAG_ENDED:
                     if (event.getResult()) {

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -20,6 +20,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.2.0'
+    compile 'com.android.support:appcompat-v7:23.3.+'
     compile project(':blocklylib-core')
 }

--- a/blocklytest/build.gradle
+++ b/blocklytest/build.gradle
@@ -27,7 +27,7 @@ android {
 dependencies {
     androidTestCompile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:appcompat-v7:23.2.0'
+    androidTestCompile 'com.android.support:appcompat-v7:23.3.+'
     androidTestCompile project(':blocklylib-vertical')
     // For UI testing with Espresso.
     androidTestCompile 'com.android.support.test:runner:0.4.1'


### PR DESCRIPTION
If the user does something that causes a big measure pass (such as dragging
a block out of a very large stack of nested views) it can cause us to miss a
bunch of drag events. The framework is a little squirrely in how it handles
this and we end up getting some random drag events in the middle of subsequent
drags.

Also updates the supportlib versions so we stop crashing on API 19.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roboerikg/blockly-android/178)

<!-- Reviewable:end -->
