### PR TITLE
Clear trash when loading a workspace

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -740,11 +740,17 @@ public class BlocklyController {
         for (int i = 0; i < rootBlocks.size(); ++i) {
             unlinkViews(rootBlocks.get(i));
         }
-
+        List<Block> trashBlocks = mWorkspace.getTrashContents();
+        for (int i = 0; i < trashBlocks.size(); i++) {
+            unlinkViews(trashBlocks.get(i));
+        }
         mWorkspace.resetWorkspace();
         if (mWorkspaceView != null) {
             mWorkspaceView.removeAllViews();
             initBlockViews();
+        }
+        if (mTrashFragment != null) {
+            mTrashFragment.setContents(mWorkspace.getTrashContents());
         }
     }
 


### PR DESCRIPTION
This prevents the crash in #298. We should still discuss what the desired
behavior for the trash is when loading a workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/316)
<!-- Reviewable:end -->
