### PR TITLE
Fix bug #230 by disabling field automatic restore

### DIFF
--- a/blocklylib-vertical/src/main/res/layout/default_field_angle.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_angle.xml
@@ -17,6 +17,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/field_angle"
         style="@style/TextAppearance.AppCompat.Large"
+        android:saveEnabled="false"
         android:textSize="?blockTextSize"
         android:background="@drawable/edit_text_background_disabled"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_checkbox.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_checkbox.xml
@@ -15,6 +15,7 @@
   -->
 <com.google.blockly.android.ui.fieldview.BasicFieldCheckboxView
         xmlns:android="http://schemas.android.com/apk/res/android"
+        android:saveEnabled="false"
         android:id="@+id/field_checkbox"
         android:button="@drawable/checkbox_button"
         android:gravity="center"

--- a/blocklylib-vertical/src/main/res/layout/default_field_color.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_color.xml
@@ -15,6 +15,7 @@
   -->
 <com.google.blockly.android.ui.vertical.FieldColorView
         xmlns:android="http://schemas.android.com/apk/res/android"
+        android:saveEnabled="false"
         android:id="@+id/field_color"
         android:foreground="@drawable/inset_field_border"
         android:padding="4dip"

--- a/blocklylib-vertical/src/main/res/layout/default_field_date.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_date.xml
@@ -17,6 +17,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/field_date"
         style="@style/TextAppearance.AppCompat.Large"
+        android:saveEnabled="false"
         android:textSize="?blockTextSize"
         android:background="@drawable/edit_text_background_disabled"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_dropdown.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_dropdown.xml
@@ -17,6 +17,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/field_dropdown"
+    android:saveEnabled="false"
     app:itemLayout="@layout/default_spinner_closed_item"
     app:dropdownItemLayout="@layout/default_spinner_dropdown_item"
     android:background="@drawable/dropdown_background"

--- a/blocklylib-vertical/src/main/res/layout/default_field_input.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_input.xml
@@ -17,6 +17,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/field_input"
     style="@style/TextAppearance.AppCompat.Large"
+    android:saveEnabled="false"
     android:textSize="?blockTextSize"
     android:textColor="@color/field_text"
     android:background="@drawable/edit_text_background"

--- a/blocklylib-vertical/src/main/res/layout/default_field_label.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_label.xml
@@ -17,6 +17,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/field_label"
         style="@style/TextAppearance.AppCompat.Large"
+        android:saveEnabled="false"
         android:textColor="@color/label_text"
         android:textSize="?blockTextSize"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_number.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_number.xml
@@ -17,6 +17,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/field_number"
         style="@style/TextAppearance.AppCompat.Large"
+        android:saveEnabled="false"
         android:textSize="?blockTextSize"
         android:background="@drawable/edit_text_background"
         android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_field_variable.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_field_variable.xml
@@ -17,6 +17,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/field_dropdown"
+    android:saveEnabled="false"
     app:itemLayout="@layout/default_spinner_closed_item"
     app:dropdownItemLayout="@layout/default_spinner_dropdown_item"
     android:background="@drawable/dropdown_background"

--- a/blocklylib-vertical/src/main/res/layout/default_spinner_closed_item.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_spinner_closed_item.xml
@@ -15,6 +15,7 @@
   -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/default_item"
+    android:saveEnabled="false"
     android:textColor="@color/field_text"
     android:textSize="?blockTextSize"
     android:singleLine="true"

--- a/blocklylib-vertical/src/main/res/layout/default_spinner_dropdown_item.xml
+++ b/blocklylib-vertical/src/main/res/layout/default_spinner_dropdown_item.xml
@@ -15,6 +15,7 @@
   -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/default_dropdown"
+    android:saveEnabled="false"
     android:textSize="?blockTextSize"
     android:textColor="@color/field_text"
     android:singleLine="true"


### PR DESCRIPTION
The controller handles recreating the workspace during a restore, but the fields
were also trying to restore and keyed off of the layout id, which is not unique.
This disables the framework restore for these fields so Blockly handles it
correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/321)
<!-- Reviewable:end -->
