### PR TITLE
Make tap on workspace close trash/toolbox

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
@@ -459,12 +459,21 @@ public class ToolboxFragment extends BlockDrawerFragment {
 
         @Override
         protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
             // Measure the tabs before the the block list.
             measureChild(mCategoryTabs, widthMeasureSpec, heightMeasureSpec);
             updateScrollablePadding();
             measureChild(mBlockListView, widthMeasureSpec, heightMeasureSpec);
+
+            int listWidth = mBlockListView.getVisibility() == View.GONE ?
+                    0 : mBlockListView.getMeasuredWidth();
+            int listHeight = mBlockListView.getVisibility() == View.GONE ?
+                    0 : mBlockListView.getMeasuredHeight();
+            int width = Math.max(mCategoryTabs.getMeasuredWidth(), listWidth);
+            int height = Math.max(mCategoryTabs.getMeasuredHeight(), listHeight);
+            width = getSizeForSpec(widthMeasureSpec, width);
+            height = getSizeForSpec(heightMeasureSpec, height);
+
+            setMeasuredDimension(width, height);
         }
 
         @Override
@@ -493,6 +502,21 @@ public class ToolboxFragment extends BlockDrawerFragment {
                     break;
             }
         }
+    }
+
+    private int getSizeForSpec(int measureSpec, int desiredSize) {
+        int mode = View.MeasureSpec.getMode(measureSpec);
+        int size = View.MeasureSpec.getSize(measureSpec);
+
+        switch (mode) {
+            case View.MeasureSpec.AT_MOST:
+                return Math.min(size, desiredSize);
+            case View.MeasureSpec.EXACTLY:
+                return size;
+            case View.MeasureSpec.UNSPECIFIED:
+                return desiredSize;
+        }
+        return desiredSize;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -80,6 +80,15 @@ public class BlocklyController {
     private View mTrashIcon = null;
     private ToolboxFragment mToolboxFragment = null;
     private Dragger mDragger;
+    private View.OnClickListener mDismissClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (mTrashFragment.isOpened() && mTrashFragment.isCloseable()) {
+                mTrashFragment.setOpened(false);
+            }
+            mToolboxFragment.closeBlocksDrawer();
+        }
+    };
 
     private final Dragger.DragHandler mWorkspaceDragHandler = new Dragger.DragHandler() {
         @Override
@@ -489,7 +498,14 @@ public class BlocklyController {
      * @param wv The root workspace view to add to.
      */
     public void initWorkspaceView(final WorkspaceView wv) {
+        if (mVirtualWorkspaceView != null) {
+            // Clear the old view's references so we don't get unwanted events.
+            mVirtualWorkspaceView.setOnClickListener(null);
+        }
         mVirtualWorkspaceView = (VirtualWorkspaceView) wv.getParent();
+        if (mVirtualWorkspaceView != null) {
+            mVirtualWorkspaceView.setOnClickListener(mDismissClickListener);
+        }
         mWorkspaceView = wv;
         mWorkspaceView.setController(this);
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListView.java
@@ -16,7 +16,6 @@
 package com.google.blockly.android.ui;
 
 import android.content.Context;
-import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/VirtualWorkspaceView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/VirtualWorkspaceView.java
@@ -21,6 +21,7 @@ import android.graphics.Rect;
 import android.support.v4.view.MotionEventCompat;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.inputmethod.InputMethodManager;
@@ -70,6 +71,7 @@ public class VirtualWorkspaceView extends NonPropagatingViewGroup {
     private boolean mResetViewPending = true;
 
     private ScaleGestureDetector mScaleGestureDetector;
+    private GestureDetector mTapGestureDetector;
     private InputMethodManager mImeManager;
 
     public VirtualWorkspaceView(Context context) {
@@ -99,6 +101,7 @@ public class VirtualWorkspaceView extends NonPropagatingViewGroup {
         setVerticalScrollBarEnabled(true);
 
         mScaleGestureDetector = new ScaleGestureDetector(getContext(), new ScaleGestureListener());
+        mTapGestureDetector = new GestureDetector(getContext(), new TapGestureListener());
         mGridRenderer.updateGridBitmap(mViewScale);
         mImeManager = (InputMethodManager) getContext()
                 .getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -167,6 +170,12 @@ public class VirtualWorkspaceView extends NonPropagatingViewGroup {
      */
     public float getViewScale() {
         return mViewScale;
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        mTapGestureDetector.onTouchEvent(event);
+        return super.dispatchTouchEvent(event);
     }
 
     @Override
@@ -483,6 +492,12 @@ public class VirtualWorkspaceView extends NonPropagatingViewGroup {
 
     private static int clampToRange(int y, int min, int max) {
         return Math.min(max, Math.max(min, y));
+    }
+
+    private class TapGestureListener extends GestureDetector.SimpleOnGestureListener {
+        public boolean onSingleTapUp(MotionEvent e) {
+            return callOnClick();
+        }
     }
 
     /** Listener class for scaling and panning the view using pinch-to-zoom gestures. */

--- a/blocklylib-core/src/main/res/layout/blockly_unified_workspace_contents.xml
+++ b/blocklylib-core/src/main/res/layout/blockly_unified_workspace_contents.xml
@@ -67,8 +67,6 @@
         android:id="@+id/blockly_toolbox"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toLeftOf="@id/blockly_overlay_buttons"
-        android:layout_toStartOf="@id/blockly_overlay_buttons"
         blockly:closeable="true"
         blockly:scrollOrientation="vertical"
         blockly:tabEdge="start"


### PR DESCRIPTION
First pass on #112. This makes it so a tap on the workspace will close the
toolbox and the trash if either is open. This also updates the toolbox's
measure to wrap the contents of the toolbox.

To do:
-Make opening one close the other.
-Make tapping on the background also close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/327)
<!-- Reviewable:end -->
