### PR TITLE
Fix #117 enable Android's panning when the ime opens

### DIFF
--- a/blocklydemo/src/main/AndroidManifest.xml
+++ b/blocklydemo/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
             android:name=".DevTestsActivity"
             android:label="@string/dev_activity_name"
             android:taskAffinity="com.google.blockly.demo.MainActivity"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -50,7 +50,7 @@
             android:name=".WebComparisonActivity"
             android:label="@string/comparison_activity_name"
             android:taskAffinity="com.google.blockly.demo.WebActivity"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -61,7 +61,7 @@
             android:name=".SplitActivity"
             android:label="@string/split_activity_name"
             android:taskAffinity="com.google.blockly.demo.SplitActivity"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -72,7 +72,7 @@
             android:name=".TurtleActivity"
             android:label="@string/turtle_activity_name"
             android:taskAffinity="com.google.blockly.demo.TurtleActivity"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -84,7 +84,7 @@
             android:label="@string/style_activity_name"
             android:taskAffinity="com.google.blockly.demo.StylesActivity"
             android:theme="@style/StylesDemoTheme"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
This enables the default panning behavior in Android when the ime is
opened over the text being edited. It's a bit jarring if the text is
near the bottom of the screen so we should look at refining it, but
this is still an improvement over covering the text.