### PR TITLE
Strip out block ids in codegen

### DIFF
--- a/blocklydemo/src/main/assets/turtle/generators.js
+++ b/blocklydemo/src/main/assets/turtle/generators.js
@@ -108,3 +108,22 @@ Blockly.JavaScript['turtle_colour'] = function(block) {
 };
 
 Blockly.JavaScript['turtle_repeat_internal'] = Blockly.JavaScript['controls_repeat'];
+
+
+/**
+ * The generated code for turtle blocks includes block ID strings.  These are useful for
+ * highlighting the currently running block, but that behaviour is not supported in Android Blockly
+ * as of May 2016.  This snippet generates the block code normally, then strips out the block IDs
+ * for readability when displaying the code to the user.
+ *
+ * Post-processing the block code in this way allows us to use the same generators for the Android
+ * and web versions of the turtle.
+ */
+Blockly.JavaScript.workspaceToCodeWithId = Blockly.JavaScript.workspaceToCode;
+
+Blockly.JavaScript.workspaceToCode = function(workspace) {
+  var code = this.workspaceToCodeWithId(workspace);
+  // Strip out block IDs for readability.
+  code = goog.string.trimRight(code.replace(/(,\s*)?'block_id_[^']+'\)/g, ')'))
+  return code;
+};

--- a/blocklylib-core/src/main/assets/background_compiler.html
+++ b/blocklylib-core/src/main/assets/background_compiler.html
@@ -62,8 +62,6 @@
       try {
         Blockly.Xml.domToWorkspace(workspace, dom);
         var code = Blockly.JavaScript.workspaceToCode(workspace);
-        // Strip out block IDs for readability.
-        code = goog.string.trimRight(code.replace(/(,\s*)?'block_id_[^']+'\)/g, ')'))
         BlocklyJavascriptInterface.execute(code);
       } catch (e) {
         console.log(e.message);


### PR DESCRIPTION
This is part of a solution for #259 but is a bit too drastic.  In another pass I'll make it so that the app writer gets to choose whether or not to keep the IDs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/273)

<!-- Reviewable:end -->
