### PR TITLE
Change BasicFieldColourView to inherit from FrameLayout instead of View

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldColourView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldColourView.java
@@ -25,6 +25,7 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.PopupWindow;
 
 import com.google.blockly.model.Field;
@@ -33,7 +34,7 @@ import com.google.blockly.model.FieldColour;
 /**
  * Renders a color field and picker as part of a BlockView.
  */
-public class BasicFieldColourView extends View implements FieldView {
+public class BasicFieldColourView extends FrameLayout implements FieldView {
     protected static final int DEFAULT_MIN_WIDTH_DP = 40;
     protected static final int DEFAULT_MIN_HEIGHT_DP = 28;  // Base on styled label text height?
 


### PR DESCRIPTION
We were using getForeground which is available on FrameLayout back to API 1
but was only added to View in API 23 and the documentation is incorrect.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/203) &emsp; Multiple assignees:&emsp;<img alt="@AnmAtAnm" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/9916202?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/AnmAtAnm">AnmAtAnm</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
