### PR TITLE
Fix lint errors

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/NonPropagatingViewGroup.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/NonPropagatingViewGroup.java
@@ -36,11 +36,6 @@ public abstract class NonPropagatingViewGroup extends ViewGroup {
         super(context, attrs, defStyleAttr);
     }
 
-    public NonPropagatingViewGroup(Context context, AttributeSet attrs, int defStyleAttr,
-            int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
-    }
-
     @Override
     public void dispatchSetActivated(boolean activated) {
         // Do nothing.  Do not assign the activated state to children.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/ViewPoint.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/ViewPoint.java
@@ -16,6 +16,8 @@
 package com.google.blockly.android.ui;
 
 import android.graphics.Point;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * A point in view coordinates.
@@ -53,4 +55,22 @@ public class ViewPoint extends Point {
         x = other.x;
         y = other.y;
     }
+
+    public static final Parcelable.Creator<ViewPoint> CREATOR = new Parcelable.Creator<ViewPoint>() {
+        /**
+         * Return a new point from the data in the specified parcel.
+         */
+        public ViewPoint createFromParcel(Parcel in) {
+            ViewPoint r = new ViewPoint();
+            r.readFromParcel(in);
+            return r;
+        }
+
+        /**
+         * Return an array of rectangles of the specified size.
+         */
+        public ViewPoint[] newArray(int size) {
+            return new ViewPoint[size];
+        }
+    };
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/WorkspacePoint.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/WorkspacePoint.java
@@ -16,6 +16,8 @@
 package com.google.blockly.model;
 
 import android.graphics.Point;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * A point in workspace coordinates.
@@ -53,4 +55,22 @@ public class WorkspacePoint extends Point {
         x = other.x;
         y = other.y;
     }
+
+    public static final Parcelable.Creator<WorkspacePoint> CREATOR = new Parcelable.Creator<WorkspacePoint>() {
+        /**
+         * Return a new point from the data in the specified parcel.
+         */
+        public WorkspacePoint createFromParcel(Parcel in) {
+            WorkspacePoint r = new WorkspacePoint();
+            r.readFromParcel(in);
+            return r;
+        }
+
+        /**
+         * Return an array of rectangles of the specified size.
+         */
+        public WorkspacePoint[] newArray(int size) {
+            return new WorkspacePoint[size];
+        }
+    };
 }


### PR DESCRIPTION
We had one reference to an API 21 call and two parcelable objects missing
CREATOR fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/324)
<!-- Reviewable:end -->
