### PR TITLE
Fix to crash caused by shadow splice logic

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -231,7 +231,11 @@ public class Dragger {
         }
         mTempConnections.clear();
         rootBlock.getAllConnectionsRecursive(mTempConnections);
-        mDraggedConnections.removeAll(mTempConnections);
+        for (int i = 0; i < mTempConnections.size(); i++) {
+            Connection conn = mTempConnections.get(i);
+            mDraggedConnections.remove(conn);
+            conn.setDragMode(false);
+        }
     }
 
     /**


### PR DESCRIPTION
There was a crash state that could be caused by splicing a block with a
shadow, then recreating the shadow, then triggering a re-layout of the block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/314)
<!-- Reviewable:end -->
