### PR TITLE
Fix #64 Account for zoom when checking if a drop was on the trash

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -550,10 +550,12 @@ public class Dragger {
         mTrashView.getHitRect(mTrashRect);
 
         mTrashRect.offset((mTempScreenCoord1[0] - mTrashRect.left), (mTempScreenCoord1[1] - mTrashRect.top));
-        // offset drag event positions by the workspace view's position on screen.
-        mWorkspaceView.getLocationOnScreen(mTempScreenCoord1);
-        return mTrashRect.contains((int) event.getX() + mTempScreenCoord1[0],
-                (int) event.getY() + mTempScreenCoord1[1]);
+        // Get the touch location on the screen
+        mTempViewPoint.set((int) event.getX(), (int) event.getY());
+        mHelper.virtualViewToScreenCoordinates(mTempViewPoint, mTempViewPoint);
+
+        // Check if the touch location was on the trash
+        return mTrashRect.contains(mTempViewPoint.x, mTempViewPoint.y);
     }
 
     /**


### PR DESCRIPTION
Switch to using the helper coordinate utility to get the touch location on
the screen when we check if a touch is over the trash or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/326)
<!-- Reviewable:end -->
