### PR TITLE
Fixing drag bugs

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
@@ -161,6 +161,9 @@ public final class PendingDrag {
      * @param dragGroup The draggable {@link BlockGroup}.
      */
     public void setDragGroup(@NonNull BlockGroup dragGroup) {
+        if (dragGroup == null) {
+            throw new IllegalArgumentException("DragGroup cannot be null");
+        }
         if (mDragGroup != null) {
             throw new IllegalStateException("Drag group already assigned.");
         }
@@ -196,14 +199,14 @@ public final class PendingDrag {
     /**
      * @return The root {@link Block} of the drag group.
      */
-    public Block getRootBlock() {
+    public Block getRootDraggedBlock() {
         return mRootBlockView.getBlock();
     }
 
     /**
      * @return The root {@link BlockView} of the drag group.
      */
-    public BlockView getRootBlockView() {
+    public BlockView getRootDraggedBlockView() {
         return mRootBlockView;
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
@@ -417,6 +417,7 @@ public class WorkspaceHelper {
      * screen.
      * @param workspacePositionOut Output coordinates of the same location in workspace coordinates.
      */
+    // TODO(#248): Support floating point queries.
     public void screenToWorkspaceCoordinates(@Size(2) int[] screenPositionIn,
                                              WorkspacePoint workspacePositionOut) {
         screenToVirtualViewCoordinates(screenPositionIn, mTempViewPoint);


### PR DESCRIPTION
- Check against null before Drag events.
- Highlight the root BlockView during drag.
- Better naming: "Dragged" in PendingDrag.getRootDraggedBlock() and PendingDrag.getRootDraggedBlockView().

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/244)

<!-- Reviewable:end -->
