### PR TITLE
Skip code generation if the workspace is empty

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -614,6 +614,10 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      */
     protected void onRunCode() {
         try {
+            if (mWorkspaceFragment.getWorkspace().getRootBlocks().size() == 0) {
+                Log.i(TAG, "No blocks in workspace. Skipping run request.");
+                return;
+            }
             if (mBound) {
                 final StringOutputStream serialized = new StringOutputStream();
                 mWorkspaceFragment.getWorkspace().serializeToXml(serialized);


### PR DESCRIPTION
Fixes #166 but we can investigate later if we want to also disable the run
button when the workspace is empty.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/198) &emsp; Multiple assignees:&emsp;<img alt="@AnmAtAnm" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/9916202?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/AnmAtAnm">AnmAtAnm</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
