### PR TITLE
Fix a crash when dragging blocks to the trash

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -222,10 +222,6 @@ public class Dragger {
      * @param rootBlock The start of the block tree to remove connections for.
      */
     public void removeFromDraggingConnections(Block rootBlock) {
-        if (!rootBlock.isShadow()) {
-            throw new IllegalArgumentException(
-                    "Deleting a non-shadow during a drag shouldn't happen.");
-        }
         if (mPendingDrag == null) {
             return;
         }


### PR DESCRIPTION
Turns out there's a really common case for deleting non-shadows during a drag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/315)
<!-- Reviewable:end -->
