### PR TITLE
Ensure we use unique ids for fields

### DIFF
--- a/blocklylib-vertical/src/main/res/layout/default_field_angle.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_angle.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldAngleView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_angle"
         style="@style/TextAppearance.AppCompat.Large"
         android:textSize="?blockTextSize"
         android:background="@color/angle_bg_colour"

--- a/blocklylib-vertical/src/main/res/layout/default_field_checkbox.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_checkbox.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldCheckboxView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_checkbox"
         android:padding="4dip"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>

--- a/blocklylib-vertical/src/main/res/layout/default_field_colour.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_colour.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.vertical.FieldColourView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_color"
         android:foreground="@drawable/inset_field_border"
         android:padding="4dip"
         android:layout_width="wrap_content"

--- a/blocklylib-vertical/src/main/res/layout/default_field_date.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_date.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldDateView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_date"
         style="@style/TextAppearance.AppCompat.Large"
         android:textSize="?blockTextSize"
         android:background="@color/date_bg_colour"

--- a/blocklylib-vertical/src/main/res/layout/default_field_dropdown.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_dropdown.xml
@@ -16,7 +16,7 @@
 <com.google.blockly.android.ui.fieldview.BasicFieldDropdownView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/field_input"
+    android:id="@+id/field_dropdown"
     app:itemLayout="@layout/default_spinner_item"
     app:dropdownItemLayout="@layout/default_spinner_drop_down"
     android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_label.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_label.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldLabelView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_label"
         style="@style/TextAppearance.AppCompat.Large"
         android:textSize="?blockTextSize"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_number.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_number.xml
@@ -15,7 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldNumberView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/field_input"
+        android:id="@+id/field_number"
         style="@style/TextAppearance.AppCompat.Large"
         android:textSize="?blockTextSize"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_spinner_drop_down.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_spinner_drop_down.xml
@@ -14,7 +14,7 @@
   ~  limitations under the License.
   -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          android:id="@android:id/text1"
+          android:id="@+id/default_dropdown"
           style="@style/DefaultSpinnerDropDownStyle"
           android:textSize="?blockTextSize"
           android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_spinner_item.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_spinner_item.xml
@@ -14,7 +14,7 @@
   ~  limitations under the License.
   -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          android:id="@android:id/text1"
+          android:id="@+id/default_item"
           style="@style/DefaultSpinnerStyle"
           android:textSize="?blockTextSize"
           android:singleLine="true"


### PR DESCRIPTION
We were getting a cast exception when restoring on newer devices which was
caused by having the same id for all the fields. Giving them unique fields
lets the system restore each field correctly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/204) &emsp; Multiple assignees:&emsp;<img alt="@AnmAtAnm" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/9916202?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/AnmAtAnm">AnmAtAnm</a>,&emsp;<img alt="@rachel-fenichel" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/13686399?s=40&v=3">&nbsp;<a href="/google/blockly-android/pulls/assigned/rachel-fenichel">rachel-fenichel</a>

<!-- Reviewable:end -->
