### PR TITLE
Attempt number 3 (or 4?) to make shadow blocks work

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -85,6 +85,32 @@
                 <shadow type="statement_no_input"></shadow>
             </statement>
         </block>
+        <block type="controls_if">
+            <value name="IF0">
+                <shadow type="logic_compare">
+                    <field name="OP">EQ</field>
+                    <value name="A">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                    <value name="B">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                </shadow>
+            </value>
+            <statement name="DO0">
+                <shadow type="statement_value_input">
+                    <value name="value">
+                        <shadow type="math_number">
+                            <field name="NUM">11</field>
+                        </shadow>
+                    </value>
+                </shadow>
+            </statement>
+        </block>
     </category>
     <category name="Numbers">
         <block type="test_number">

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -98,6 +98,7 @@ public class BlocklyController {
                 @Override
                 public void run() {
                     extractBlockAsRoot(activeTouchedView.getBlock());
+
                     // Since this block was already on the workspace, the block's position should
                     // have been assigned correctly during the most recent layout pass.
                     BlockGroup bg = mHelper.getRootBlockGroup(activeTouchedView);
@@ -439,33 +440,34 @@ public class BlocklyController {
                 : mHelper.getRootBlockGroup(block);
 
         // Child block
-        if (block.getPreviousConnection() != null
-                && block.getPreviousConnection().isConnected()) {
-            Input in = block.getPreviousConnection().getTargetConnection().getInput();
+        if (block.getParentConnection() != null) {
+            Connection parentConnection = block.getParentConnection();
+            Input in = parentConnection.getInput();
             if (in == null) {
                 if (bg != null) {
                     // Next block
                     bg = bg.extractBlocksAsNewGroup(block);
                 }
             } else {
-                // Statement input
+                // Statement or value input
                 // Disconnect view.
                 InputView inView = in.getView();
                 if (inView != null) {
                     inView.setConnectedBlockGroup(null);
                 }
             }
-            block.getPreviousConnection().disconnect();
-        } else if (block.getOutputConnection() != null
-                && block.getOutputConnection().isConnected()) {
-            // Value input
-            Input in = block.getOutputConnection().getTargetConnection().getInput();
-            block.getOutputConnection().disconnect();
+            parentConnection.disconnect();
 
-            // Disconnect view.
-            InputView inView = in.getView();
-            if (inView != null) {
-                inView.setConnectedBlockGroup(null);
+            // Check if the block's old parent had a shadow that we should create views for.
+            // If this is itself a shadow block the answer is 'no'.
+            if (!block.isShadow() && parentConnection != null
+                    && parentConnection.getShadowBlock() != null) {
+                Block shadowBlock = parentConnection.getShadowBlock();
+                // We add the shadow as a root and then connect it so we properly add all the
+                // connectors and views.
+                addRootBlock(shadowBlock, null, true);
+                connect(shadowBlock, parentConnection.getShadowConnection(),
+                        parentConnection);
             }
         }
 
@@ -555,6 +557,8 @@ public class BlocklyController {
      * connected previous or output; usually a root block. If another block is in the way
      * of making the connection (occupies the required workspace location), that block will be
      * bumped out of the way.
+     * <p>
+     * Note: The blocks involved are assumed to be in the workspace.
      *
      * @param block The {@link Block} that is the root of the group of blocks being connected.
      * @param blockConnection The {@link Connection} of the block being moved to connect.
@@ -814,20 +818,27 @@ public class BlocklyController {
         // If there was already a block connected there.
         if (parentStatementConnection.isConnected()) {
             Block remainderBlock = parentStatementConnection.getTargetBlock();
-            parentStatementConnection.disconnect();
-            InputView parentInputView = parentStatementConnection.getInputView();
-            if (parentInputView != null) {
-                parentInputView.setConnectedBlockGroup(null);
-            }
-
-            // Try to reconnect the remainder to the end of the new sequence.
-            Block lastBlock = toConnect.getLastBlockInSequence();
-            if (lastBlock.getNextConnection() != null) {
-                connectAfter(lastBlock, remainderBlock);
+            if (remainderBlock.isShadow()) {
+                removeBlockTree(remainderBlock);
             } else {
-                // Nothing to connect to.  Bump and add to root.
-                addRootBlock(remainderBlock, mHelper.getParentBlockGroup(remainderBlock), false);
-                bumpBlock(parentStatementConnection, remainderBlock.getPreviousConnection());
+                parentStatementConnection.disconnect();
+                InputView parentInputView = parentStatementConnection.getInputView();
+                if (parentInputView != null) {
+                    parentInputView.setConnectedBlockGroup(null);
+                }
+
+                // Try to reconnect the remainder to the end of the new sequence.
+                Block lastBlock = toConnect.getLastBlockInSequence();
+                // lastBlock may not have a next or it may have a shadow block connected. In either
+                // case bump instead of connecting.
+                if (lastBlock.getNextConnection() != null && lastBlock.getNextBlock() == null) {
+                    connectAfter(lastBlock, remainderBlock);
+                } else {
+                    // Nothing to connect to.  Bump and add to root.
+                    addRootBlock(remainderBlock, mHelper.getParentBlockGroup(remainderBlock),
+                            false);
+                    bumpBlock(parentStatementConnection, remainderBlock.getPreviousConnection());
+                }
             }
         }
         connectAsInput(parentStatementConnection, toConnect.getPreviousConnection());
@@ -852,18 +863,25 @@ public class BlocklyController {
         // To splice between two blocks, just need another call to connectAfter.
         if (superior.getNextConnection().isConnected()) {
             Block remainderBlock = superior.getNextBlock();
-            BlockGroup remainderGroup = (superiorBlockGroup == null) ? null :
-                    superiorBlockGroup.extractBlocksAsNewGroup(remainderBlock);
-            superior.getNextConnection().disconnect();
-
-            // Try to reconnect the remainder to the end of the new sequence.
-            Block lastBlock = inferior.getLastBlockInSequence();
-            if (lastBlock.getNextConnection() != null) {
-                connectAfter(lastBlock, inferiorBlockGroup, remainderBlock, remainderGroup);
+            if (remainderBlock.isShadow()) {
+                // If there was a shadow connected just remove it
+                removeBlockTree(remainderBlock);
             } else {
-                // Nothing to connect to.  Bump and add to root.
-                addRootBlock(remainderBlock, remainderGroup, false);
-                bumpBlock(inferior.getPreviousConnection(), remainderBlock.getPreviousConnection());
+                BlockGroup remainderGroup = (superiorBlockGroup == null) ? null :
+                        superiorBlockGroup.extractBlocksAsNewGroup(remainderBlock);
+                superior.getNextConnection().disconnect();
+
+                // Try to reconnect the remainder to the end of the new sequence. If the last block
+                // has no next or has a shadow block connected bump instead.
+                Block lastBlock = inferior.getLastBlockInSequence();
+                if (lastBlock.getNextConnection() != null && lastBlock.getNextBlock() == null) {
+                    connectAfter(lastBlock, inferiorBlockGroup, remainderBlock, remainderGroup);
+                } else {
+                    // Nothing to connect to.  Bump and add to root.
+                    addRootBlock(remainderBlock, remainderGroup, false);
+                    bumpBlock(inferior.getPreviousConnection(),
+                            remainderBlock.getPreviousConnection());
+                }
             }
         }
 
@@ -910,23 +928,31 @@ public class BlocklyController {
         Connection previousTargetConnection = null;
         if (parentConn.isConnected()) {
             previousTargetConnection = parentConn.getTargetConnection();
-            parentConn.disconnect();
-            if (parentInputView != null) {
-                parentInputView.setConnectedBlockGroup(null);
+            // If there was a shadow block here delete it from the hierarchy and forget about it.
+            if (previousTargetConnection.getBlock().isShadow()) {
+                removeBlockTree(previousTargetConnection.getBlock());
+                previousTargetConnection = null;
+            } else {
+                // Otherwise just disconnect for now
+                parentConn.disconnect();
+                if (parentInputView != null) {
+                    parentInputView.setConnectedBlockGroup(null);
+                }
             }
         }
         parentConn.connect(childConn);
         if (previousTargetConnection != null) {
             Block previousTargetBlock = previousTargetConnection.getBlock();
 
-            // Traverse the tree to ensure it doesn't branch. We only reconnect if there's a single
-            // place it could be rebased to.
+            // Traverse the tree to ensure it doesn't branch. We only reconnect if there's a
+            // single place it could be rebased to and there's no shadow there.
             Connection lastInputConnection = child.getLastUnconnectedInputConnection();
-            if (lastInputConnection != null) {
+            if (lastInputConnection != null && !lastInputConnection.isConnected()) {
                 connectAsInput(lastInputConnection, previousTargetConnection);
             } else {
                 // Bump and add back to root.
-                BlockGroup previousTargetGroup = mHelper.getParentBlockGroup(previousTargetBlock);
+                BlockGroup previousTargetGroup =
+                        mHelper.getParentBlockGroup(previousTargetBlock);
                 addRootBlock(previousTargetBlock, previousTargetGroup, false);
                 bumpBlock(parentConn, previousTargetConnection);
             }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractInputView.java
@@ -43,8 +43,6 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
 
     // The view of the blocks connected to this input.
     protected BlockGroup mConnectedGroup = null;
-    // The view of the shadow blocks connected to this input.
-    protected BlockGroup mConnectedShadowGroup = null;
 
     /**
      * Constructs a base implementation of an {@link InputView}.
@@ -110,9 +108,6 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
             if (mConnectedGroup != null) {
                 removeView(mConnectedGroup);
                 mConnectedGroup = null;
-                if (mConnectedShadowGroup != null) {
-                    mConnectedShadowGroup.setVisibility(View.VISIBLE);
-                }
                 requestLayout();
             }
             return;
@@ -122,66 +117,9 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
         }
 
         mConnectedGroup = blockGroup;
-        if (mConnectedShadowGroup != null) {
-            mConnectedShadowGroup.setVisibility(View.GONE);
-        }
 
         addView(blockGroup);
         requestLayout();
-    }
-
-    /**
-     * @return The {@link BlockGroup} containing the shadow blocks connected to this input port,
-     * if any.
-     */
-    @Override
-    @Nullable
-    public BlockGroup getConnectedShadowGroup() {
-        return mConnectedShadowGroup;
-    }
-
-    /**
-     * Sets the view of the shadow blocks whose output/previous connector is connected to this
-     * input. Setting it to null will remove the connected group instead.
-     *
-     * @param blockGroup The {@link BlockGroup} to attach to this input. The {@code childView} will
-     *                  be added to the layout hierarchy for the current view via a call to
-     *                  {@link ViewGroup#addView(View)}.
-     *
-     * @throws IllegalStateException if a child view is already set. The Blockly model requires
-     *         disconnecting a block from an input before a new one can be connected.
-     * @throws IllegalArgumentException if the method argument is {@code null}.
-     */
-    public void setConnectedShadowGroup(BlockGroup blockGroup) {
-        if (blockGroup == null) {
-            if (mConnectedShadowGroup != null) {
-                removeView(mConnectedShadowGroup);
-                mConnectedShadowGroup = null;
-                requestLayout();
-            }
-            return;
-        }
-        if (mConnectedShadowGroup != null) {
-            throw new IllegalStateException("Input is already connected; must disconnect first.");
-        }
-
-        mConnectedShadowGroup = blockGroup;
-        if (mConnectedGroup != null) {
-            mConnectedShadowGroup.setVisibility(View.GONE);
-        }
-
-        addView(blockGroup);
-        requestLayout();
-    }
-
-    /**
-     * @return The {@link BlockGroup} connected to this input connection, or the shadow block group
-     *         if no normal {@code BlockGroup} is connected.
-     */
-    @Override
-    @Nullable
-    public BlockGroup getConnectedBlockGroupOrShadowGroup() {
-        return mConnectedGroup == null ? mConnectedShadowGroup : mConnectedGroup;
     }
 
     /**
@@ -197,10 +135,6 @@ public abstract class AbstractInputView extends NonPropagatingViewGroup implemen
         if (mConnectedGroup != null) {
             mConnectedGroup.unlinkModel();
             mConnectedGroup = null;
-        }
-        if (mConnectedShadowGroup != null) {
-            mConnectedShadowGroup.unlinkModel();
-            mConnectedShadowGroup = null;
         }
         removeAllViews();
         mInput.setView(null);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -16,13 +16,9 @@
 package com.google.blockly.android.ui;
 
 import android.content.Context;
-import android.database.DataSetObserver;
-import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
 import android.view.View;
-import android.widget.ArrayAdapter;
 import android.widget.SpinnerAdapter;
-import android.widget.TextView;
 
 import com.google.blockly.android.ToolboxFragment;
 import com.google.blockly.android.TrashFragment;
@@ -158,13 +154,6 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
                     BlockGroup subgroup = buildBlockGroupTree(
                             targetBlock, connectionManager, touchHandler);
                     inputView.setConnectedBlockGroup(subgroup);
-                }
-                targetBlock = input.getConnection().getTargetShadowBlock();
-                if (targetBlock != null) {
-                    // Blocks connected to inputs live in their own BlockGroups.
-                    BlockGroup subgroup = buildBlockGroupTree(
-                            targetBlock, connectionManager, touchHandler);
-                    inputView.setConnectedShadowGroup(subgroup);
                 }
             }
             inputViews.add(inputView);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/InputView.java
@@ -42,32 +42,10 @@ public interface InputView {
     void setConnectedBlockGroup(@Nullable BlockGroup group);
 
     /**
-     * Sets the {@link BlockGroup} containing the shadow block connected to this input and updates
-     * the view hierarchy. This generally only needs to be done when the view hierarchy is first
-     * created. Calling this with null will disconnect the current group.
-     *
-     * @param group The {@link BlockGroup} to add to this input view.
-     */
-    void setConnectedShadowGroup(@Nullable BlockGroup group);
-
-    /**
      * @return The {@link BlockGroup} connected to this input connection.
      */
     @Nullable
     BlockGroup getConnectedBlockGroup();
-
-    /**
-     * @return The {@link BlockGroup} shadow block connected to this input connection.
-     */
-    @Nullable
-    BlockGroup getConnectedShadowGroup();
-
-    /**
-     * @return The {@link BlockGroup} connected to this input connection, or the shadow block group
-     *         if no normal {@code BlockGroup} is connected.
-     */
-    @Nullable
-    BlockGroup getConnectedBlockGroupOrShadowGroup();
 
     /**
      * Recursively disconnects the view from the model, including all subviews/model subcomponents.

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
@@ -15,7 +15,6 @@
 
 package com.google.blockly.model;
 
-import android.graphics.Point;
 import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -61,6 +60,7 @@ public class Connection implements Cloneable {
     public static final int REASON_MUST_DISCONNECT = 3;
     public static final int REASON_TARGET_NULL = 4;
     public static final int REASON_CHECKS_FAILED = 5;
+
     // If updating this, also update ConnectionManager's matchingLists and oppositeLists arrays.
     @ConnectionType
     private static final int[] OPPOSITE_TYPES = new int[]{
@@ -81,6 +81,9 @@ public class Connection implements Cloneable {
     private Block mBlock;
     private Input mInput;
     private Connection mTargetConnection;
+    // The shadow connection is only valid for next/input connections. It is not a live connection,
+    // just a reference to the default shadow (if there is one) that should be connected when there
+    // isn't another connection.
     private Connection mTargetShadowConnection;
     private boolean mInDragMode = false;
 
@@ -107,6 +110,26 @@ public class Connection implements Cloneable {
      */
     public boolean canConnect(Connection target) {
         return canConnectWithReason(target) == CAN_CONNECT;
+    }
+
+    /**
+     * Sets the connection (and shadow block) to use when a normal block isn't connected. This may
+     * only be called on connections that belong to an input (value or statement).
+     *
+     * @param target The connection on the shadow block to use.
+     */
+    public void setShadowConnection(Connection target) {
+        if (target == null) {
+            mTargetShadowConnection = null;
+            return;
+        }
+        if (canConnectWithReason(target, true) != CAN_CONNECT) {
+            throw new IllegalArgumentException("The shadow connection can't be connected.");
+        }
+        if (!target.getBlock().isShadow()) {
+            throw new IllegalArgumentException("The connection does not belong to a shadow block");
+        }
+        mTargetShadowConnection = target;
     }
 
     /**
@@ -153,10 +176,19 @@ public class Connection implements Cloneable {
     }
 
     /**
-     * @return The shadow {@link Block} this is connected to or null if it has no shadow block.
+     * @return The shadow {@link Block} that is used when no other block is connected or null if it
+     * has no shadow block.
      */
-    public Block getTargetShadowBlock() {
+    public Block getShadowBlock() {
         return mTargetShadowConnection == null ? null : mTargetShadowConnection.getBlock();
+    }
+
+    /**
+     * @return The shadow block {@link Connection} that is used when no other block is connected or
+     * null if it has no shadow block.
+     */
+    public Connection getShadowConnection() {
+        return mTargetShadowConnection;
     }
 
     /**
@@ -263,13 +295,6 @@ public class Connection implements Cloneable {
     }
 
     /**
-     * @return True if the connection has a shadow block connection, false otherwise.
-     */
-    public boolean isShadowConnected() {
-        return mTargetShadowConnection != null;
-    }
-
-    /**
      * @return Whether the connection has high priority in the context of bumping connections away.
      */
     public boolean isHighPriority() {
@@ -283,6 +308,17 @@ public class Connection implements Cloneable {
      */
     @CheckResultType
     public int canConnectWithReason(Connection target) {
+        return canConnectWithReason(target, false);
+    }
+
+    /**
+     * @param target The {@link Connection} to check compatibility with.
+     * @param ignoreDisconnect True to skip checking if the connection is already connected.
+     *
+     * @return {@code CAN_CONNECT} if the connection is legal, an error code otherwise.
+     */
+    @CheckResultType
+    private int canConnectWithReason(Connection target, boolean ignoreDisconnect) {
         if (target == null || target.getBlock() == null) {
             return REASON_TARGET_NULL;
         }
@@ -292,11 +328,7 @@ public class Connection implements Cloneable {
         if (target.getType() != OPPOSITE_TYPES[mConnectionType]) {
             return REASON_WRONG_TYPE;
         }
-        if (target.getBlock().isShadow()) {
-            if (mTargetShadowConnection != null) {
-                return REASON_MUST_DISCONNECT;
-            }
-        } else if (mTargetConnection != null) {
+        if (!ignoreDisconnect && mTargetConnection != null) {
             return REASON_MUST_DISCONNECT;
         }
         if (!checksMatch(target)) {
@@ -322,11 +354,7 @@ public class Connection implements Cloneable {
     }
 
     private void connectInternal(Connection target) {
-        if (target.getBlock().isShadow()) {
-            mTargetShadowConnection = target;
-        } else {
-            mTargetConnection = target;
-        }
+        mTargetConnection = target;
     }
 
     private void disconnectInternal() {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
@@ -188,19 +188,21 @@ public abstract class Input implements Cloneable {
      */
     public void serialize(XmlSerializer serializer, @Nullable String tag) throws IOException {
         if (tag != null && getConnection() != null && (getConnection().isConnected()
-                || getConnection().getTargetShadowBlock() != null)) {
+                || getConnection().getShadowBlock() != null)) {
             serializer.startTag(null, tag)
                     .attribute(null, "name", getName());
 
             // Serialize the connection's shadow if it has one
-            Block block = getConnection().getTargetShadowBlock();
+            Block block = getConnection().getShadowBlock();
             if (block != null) {
                 block.serialize(serializer, false);
             }
             // Then serialize its non-shadow target if it has one
-            block = getConnection().getTargetBlock();
-            if (block != null) {
-                block.serialize(serializer, false);
+            if (block != getConnection().getTargetBlock()) {
+                block = getConnection().getTargetBlock();
+                if (block != null) {
+                    block.serialize(serializer, false);
+                }
             }
 
             serializer.endTag(null, tag);

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
@@ -266,8 +266,7 @@ public class InputView extends AbstractInputView {
     private void measureConnectedBlockGroup(int widthMeasureSpec, int heightMeasureSpec) {
         final boolean inputsInline = mInput.getBlock().getInputsInline();
 
-        BlockGroup groupToMeasure = mConnectedGroup != null ? mConnectedGroup
-                : mConnectedShadowGroup;
+        BlockGroup groupToMeasure = mConnectedGroup;
         if (groupToMeasure != null) {
             // There is a block group connected to this input - measure it and add its size
             // to this InputView's size.
@@ -331,8 +330,7 @@ public class InputView extends AbstractInputView {
      * If there is a child connected to this Input, then layout the child in the correct place.
      */
     private void layoutChild() {
-        BlockGroup groupToLayout = mConnectedGroup != null ? mConnectedGroup
-                : mConnectedShadowGroup;
+        BlockGroup groupToLayout = mConnectedGroup;
         if (groupToLayout != null) {
             // Compute offset of child relative to InputView. By default, align top of fields and
             // input, and shift right by left padding plus field width.

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -82,14 +82,15 @@ public class BlockTest extends AndroidTestCase {
         Block originalShadow = mBlockFactory.obtainBlock("simple_input_output", "3");
         originalShadow.setShadow(true);
         original.getOnlyValueInput().getConnection().connect(original2.getOutputConnection());
-        original.getOnlyValueInput().getConnection().connect(originalShadow.getOutputConnection());
+        original.getOnlyValueInput().getConnection()
+                .setShadowConnection(originalShadow.getOutputConnection());
 
         Block copy = original.deepCopy();
         assertNotSame(original, copy);
         assertNotSame(original.getOnlyValueInput().getConnection().getTargetBlock(),
                 copy.getOnlyValueInput().getConnection().getTargetBlock());
-        assertNotSame(original.getOnlyValueInput().getConnection().getTargetShadowBlock(),
-                copy.getOnlyValueInput().getConnection().getTargetShadowBlock());
+        assertNotSame(original.getOnlyValueInput().getConnection().getShadowBlock(),
+                copy.getOnlyValueInput().getConnection().getShadowBlock());
     }
 
     public void testMessageTokenizer() {
@@ -223,22 +224,22 @@ public class BlockTest extends AndroidTestCase {
         loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "1",
                 BlockTestStrings.VALUE_SHADOW), bf);
         Connection conn = loaded.getInputByName("value_input").getConnection();
-        assertNull(conn.getTargetBlock());
-        assertTrue(conn.getTargetShadowBlock().isShadow());
+        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
+        assertTrue(conn.getShadowBlock().isShadow());
 
         loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "2",
                 BlockTestStrings.VALUE_SHADOW_GOOD), bf);
         conn = loaded.getInputByName("value_input").getConnection();
         assertEquals("VALUE_REAL", conn.getTargetBlock().getId());
         assertFalse(conn.getTargetBlock().isShadow());
-        assertEquals("VALUE_SHADOW", conn.getTargetShadowBlock().getId());
-        assertTrue(conn.getTargetShadowBlock().isShadow());
+        assertEquals("VALUE_SHADOW", conn.getShadowBlock().getId());
+        assertTrue(conn.getShadowBlock().isShadow());
 
         loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "3",
                 BlockTestStrings.STATEMENT_SHADOW), bf);
         conn = loaded.getInputByName("NAME").getConnection();
-        assertNull(conn.getTargetBlock());
-        assertTrue(conn.getTargetShadowBlock().isShadow());
+        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
+        assertTrue(conn.getShadowBlock().isShadow());
 
         // Clear refs so block names can be reused
         bf.clearPriorBlockReferences();
@@ -247,30 +248,29 @@ public class BlockTest extends AndroidTestCase {
         conn = loaded.getInputByName("NAME").getConnection();
         assertEquals("STATEMENT_REAL", conn.getTargetBlock().getId());
         assertFalse(conn.getTargetBlock().isShadow());
-        assertEquals("STATEMENT_SHADOW", conn.getTargetShadowBlock().getId());
-        assertTrue(conn.getTargetShadowBlock().isShadow());
+        assertEquals("STATEMENT_SHADOW", conn.getShadowBlock().getId());
+        assertTrue(conn.getShadowBlock().isShadow());
 
         loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "5",
                 BlockTestStrings.VALUE_NESTED_SHADOW), bf);
         conn = loaded.getInputByName("value_input").getConnection();
-        assertNull(conn.getTargetBlock());
-        Block shadow1 = conn.getTargetShadowBlock();
+        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
+        Block shadow1 = conn.getShadowBlock();
         assertEquals("SHADOW1", shadow1.getId());
         conn = shadow1.getOnlyValueInput().getConnection();
-        assertNull(conn.getTargetBlock());
-        assertEquals("SHADOW2", conn.getTargetShadowBlock().getId());
+        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
+        assertEquals("SHADOW2", conn.getShadowBlock().getId());
 
         // Clear refs so block names can be reused
         bf.clearPriorBlockReferences();
         loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "6",
                 BlockTestStrings.VALUE_NESTED_SHADOW_BLOCK), bf);
         conn = loaded.getInputByName("value_input").getConnection();
-        assertNull(conn.getTargetBlock());
-        shadow1 = conn.getTargetShadowBlock();
+        shadow1 = conn.getShadowBlock();
         assertEquals("SHADOW1", shadow1.getId());
         conn = shadow1.getOnlyValueInput().getConnection();
         assertEquals("BLOCK_INNER", conn.getTargetBlock().getId());
-        assertEquals("SHADOW2", conn.getTargetShadowBlock().getId());
+        assertEquals("SHADOW2", conn.getShadowBlock().getId());
     }
 
     public void testSerializeBlock() throws BlocklySerializerException, IOException {
@@ -372,7 +372,7 @@ public class BlockTest extends AndroidTestCase {
         input.getConnection().connect(inputBlock.getOutputConnection());
         inputBlock = bf.obtainBlock("output_foo", "VALUE_SHADOW");
         inputBlock.setShadow(true);
-        input.getConnection().connect(inputBlock.getOutputConnection());
+        input.getConnection().setShadowConnection(inputBlock.getOutputConnection());
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         XmlSerializer serializer = getXmlSerializer(os);

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/ConnectionTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/ConnectionTest.java
@@ -120,18 +120,14 @@ public class ConnectionTest extends AndroidTestCase {
         // Verify a shadow can connect
         assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(shadowOutput));
         input.connect(output);
-        // Verify it can still connect after a non-shadow has been connected
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(shadowOutput));
+        // Verify a shadow and non shadow can't be connected at the same time
+        assertEquals(Connection.REASON_MUST_DISCONNECT, input.canConnectWithReason(shadowOutput));
+        input.disconnect();
         input.connect(shadowOutput);
 
-        shadowOutput = new Connection(Connection.CONNECTION_TYPE_OUTPUT, null);
-        shadowOutput.setBlock(blockBuilder.build());
-        // And can't connect once another shadow is connected
-        assertEquals(Connection.REASON_MUST_DISCONNECT, input.canConnectWithReason(shadowOutput));
-
-        // Veryify a normal connection can be made after a shadow connection
+        // Veryify a normal connection can't be made after a shadow connection
         next.connect(shadowPrevious);
-        assertEquals(Connection.CAN_CONNECT, next.canConnectWithReason(previous));
+        assertEquals(Connection.REASON_MUST_DISCONNECT, next.canConnectWithReason(previous));
     }
 
     public void testCheckConnection_failure() {


### PR DESCRIPTION
This covers most of bug #199 by allowing complex shadow blocks to be added.
However, only connecting shadow blocks to inputs (value and statement) is
supported in this CL. We should review further if we want to support shadows
in a stack of statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/301)
<!-- Reviewable:end -->
