### PR TITLE
Fixing numerous bugs in Dragger.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/TrashFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/TrashFragment.java
@@ -62,7 +62,6 @@ import java.util.List;
  */
 public class TrashFragment extends BlockDrawerFragment {
     private BlocklyController mController;
-    private BlockListView mBlockListView;
 
     private BlockListView.OnDragListBlock mListDragHandler = new BlockListView.OnDragListBlock() {
         @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -83,24 +83,35 @@ public class BlocklyController {
 
     private final Dragger.DragHandler mWorkspaceDragHandler = new Dragger.DragHandler() {
         @Override
-        public void maybeAssignDragGroup(PendingDrag pendingDrag) {
+        public Runnable maybeGetDragGroupCreator(final PendingDrag pendingDrag) {
             BlockView touchedView = pendingDrag.getTouchedBlockView();
 
             // If a shadow or other undraggable block is touched, and it is attached to a draggable
             // parent block, drag that block instead.
-            touchedView = mHelper.getNearestActiveView(touchedView);
-            if (touchedView == null) {
+            final BlockView activeTouchedView = mHelper.getNearestActiveView(touchedView);
+            if (activeTouchedView == null) {
                 Log.i(TAG, "User touched a stack of blocks that may not be dragged");
-                return;
+                return null;
             }
 
-            extractBlockAsRoot(touchedView.getBlock());
-            // Since this block was already on the workspace, the block's position should have
-            // been assigned correctly during the most recent layout pass.
-            BlockGroup bg = mHelper.getRootBlockGroup(touchedView);
-            bg.bringToFront();
+            return new Runnable() {
+                @Override
+                public void run() {
+                    extractBlockAsRoot(activeTouchedView.getBlock());
+                    // Since this block was already on the workspace, the block's position should
+                    // have been assigned correctly during the most recent layout pass.
+                    BlockGroup bg = mHelper.getRootBlockGroup(activeTouchedView);
+                    bg.bringToFront();
 
-            pendingDrag.setDragGroup(bg);
+                    pendingDrag.setDragGroup(bg);
+                }
+            };
+        }
+
+        @Override
+        public boolean onBlockClicked(PendingDrag pendingDrag) {
+            // TODO(#35): Mark block as focused / selected.
+            return false;
         }
     };
     private final BlockTouchHandler mTouchHandler;
@@ -141,7 +152,7 @@ public class BlocklyController {
         }
 
         mDragger = new Dragger(this);
-        mTouchHandler = mDragger.buildBlockTouchHandler(mWorkspaceDragHandler);
+        mTouchHandler = mDragger.buildSloppyBlockTouchHandler(mWorkspaceDragHandler);
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
@@ -299,6 +299,7 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
     /**
      * @return The {@link InputView} for the {@link Input} at the given index.
      */
+    @Override
     public InputView getInputView(int index) {
         return mInputViews.get(index);
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
@@ -175,6 +175,16 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
     }
 
     /**
+     * @return The {@link BlockGroup} connected to this input connection, or the shadow block group
+     *         if no normal {@code BlockGroup} is connected.
+     */
+    @Override
+    @Nullable
+    public BlockGroup getConnectedBlockGroupOrShadowGroup() {
+        return mConnectedGroup == null ? mConnectedShadowGroup : mConnectedGroup;
+    }
+
+    /**
      * Recursively disconnects the view from the model, and removes all views.
      */
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
@@ -24,6 +24,7 @@ import android.view.ViewParent;
 
 import com.google.blockly.model.Block;
 import com.google.blockly.model.Connection;
+import com.google.blockly.model.Input;
 
 /**
  * Draws a block and handles laying out all its inputs/fields.
@@ -111,4 +112,10 @@ public interface BlockView {
      * sure the view is not returned by {@link BlockViewFactory#getView(Block)}.
      */
     void unlinkModel();
+
+    /**
+     * @return The {@link InputView} for the {@link Input} at the given index.
+     */
+    @Nullable
+    InputView getInputView(int n);
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
@@ -15,6 +15,7 @@
 
 package com.google.blockly.android.ui;
 
+import android.support.annotation.Nullable;
 import android.view.ViewGroup;
 
 import com.google.blockly.model.Input;
@@ -38,7 +39,7 @@ public interface InputView {
      *
      * @param group The {@link BlockGroup} to add to this input view.
      */
-    void setConnectedBlockGroup(BlockGroup group);
+    void setConnectedBlockGroup(@Nullable BlockGroup group);
 
     /**
      * Sets the {@link BlockGroup} containing the shadow block connected to this input and updates
@@ -47,17 +48,26 @@ public interface InputView {
      *
      * @param group The {@link BlockGroup} to add to this input view.
      */
-    void setConnectedShadowGroup(BlockGroup group);
+    void setConnectedShadowGroup(@Nullable BlockGroup group);
 
     /**
      * @return The {@link BlockGroup} connected to this input connection.
      */
+    @Nullable
     BlockGroup getConnectedBlockGroup();
 
     /**
      * @return The {@link BlockGroup} shadow block connected to this input connection.
      */
+    @Nullable
     BlockGroup getConnectedShadowGroup();
+
+    /**
+     * @return The {@link BlockGroup} connected to this input connection, or the shadow block group
+     *         if no normal {@code BlockGroup} is connected.
+     */
+    @Nullable
+    BlockGroup getConnectedBlockGroupOrShadowGroup();
 
     /**
      * Recursively disconnects the view from the model, including all subviews/model subcomponents.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
@@ -2,7 +2,9 @@ package com.google.blockly.android.ui;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Size;
+import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.MotionEventCompat;
+import android.view.GestureDetector;
 import android.view.MotionEvent;
 
 import com.google.blockly.android.control.BlocklyController;
@@ -16,7 +18,22 @@ import com.google.blockly.model.WorkspacePoint;
  * which calls {@link #setDragGroup(BlockGroup)} to inform the dragger how to complete the rest of
  * the drag behavior.
  */
+// TODO(#233): Rename to PendingGesture or similar
 public final class PendingDrag {
+    /**
+     * This threshold is used to detect bad state from invalid MotionEvent streams.  There are cases
+     * where an intercepting OnTouchListener never receives an appropriate ACTION_CANCEL or
+     * ACTION_UP event.  For example, on API 23, when dragging away from a Spinner (i.e., drop-down
+     * field), the MotionEvent stream will stop as soon as the Spinner popup opens.
+     * </p>
+     * We assume that during a drag, the system should continue to receive events on the touch
+     * stream at least this often during the drag.  Further, by detecting and resetting the state,
+     * it is possible to recover for new drags, rather than locking the drag state in under the
+     * presumption the missing UP or CANCEL will eventually arrive.  The latter case prevents
+     * the {@link Dragger} from detecting future drag gestures.
+     */
+    private long MAX_MOTION_EVENT_MILLISECONDS_DELTA = 500;
+
     private final BlocklyController mController;
     private final WorkspaceHelper mHelper;
     private final BlockView mTouchedView;
@@ -40,6 +57,15 @@ public final class PendingDrag {
     private BlockView mRootBlockView;
     private WorkspacePoint mOriginalBlockPosition = new WorkspacePoint();
 
+    // One gesture detector per drag ensures bad state will not carry over due to event bugs.
+    // The GestureDetector class is relatively lightweight (as of API 23), without any
+    // instantiations at construction.
+    private final GestureDetectorCompat mGestureDetector;
+
+    private long mLatestEventTime;
+    private boolean mAlive = true;
+    private boolean mClicked;
+
     /**
      * Constructs a new PendingDrag that, if accepted by the DragHandler, begins with the
      * {@code actionDown} event.
@@ -50,10 +76,12 @@ public final class PendingDrag {
      */
     PendingDrag(@NonNull BlocklyController controller,
                 @NonNull BlockView touchedView, @NonNull MotionEvent actionDown) {
-        this.mController = controller;
-        this.mHelper = controller.getWorkspaceHelper();
-
         assert (actionDown.getAction() == MotionEvent.ACTION_DOWN);
+
+        mController = controller;
+        mHelper = controller.getWorkspaceHelper();
+
+        mLatestEventTime = actionDown.getEventTime();
 
         mTouchedView = touchedView;
 
@@ -65,6 +93,17 @@ public final class PendingDrag {
 
         touchedView.getTouchLocationOnScreen(actionDown, mTouchDownScreen);
         mHelper.screenToWorkspaceCoordinates(mTouchDownScreen, mTouchDownWorkspace);
+
+        mGestureDetector = new GestureDetectorCompat(mController.getContext(),
+                new GestureListener());
+        mGestureDetector.onTouchEvent(actionDown);
+    }
+
+    /**
+     * @return True if this PendingDrag has received a continuous stream of events for its pointer.
+     */
+    public boolean isAlive() {
+        return mAlive;
     }
 
     /**
@@ -173,5 +212,58 @@ public final class PendingDrag {
      */
     public WorkspacePoint getOriginalBlockPosition() {
         return mOriginalBlockPosition;
+    }
+
+    public boolean isClick() {
+        return mClicked;
+    }
+
+    /**
+     * Compares if {@code event} on {@code touchedView} is a continuation of the event stream
+     * tracked by this PendingDrag.  This includes whether the event stream has had sufficient
+     * regular updates, at least more often than {@link #MAX_MOTION_EVENT_MILLISECONDS_DELTA}
+     * (in an effort to disregard it from dropped previous streams with dropped
+     * {@link MotionEvent#ACTION_UP} and {@link MotionEvent#ACTION_CANCEL}).  If that threshold
+     * is exceeded (for matching view and pointer id), the PendingDrag will no longer be alive
+     * ({@link #isAlive()}, and not match any future events.
+     * <p/>
+     * If the event is a match and alive, it will pass the event through a {@link GestureDetector}
+     * to determine if the event triggers a click (or other interesting gestures in the future).
+     * Check {@link #isClick()} to determine whether a click was detected.
+     * <p/>
+     * This method should only be called from {@link Dragger#onTouchBlockImpl}.
+     *
+     * @param event The event to compare to.
+     * @param touchedView The view that received the touch event.
+     * @return Whether the event was a match and the drag is still alive.
+     */
+    boolean isMatchAndProcessed(MotionEvent event, BlockView touchedView) {
+        if (!mAlive) {
+            return false;
+        }
+
+        final int pointerId = MotionEventCompat.getPointerId(
+                event, MotionEventCompat.getActionIndex(event));
+        long curEventTime = event.getEventTime();
+        long deltaMs = curEventTime - mLatestEventTime;
+        if (deltaMs < MAX_MOTION_EVENT_MILLISECONDS_DELTA) {
+            if (pointerId == mPointerId && touchedView == mTouchedView) {
+                mLatestEventTime = curEventTime;
+                mGestureDetector.onTouchEvent(event);
+                return true;
+            }
+        } else {
+            mAlive = false; // Exceeded threshold and expired.
+        }
+
+        return false;  // Not a pointer & view match or died.
+    }
+
+    private class GestureListener extends GestureDetector.SimpleOnGestureListener {
+        @Override
+        public boolean onSingleTapUp(MotionEvent e) {
+            mClicked = true;
+            return true; // Not actually consumed anywhere.
+        }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -134,4 +134,16 @@ public class BasicFieldInputView extends EditText implements FieldView {
     public void unlinkField() {
         setField(null);
     }
+
+    @Override
+    public boolean callOnClick() {
+        Log.d(TAG, "callOnClick()");
+        return super.callOnClick();
+    }
+
+    @Override
+    public boolean performClick() {
+        Log.d(TAG, "performClick()");
+        return super.performClick();
+    }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -118,6 +118,6 @@ public class BasicFieldVariableView extends Spinner implements FieldView {
                 return;
             }
         }
-        throw new IllegalArgumentException("The variable " + variableName + " does not exist.");
+        throw new IllegalArgumentException("The variable \"" + variableName + "\" does not exist.");
     }
 }


### PR DESCRIPTION
- Adds lots of logging, disabled by constants LOG_TOUCH_EVENTS and LOG_DRAG_EVENTS.
- Creates two modes of touch handling: immediate and sloppy.  Immediate mode initiate a drag as soon as it bubbled down to the actual BlockView (not intercepted from child). Sloppy will delay the drag until the user moves beyond the slop threshold.  Immediate mode is used on the toolbox. Sloppy is used on the workspace.
- PendingDrag tracks the timestamp of each event, looking for gaps larger than MAX_MOTION_EVENT_MILLISECONDS_DELTA.  This hack detects missing ACTION_UP or ACTION_CANCEL events, preventing the state from getting locked on older gestures. (Can occur with Spinner interaction.)
- Using GestureDetector to identify BlockView taps.  Used to instantiate blocks from BlockListViews, but has numerous uses in the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/234)

<!-- Reviewable:end -->
