### PR TITLE
BlocklyEvents (first pass, create events only, foundations of #309)

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -17,6 +17,7 @@ package com.google.blockly.android.demo;
 
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ArrayAdapter;
 import android.widget.ListAdapter;
@@ -59,14 +60,28 @@ public class DevTestsActivity extends BlocklySectionsActivity {
 
     public static final String WORKSPACE_FOLDER_PREFIX = "sample_sections/level_";
 
+    protected MenuItem mLogEventsMenuItem;
+
     protected CodeGenerationRequest.CodeGeneratorCallback mCodeGeneratorCallback =
             new LoggingCodeGeneratorCallback(this, TAG);
+    protected LogAllEventsListener mEventsListener = new LogAllEventsListener("BlocklyEvents");
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        boolean isShown = super.onCreateOptionsMenu(menu);
+        if (isShown) {
+            mLogEventsMenuItem = menu.findItem(R.id.log_events_menuitem);
+        }
+        return isShown;
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         int id = item.getItemId();
 
-        if (id == R.id.action_airstrike) {
+        if (id == R.id.log_events_menuitem) {
+            setLogEvents(!mLogEventsMenuItem.isChecked());
+        } else if (id == R.id.action_airstrike) {
             airstrike();
             return true;
         } else if (id == R.id.action_carpet_bomb) {
@@ -88,6 +103,15 @@ public class DevTestsActivity extends BlocklySectionsActivity {
     @Override
     public void onSaveWorkspace() {
         saveWorkspaceToAppDir(SAVED_WORKSPACE_FILENAME);
+    }
+
+    private void setLogEvents(boolean logEvents) {
+        if (logEvents) {
+            mController.addListener(mEventsListener);
+        } else {
+            mController.removeListener(mEventsListener);
+        }
+        mLogEventsMenuItem.setChecked(logEvents);
     }
 
     /**

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/LogAllEventsListener.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/LogAllEventsListener.java
@@ -1,0 +1,70 @@
+package com.google.blockly.android.demo;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.control.BlocklyEvent;
+
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+/**
+ * Logs all {@link BlocklyEvent}s to the console.
+ */
+public class LogAllEventsListener implements BlocklyController.EventsCallback {
+    private static final String TAG = "LogAllEventsListener";
+
+    private final String mEventsTag;
+    private boolean mPrettyPrint = false;
+
+    public LogAllEventsListener(String tag) {
+        if (TextUtils.isEmpty(tag)) {
+            throw new IllegalArgumentException("Tag cannot be null");
+        }
+        mEventsTag = tag;
+    }
+
+    public LogAllEventsListener() {
+        this(TAG);
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        mPrettyPrint = prettyPrint;
+    }
+
+    /**
+     * @return {@link BlocklyEvent#TYPE_ALL} to listen for all events.
+     */
+    @Override
+    public int getTypesBitmask() {
+        return BlocklyEvent.TYPE_ALL;
+    }
+
+    @Override
+    public void onEventGroup(List<BlocklyEvent> events) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw, false);
+        for (BlocklyEvent event : events) {
+            try {
+                pw.print(event.toJsonString());
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to serialize event", e);
+            }
+        }
+        pw.flush();
+        Log.i(mEventsTag, sw.toString());
+
+        try {
+            pw.close();
+            sw.close();
+        } catch (IOException e) {
+            // Shouldn't get here. Don't care anyway.
+            Log.wtf(TAG, "Couldn't fire the writer. Broken pencils are pointless.");
+        }
+    }
+}

--- a/blocklydemo/src/main/res/menu/dev_actionbar.xml
+++ b/blocklydemo/src/main/res/menu/dev_actionbar.xml
@@ -14,6 +14,11 @@
           android:orderInCategory="15" app:showAsAction="ifRoom"
         android:icon="@drawable/ic_play_arrow_white_24dp"/>
 
+    <group android:checkableBehavior="all">
+        <item android:id="@+id/log_events_menuitem"
+            android:title="@string/log_events_menuitem" />
+    </group>
+
     <item android:id="@+id/action_airstrike" android:title="@string/action_airstrike"
           android:orderInCategory="90" app:showAsAction="never"/>
     <item android:id="@+id/action_carpet_bomb" android:title="@string/action_carpet_bomb"

--- a/blocklydemo/src/main/res/values/strings.xml
+++ b/blocklydemo/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="turtle_activity_name">Blockly Turtle</string>
     <string name="style_activity_name">Blockly Styles</string>
 
+    <string name="log_events_menuitem">Log Events</string>
+
     <string name="action_demo_android">Android</string>
     <string name="action_demo_lacey_curves">Lacey Curves</string>
     <string name="action_demo_paint_strokes">Paint Strokes</string>

--- a/blocklylib-core/src/main/assets/default/test_blocks.json
+++ b/blocklylib-core/src/main/assets/default/test_blocks.json
@@ -26,6 +26,8 @@
         "name": "DO"
       }
     ],
+    "previousStatement": null,
+    "nextStatement": null,
     "tooltip": "",
     "helpUrl": "http://www.example.com/"
   },

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyEvent.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyEvent.java
@@ -1,0 +1,930 @@
+package com.google.blockly.android.control;
+
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+import android.support.v4.util.ArrayMap;
+import android.text.TextUtils;
+import android.util.SparseArray;
+
+import com.google.blockly.model.Block;
+import com.google.blockly.model.BlocklySerializerException;
+import com.google.blockly.model.Connection;
+import com.google.blockly.model.Field;
+import com.google.blockly.model.Input;
+import com.google.blockly.model.Workspace;
+import com.google.blockly.model.WorkspacePoint;
+import com.google.blockly.utils.BlocklyXmlHelper;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONStringer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for all Blockly events.
+ */
+public abstract class BlocklyEvent {
+    // JSON serialization attributes.  See also TYPENAME_ and ELEMENT_ constants for ids.
+    private static final String JSON_BLOCK_ID = "blockId";
+    private static final String JSON_ELEMENT = "element";
+    private static final String JSON_GROUP_ID = "groupId";
+    private static final String JSON_IDS = "ids";
+    private static final String JSON_NAME = "name";
+    private static final String JSON_NEW_VALUE = "newValue";
+    private static final String JSON_OLD_VALUE = "oldValue";  // Rarely used.
+    private static final String JSON_TYPE = "type";
+    private static final String JSON_WORKSPACE_ID = "workspaceId"; // Rarely used.
+    private static final String JSON_XML = "xml";
+
+    @IntDef(flag = true,
+            value = {TYPE_CHANGE, TYPE_CREATE, TYPE_DELETE, TYPE_MOVE, TYPE_UI})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface EventType {}
+
+    public static final int TYPE_CREATE = 1 << 0;
+    public static final int TYPE_DELETE = 1 << 1;
+    public static final int TYPE_CHANGE = 1 << 2;
+    public static final int TYPE_MOVE = 1 << 3;
+    public static final int TYPE_UI = 1 << 4;
+    // When adding an event type, update TYPE_ID_COUNT, TYPE_ALL, TYPE_ID_TO_NAME, and
+    // TYPE_NAME_TO_ID.
+    private static final int TYPE_ID_COUNT = 5;
+    public static final @EventType int TYPE_ALL =
+            TYPE_CHANGE | TYPE_CREATE | TYPE_DELETE | TYPE_MOVE | TYPE_UI;
+
+    public static final String TYPENAME_CHANGE = "change";
+    public static final String TYPENAME_CREATE = "create";
+    public static final String TYPENAME_DELETE = "delete";
+    public static final String TYPENAME_MOVE = "move";
+    public static final String TYPENAME_UI = "ui";
+
+    @StringDef({ELEMENT_COLLAPSED, ELEMENT_COMMENT, ELEMENT_DISABLED, ELEMENT_FIELD, ELEMENT_INLINE,
+            ELEMENT_MUTATE})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ChangeElement {}
+
+    public static final String ELEMENT_COLLAPSED = "collapsed";
+    public static final String ELEMENT_COMMENT = "comment";
+    public static final String ELEMENT_DISABLED = "disabled";
+    public static final String ELEMENT_FIELD = "field";
+    public static final String ELEMENT_INLINE = "inline";
+    public static final String ELEMENT_MUTATE = "mutate";
+
+    @StringDef({ELEMENT_CATEGORY, ELEMENT_CLICK, ELEMENT_COMMENT_OPEN, ELEMENT_MUTATOR_OPEN,
+            ELEMENT_SELECTED, ELEMENT_TRASH, ELEMENT_WARNING_OPEN})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface UIElement {}
+
+    public static final String ELEMENT_CATEGORY = "category";
+    public static final String ELEMENT_CLICK = "click";
+    public static final String ELEMENT_COMMENT_OPEN = "commentOpen";
+    public static final String ELEMENT_MUTATOR_OPEN = "mutatorOpen";
+    public static final String ELEMENT_SELECTED = "selected";
+    public static final String ELEMENT_TRASH = "trashOpen";
+    public static final String ELEMENT_WARNING_OPEN = "warningOpen";
+
+    private static final SparseArray<String> TYPE_ID_TO_NAME = new SparseArray<>(TYPE_ID_COUNT);
+    private static final Map<String, Integer> TYPE_NAME_TO_ID = new ArrayMap<>(TYPE_ID_COUNT);
+    static {
+        TYPE_ID_TO_NAME.put(TYPE_CHANGE, TYPENAME_CHANGE);
+        TYPE_ID_TO_NAME.put(TYPE_CREATE, TYPENAME_CREATE);
+        TYPE_ID_TO_NAME.put(TYPE_DELETE, TYPENAME_DELETE);
+        TYPE_ID_TO_NAME.put(TYPE_MOVE, TYPENAME_MOVE);
+        TYPE_ID_TO_NAME.put(TYPE_UI, TYPENAME_UI);
+
+        TYPE_NAME_TO_ID.put(TYPENAME_CHANGE, TYPE_CHANGE);
+        TYPE_NAME_TO_ID.put(TYPENAME_CREATE, TYPE_CREATE);
+        TYPE_NAME_TO_ID.put(TYPENAME_DELETE, TYPE_DELETE);
+        TYPE_NAME_TO_ID.put(TYPENAME_MOVE, TYPE_MOVE);
+        TYPE_NAME_TO_ID.put(TYPENAME_UI, TYPE_UI);
+    }
+
+    public static BlocklyEvent fromJson(String json) throws JSONException {
+        return fromJson(new JSONObject(json));
+    }
+
+    public static BlocklyEvent fromJson(JSONObject json) throws JSONException {
+        String typename = json.getString(JSON_TYPE);
+        switch(typename) {
+            case TYPENAME_CHANGE:
+                return new ChangeEvent(json);
+            case TYPENAME_CREATE:
+                return new CreateEvent(json);
+            case TYPENAME_DELETE:
+                return new DeleteEvent(json);
+            case TYPENAME_MOVE:
+                return new MoveEvent(json);
+            case TYPENAME_UI:
+                return new UIEvent(json);
+
+            default:
+                throw new JSONException("Unknown event type: " + typename);
+        }
+    }
+
+    @EventType
+    protected final int mTypeId;
+    protected final String mBlockId;
+    protected final String mWorkspaceId;
+
+    protected String mGroupId;
+
+    /**
+     * Base constructor for all BlocklyEvents.
+     *
+     * @param typeId The {@link EventType}.
+     * @param workspaceId The id string of the Blockly workspace.
+     * @param groupId The id string of the event group. Usually null for local events (assigned
+     *                later); non-null for remote events.
+     * @param blockId The id string of the block affected. Null for a few event types (e.g., toolbox
+     *                category).
+     */
+    protected BlocklyEvent(@EventType int typeId, @NonNull String workspaceId,
+                           @Nullable String groupId, @Nullable String blockId) {
+        validateEventType(typeId);
+        mTypeId = typeId;
+        mBlockId = blockId;
+        mWorkspaceId = workspaceId;
+        mGroupId = groupId;
+    }
+
+    /**
+     * Constructs BlocklyEvent with base attributes assigned from {@code json}.
+     *
+     * @param typeId The type of the event. Assumed to match {@link #JSON_TYPE} in {@code json}.
+     * @param json The JSON object with event attribute values.
+     * @throws JSONException
+     */
+    protected BlocklyEvent(@EventType int typeId, JSONObject json) throws JSONException {
+        validateEventType(typeId);
+        mTypeId = typeId;
+        mWorkspaceId = json.optString(JSON_WORKSPACE_ID);
+        mGroupId = json.optString(JSON_GROUP_ID);
+        mBlockId = json.optString(JSON_BLOCK_ID);
+    }
+
+    /**
+     * @return The type identifier for this event.
+     */
+    @EventType
+    public int getTypeId() {
+        return mTypeId;
+    }
+
+    /**
+     * @return The JSON type identifier string for this event.
+     */
+    @NonNull
+    public String getTypeName() {
+        return TYPE_ID_TO_NAME.get(mTypeId);
+    }
+
+    /**
+     * @return The identifier for the workspace that triggered this event.
+     */
+    @Nullable
+    public String getWorkspaceId() {
+        return mWorkspaceId;
+    }
+
+    /**
+     * @return The identifier for the group of related events.
+     */
+    @Nullable
+    public String getGroupId() {
+        return mGroupId;
+    }
+
+    /**
+     * @return The id of the primary or root affected block.
+     */
+    @Nullable
+    public String getBlockId() {
+        return mBlockId;
+    }
+
+    public String toJsonString() throws JSONException {
+        JSONStringer out = new JSONStringer();
+        out.object();
+        out.key(JSON_TYPE);
+        out.value(getTypeName());
+        if (!TextUtils.isEmpty(mBlockId)) {
+            out.key(JSON_BLOCK_ID);
+            out.value(mBlockId);
+        }
+        if (!TextUtils.isEmpty(mGroupId)) {
+            out.key(JSON_GROUP_ID);
+            out.value(mGroupId);
+        }
+        writeJsonAttributes(out);
+        // Workspace id is not included to reduce size over network.
+        out.endObject();
+        return out.toString();
+    }
+
+    protected void setGroupId(String groupId) {
+        this.mGroupId = groupId;
+    }
+
+    protected abstract void writeJsonAttributes(JSONStringer out) throws JSONException;
+
+    /**
+     * Event fired when a property of a block changes.
+     */
+    public static final class ChangeEvent extends BlocklyEvent {
+        /**
+         * Creates a ChangeEvent reflecting a change in the block's collapsed state.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newCollapsedStateEvent(@NonNull Workspace workspace,
+                                                         @NonNull Block block) {
+            boolean collapsed = block.isCollapsed();
+            return new ChangeEvent(ELEMENT_COLLAPSED, workspace, block, null,
+                    /* oldValue */ !collapsed ? "true" : "false",
+                    /* newValue */ collapsed ? "true" : "false");
+        }
+
+        /**
+         * Creates a ChangeEvent reflecting a change in the block's comment text.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @param oldValue The prior comment text.
+         * @param newValue The updated comment text.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newCommentTextEvent(
+                @NonNull Workspace workspace, @NonNull Block block,
+                @Nullable String oldValue, @Nullable String newValue) {
+            return new ChangeEvent(ELEMENT_COMMENT, workspace, block, null, oldValue, newValue);
+        }
+
+        /**
+         * Creates a ChangeEvent reflecting a change in the block's disabled state.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newDisabledStateEvent(@NonNull Workspace workspace,
+                                                        @NonNull Block block) {
+            boolean disabled = block.isDisabled();
+            return new ChangeEvent(ELEMENT_DISABLED, workspace, block, null,
+                    /* oldValue */ !disabled ? "true" : "false",
+                    /* newValue */ disabled ? "true" : "false");
+        }
+
+        /**
+         * Creates a ChangeEvent reflecting a change in a field's value.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @param field The field with the changed value.
+         * @param oldValue The prior value.
+         * @param newValue The updated value.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newFieldValueEvent(
+                @NonNull Workspace workspace, @NonNull Block block, @NonNull Field field,
+                @NonNull String oldValue, @NonNull String newValue) {
+            return new ChangeEvent(ELEMENT_FIELD, workspace, block, field, oldValue, newValue);
+        }
+
+        /**
+         * Creates a ChangeEvent reflecting a change in the block's inlined inputs state.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newInlineStateEvent(@NonNull Workspace workspace,
+                                                      @NonNull Block block) {
+            boolean inline = block.getInputsInline();
+            return new ChangeEvent(ELEMENT_INLINE, workspace, block, null,
+                    /* oldValue */ !inline ? "true" : "false",
+                    /* newValue */ inline ? "true" : "false");
+        }
+
+        /**
+         * Creates a ChangeEvent reflecting a change in the block's mutation state.
+         *
+         * @param workspace The workspace containing the block.
+         * @param block The block where the state changed.
+         * @param oldValue The serialized version of the prior mutation state.
+         * @param newValue The serialized version of the updated mutation state.
+         * @return The new ChangeEvent.
+         */
+        public static ChangeEvent newMutateEvent(
+                @NonNull Workspace workspace, @NonNull Block block,
+                @Nullable String oldValue, @Nullable String newValue) {
+            return new ChangeEvent(ELEMENT_MUTATE, workspace, block, null, oldValue, newValue);
+        }
+
+        @NonNull @ChangeElement
+        private final String mElementChanged;
+        @Nullable
+        private final String mFieldName;
+        @NonNull
+        private final String mOldValue;
+        @NonNull
+        private final String mNewValue;
+
+        /**
+         * Constructs a ChangeEvent, signifying {@code block}'s value changed.
+         *
+         * @param workspace The workspace containing the change.
+         * @param block The block containing the change.
+         * @param field The field containing the change, if the change is a field value. Otherwise
+         *              null.
+         * @param oldValue The original value.
+         * @param newValue The new value.
+         */
+        private ChangeEvent(@ChangeElement String element, @NonNull Workspace workspace,
+                            @NonNull Block block, @Nullable Field field,
+                            @Nullable String oldValue, @Nullable String newValue) {
+            super(TYPE_CHANGE, workspace.getId(), null, block.getId());
+            mElementChanged = validateChangeElement(element);
+            if (mElementChanged == ELEMENT_FIELD) {
+                mFieldName = field.getName();
+            }  else {
+                mFieldName = null; // otherwise ignore the field name
+            }
+            mOldValue = oldValue;
+            mNewValue = newValue;
+        }
+
+        /**
+         * Constructs a ChangeEvent from the JSON serialized representation.
+         *
+         * @param json The serialized ChangeEvent.
+         * @throws JSONException
+         */
+        public ChangeEvent(@NonNull JSONObject json) throws JSONException {
+            super(TYPE_CHANGE, json);
+            if (TextUtils.isEmpty(mBlockId)) {
+                throw new JSONException(JSON_BLOCK_ID + " must be assigned.");
+            }
+            String element = json.getString(JSON_ELEMENT);
+            try {
+                mElementChanged = validateChangeElement(element);
+            } catch (IllegalArgumentException e) {
+                throw new JSONException("Invalid change element: " + element);
+            }
+            mFieldName = (mElementChanged == ELEMENT_FIELD) ? json.getString(JSON_NAME) : null;
+            mOldValue = json.optString(JSON_OLD_VALUE); // Not usually serialized.
+            mNewValue = json.getString(JSON_NEW_VALUE);
+        }
+
+        @NonNull @ChangeElement
+        public String getElement() {
+            return mElementChanged;
+        }
+
+        public String getFieldName() {
+            return mFieldName;
+        }
+
+        public String getOldValue() {
+            return mOldValue;
+        }
+
+        public String getNewValue() {
+            return mNewValue;
+        }
+
+        protected void writeJsonAttributes(JSONStringer out) throws JSONException {
+            out.key("element");
+            out.value(mElementChanged);
+            if (mFieldName != null) {
+                out.key("name");
+                out.value(mFieldName);
+            }
+            out.key("newValue");
+            out.value(mNewValue);
+        }
+    }
+
+    /**
+     * Event fired when a block is added to the workspace, possibly containing other child blocks
+     * and next blocks.
+     */
+    public static final class CreateEvent extends BlocklyEvent {
+        private final String mXml;
+        private final List<String> mIds;
+
+        /**
+         * Constructs a {@code CreateEvent} for the given block.
+         *
+         * @param workspace The workspace containing the new block.
+         * @param block The newly created block.
+         */
+        public CreateEvent(@NonNull Workspace workspace, @NonNull Block block) {
+            super(TYPE_CREATE, workspace.getId(), null, block.getId());
+            try {
+                mXml = BlocklyXmlHelper.writeOneBlockToXml(block);
+            } catch (BlocklySerializerException e) {
+                throw new IllegalArgumentException("Invalid block for event serialization");
+            }
+
+            List<String> ids = new ArrayList<>();
+            block.addAllBlockIds(ids);
+            mIds = Collections.unmodifiableList(ids);
+        }
+
+        /**
+         * Constructs a CreateEvent from the JSON serialized representation.
+         *
+         * @param json The serialized CreateEvent.
+         * @throws JSONException
+         */
+        public CreateEvent(JSONObject json) throws JSONException {
+            super(TYPE_CREATE, json);
+            if (mBlockId == null) {
+                throw new JSONException(JSON_BLOCK_ID + " must be assigned.");
+            }
+            mXml = json.getString(JSON_XML);
+
+            JSONArray jsonIds = json.getJSONArray("ids");
+            int count = jsonIds.length();
+            List<String> ids = new ArrayList<>(count);
+            for (int i = 0; i < count; ++i) {
+                ids.add(jsonIds.getString(i));
+            }
+            mIds = Collections.unmodifiableList(ids);
+        }
+
+        /**
+         * @return The XML serialization of all blocks created by this event.
+         */
+        public String getXml() {
+            return mXml;
+        }
+
+        /**
+         * @return The list of all block ids for all blocks created by this event.
+         */
+        public List<String> getIds() {
+            return mIds;
+        }
+
+        @Override
+        protected void writeJsonAttributes(JSONStringer out) throws JSONException {
+            out.key("xml");
+            out.value(mXml);
+            out.key("ids");
+            out.array();
+            for (String id : mIds) {
+                out.value(id);
+            }
+            out.endArray();
+        }
+    }
+
+    /**
+     * Event fired when a block is removed from the workspace.
+     */
+    public static final class DeleteEvent extends BlocklyEvent {
+        private final String mOldXml;
+        private final List<String> mIds;
+
+        /**
+         * Constructs a {@code DeleteEvent}, signifying the removal of a block from the workspace.
+         *
+         * @param workspace The workspace containing the deletion.
+         * @param block The deleted block (or to-be-deleted block), with all children attached.
+         */
+        DeleteEvent(@NonNull Workspace workspace, @NonNull Block block) {
+            super(TYPE_DELETE, workspace.getId(), null, block.getId());
+            try {
+                mOldXml = BlocklyXmlHelper.writeOneBlockToXml(block);
+            } catch (BlocklySerializerException e) {
+                throw new IllegalArgumentException("Invalid block for event serialization");
+            }
+
+            List<String> ids = new ArrayList<>();
+            block.addAllBlockIds(ids);
+            mIds = Collections.unmodifiableList(ids);
+        }
+
+        /**
+         * Constructs a DeleteEvent from the JSON serialized representation.
+         *
+         * @param json The serialized DeleteEvent.
+         * @throws JSONException
+         */
+        DeleteEvent(@NonNull JSONObject json) throws JSONException {
+            super(TYPE_DELETE, json);
+            if (TextUtils.isEmpty(mBlockId)) {
+                throw new JSONException(TYPENAME_DELETE + " requires " + JSON_BLOCK_ID);
+            }
+
+            mOldXml = json.optString(JSON_OLD_VALUE); // Not usually used.
+            JSONArray ids = json.getJSONArray(JSON_IDS);
+            int count = ids.length();
+            List<String> temp = new ArrayList<>(count);
+            for (int i = 0; i < count; ++i) {
+                temp.add(ids.getString(i));
+            }
+            mIds = Collections.unmodifiableList(temp);
+        }
+
+        /**
+         * @return The XML serialization of all blocks deleted by this event.
+         */
+        public String getXml() {
+            return mOldXml;
+        }
+
+        /**
+         * @return The list of all block ids for all blocks deleted by this event.
+         */
+        public List<String> getIds() {
+            return mIds;
+        }
+
+        @Override
+        protected void writeJsonAttributes(JSONStringer out) throws JSONException {
+            out.key("ids");
+            out.array();
+            for (String id : mIds) {
+                out.value(id);
+            }
+            out.endArray();
+        }
+    }
+
+    /**
+     * Event fired when a block is moved on the workspace, or its parent connection is changed.
+     * <p/>
+     * This event must be created before the block is moved to capture the original position.
+     * After the move has been completed in the workspace, capture the updated position or parent
+     * using {@link #recordNew(Block)}.  All of this is managed by {@link BlocklyController}, before
+     * {@link BlocklyController.EventsCallback}s receive the event.
+     */
+    public static final class MoveEvent extends BlocklyEvent {
+        private static final String JSON_NEW_COORDINATE = "newCoordinate";
+        private static final String JSON_NEW_INPUT_NAME = "newInputName";
+        private static final String JSON_NEW_PARENT_ID = "newParentId";
+
+        @Nullable
+        private String mOldParentId;
+        @Nullable
+        private String mOldInputName;
+        private boolean mHasOldPosition;
+        private int mOldPositionX;
+        private int mOldPositionY;
+
+        // New values are recorded
+        @Nullable
+        private String mNewParentId;
+        @Nullable
+        private String mNewInputName;
+        private boolean mHasNewPosition;
+        private int mNewPositionX;
+        private int mNewPositionY;
+
+        /**
+         * Constructs a {@link MoveEvent} signifying the movement of a block on the workspace.
+         *
+         * @param workspace The workspace containing the moved blocks.
+         * @param block The root block of the move, while it is still in its original position.
+         */
+        MoveEvent(@NonNull Workspace workspace, @NonNull Block block) {
+            super(TYPE_MOVE, workspace.getId(), null, block.getId());
+
+            Connection parentConnection = block.getParentConnection();
+            if (parentConnection == null) {
+                WorkspacePoint position = block.getPosition();
+                if (position == null) {
+                    throw new IllegalStateException("Block must have parent or position.");
+                }
+                mHasOldPosition = true;
+                mOldPositionX = position.x;
+                mOldPositionY = position.y;
+                mOldParentId = null;
+                mOldInputName = null;
+            } else {
+                Input parentInput = parentConnection.getInput();
+                mOldInputName = parentInput.getName();
+                mOldParentId = parentInput.getBlock().getId();
+                mHasOldPosition = false;
+                mOldPositionX = mOldPositionY = -1;
+            }
+        }
+
+        /**
+         * Constructs a MoveEvent from the JSON serialized representation.
+         *
+         * @param json The serialized MoveEvent.
+         * @throws JSONException
+         */
+        MoveEvent(JSONObject json) throws JSONException {
+            super(TYPE_MOVE, json);
+            if (TextUtils.isEmpty(mBlockId)) {
+                throw new JSONException(TYPENAME_MOVE + " requires " + JSON_BLOCK_ID);
+            }
+
+            // Old values are not stored in JSON
+            mOldParentId = null;
+            mOldInputName = null;
+            mOldPositionX = mOldPositionY = 0;
+
+            String newCoordinateStr = json.optString(JSON_NEW_COORDINATE);
+            if (newCoordinateStr != null) {
+                // JSON coordinates are always integers, separated by a comma.
+                int comma = newCoordinateStr.indexOf(',');
+                if (comma == -1) {
+                    throw new JSONException(
+                            "Invalid " + JSON_NEW_COORDINATE + ": " + newCoordinateStr);
+                }
+                try {
+                    mNewPositionX = Integer.parseInt(newCoordinateStr.substring(0, comma));
+                    mNewPositionY = Integer.parseInt(newCoordinateStr.substring(comma + 1));
+                } catch (NumberFormatException e) {
+                    throw new JSONException(
+                            "Invalid " + JSON_NEW_COORDINATE + ": " + newCoordinateStr);
+                }
+            } else {
+
+            }
+        }
+
+        public void recordNew(Block block) {
+            if (!block.getId().equals(mBlockId)) {
+                throw new IllegalArgumentException("Block id does not match original.");
+            }
+
+            Connection parentConnection = block.getParentConnection();
+            if (parentConnection == null) {
+                WorkspacePoint position = block.getPosition();
+                if (position == null) {
+                    throw new IllegalStateException("Block must have parent or position.");
+                }
+                mHasNewPosition = true;
+                mNewPositionX = position.x;
+                mNewPositionY = position.y;
+                mNewParentId = null;
+                mNewInputName = null;
+            } else {
+                Input parentInput = parentConnection.getInput();
+                mNewInputName = parentInput.getName();
+                mNewParentId = parentInput.getBlock().getId();
+                mHasNewPosition = false;
+                mNewPositionX = mNewPositionY = -1;
+            }
+        }
+
+        public String getOldParentId() {
+            return mOldParentId;
+        }
+
+        public String getOldInputName() {
+            return mOldInputName;
+        }
+
+        public boolean hasOldPosition() {
+            return mHasOldPosition;
+        }
+
+        public boolean getOldWorkspacePosition(WorkspacePoint output) {
+            if (mHasOldPosition) {
+                output.set(mOldPositionX, mOldPositionY);
+            }
+            return mHasOldPosition;
+        }
+
+        public String getNewParentId() {
+            return mNewParentId;
+        }
+
+        public String getNewInputName() {
+            return mNewInputName;
+        }
+
+        public boolean hasNewPosition() {
+            return mHasNewPosition;
+        }
+
+        public boolean getNewWorkspacePosition(WorkspacePoint output) {
+            if (mHasNewPosition) {
+                output.set(mNewPositionX, mNewPositionY);
+            }
+            return mHasNewPosition;
+        }
+
+        @Override
+        protected void writeJsonAttributes(JSONStringer out) throws JSONException {
+            if (mNewParentId != null) {
+                out.key(JSON_NEW_PARENT_ID);
+                out.value(mNewParentId);
+            }
+            if (mNewInputName != null) {
+                out.key(JSON_NEW_INPUT_NAME);
+                out.value(mNewInputName);
+            }
+            if (mHasNewPosition) {
+                out.key(JSON_NEW_COORDINATE);
+                StringBuilder sb = new StringBuilder();
+                sb.append(mNewPositionX).append(',').append(mNewPositionY);
+                out.value(sb.toString());
+            }
+        }
+    }
+
+    /**
+     * Event class for user interface related actions, including selecting blocks, opening/closing
+     * the toolbox or trash, and changing toolbox categories.
+     */
+    public static final class UIEvent extends BlocklyEvent {
+        private final @BlocklyEvent.UIElement String mUiElement;
+        private final String mOldValue;
+        private final String mNewValue;
+
+        public UIEvent newBlockClickedEvent(@NonNull Workspace workspace, @NonNull Block block) {
+            return new UIEvent(ELEMENT_CLICK, workspace, block, null, null);
+        }
+
+        public UIEvent newBlockCommentEvent(@NonNull Workspace workspace, @NonNull Block block,
+                                            boolean openedBefore, boolean openedAfter) {
+            return new UIEvent(ELEMENT_COMMENT_OPEN, workspace, block,
+                    openedBefore ? "true" : "false", openedAfter ? "true" : "false");
+        }
+
+        public UIEvent newBlockMutatorEvent(@NonNull Workspace workspace, @NonNull Block block,
+                                            boolean openedBefore, boolean openedAfter) {
+            return new UIEvent(ELEMENT_MUTATOR_OPEN, workspace, block,
+                    openedBefore ? "true" : "false", openedAfter ? "true" : "false");
+        }
+
+        public UIEvent newBlockSelectedEvent(@NonNull Workspace workspace, @NonNull Block block,
+                                            boolean selectedBefore, boolean selectedAfter) {
+            return new UIEvent(ELEMENT_SELECTED, workspace, block,
+                               selectedBefore ? "true" : "false", selectedAfter ? "true" : "false");
+        }
+
+        public UIEvent newBlockWarningEvent(@NonNull Workspace workspace, @NonNull Block block,
+                                            boolean openedBefore, boolean openedAfter) {
+            return new UIEvent(ELEMENT_WARNING_OPEN, workspace, block,
+                    openedBefore ? "true" : "false", openedAfter ? "true" : "false");
+        }
+
+        public UIEvent newToolboxCategoryEvent(@NonNull Workspace workspace,
+                                               @Nullable String oldValue,
+                                               @Nullable String newValue) {
+            return new UIEvent(ELEMENT_CATEGORY, workspace, null, oldValue, newValue);
+        }
+
+        /**
+         * Constructs a block related UI event, such as clicked, selected, comment opened, mutator
+         * opened, or warning opened.
+         *
+         * @param element The UI element that changed.
+         * @param workspace The workspace containing the moved blocks.
+         * @param block The related block. Null for toolbox category events.
+         * @param oldValue The value before the event. Booleans are mapped to "true" and "false".
+         * @param newValue The value after the event. Booleans are mapped to "true" and "false".
+         */
+        private UIEvent(@BlocklyEvent.UIElement String element, @NonNull Workspace workspace,
+                        @Nullable Block block, String oldValue, String newValue) {
+            super(TYPE_UI, workspace.getId(), null, block == null ? null : block.getId());
+            this.mUiElement = validateUiElement(element);
+            this.mOldValue = oldValue;
+            this.mNewValue = newValue;
+        }
+
+        /**
+         * Constructs a UIEvent from the JSON serialized representation.
+         *
+         * @param json The serialized UIEvent.
+         * @throws JSONException
+         */
+        UIEvent(JSONObject json) throws JSONException {
+            super(TYPE_UI, json);
+            String element = json.getString(JSON_ELEMENT);
+            try {
+                mUiElement = validateUiElement(element);
+            } catch (IllegalArgumentException e) {
+                throw new JSONException("Invalid UI element: " + element);
+            }
+            if (mUiElement != ELEMENT_CATEGORY && TextUtils.isEmpty(mBlockId)) {
+                throw new JSONException("UI element " + mUiElement + " requires " + JSON_BLOCK_ID);
+            }
+            this.mOldValue = json.optString(JSON_OLD_VALUE);  // Rarely used.
+            this.mNewValue = json.optString(JSON_NEW_VALUE);
+            if (mUiElement != ELEMENT_CATEGORY && mUiElement != ELEMENT_CLICK
+                    && TextUtils.isEmpty(mNewValue)) {
+                throw new JSONException("UI element " + mUiElement + " requires " + JSON_NEW_VALUE);
+            }
+        }
+
+        public String getElement() {
+            return mUiElement;
+        }
+
+        public String getOldValue() {
+            return mOldValue;
+        }
+
+        public String getNewValue() {
+            return mNewValue;
+        }
+
+        @Override
+        protected void writeJsonAttributes(JSONStringer out) throws JSONException {
+            out.key("element");
+            out.value(mUiElement);
+            if (mNewValue != null) {
+                out.key("newValue");
+                out.value(mNewValue);
+            }
+            // Old value is not included to reduce size over network.
+        }
+    }
+
+
+    /**
+     * Ensures {@code typeId} is a singular valid event id.
+     * @param typeId The typeId to test.
+     */
+    private static void validateEventType(int typeId) {
+        if (typeId <= 0 || typeId > TYPE_ALL // Outside bounds.
+                || ((typeId & (typeId - 1)) != 0)) /* Not a power of two */ {
+            throw new IllegalArgumentException("Invalid typeId: " + typeId);
+        }
+    }
+
+    /**
+     * @param eventTypeName A JSON "type" event name.
+     * @return returns The {@link EventType} for {@code eventTypeName}, or 0 if not valid.
+     * @throws IllegalArgumentException when
+     */
+    private static int getIdForEventName(final String eventTypeName) {
+        Integer typeId = TYPE_NAME_TO_ID.get(eventTypeName);
+        if (typeId == null) {
+            return 0;
+        }
+        return typeId;
+    }
+
+    /**
+     * @param changeElement An element name string, as used by {@link ChangeEvent}s.
+     * @return The canonical (identity comparable) version of {@code changeElement}.
+     * @throws IllegalArgumentException If {@code changeElement} is not a {@link ChangeElement}.
+     */
+    private static String validateChangeElement(final String changeElement) {
+        switch (changeElement) {
+            case ELEMENT_COLLAPSED:
+                return ELEMENT_COLLAPSED;
+            case ELEMENT_COMMENT:
+                return ELEMENT_COMMENT;
+            case ELEMENT_DISABLED:
+                return ELEMENT_DISABLED;
+            case ELEMENT_FIELD:
+                return ELEMENT_FIELD;
+            case ELEMENT_INLINE:
+                return ELEMENT_INLINE;
+            case ELEMENT_MUTATE:
+                return ELEMENT_MUTATE;
+
+            default:
+                throw new IllegalArgumentException("Unrecognized change element: " + changeElement);
+        }
+    }
+
+    /**
+     * @param uiElement An element name string, as used by {@link UIEvent}s.
+     * @return The canonical (identity comparable) version of the {@code uiElement}.
+     * @throws IllegalArgumentException If {@code changeElement} is not a {@link UIElement}.
+     */
+    private static String validateUiElement(final String uiElement) {
+        switch (uiElement) {
+            case ELEMENT_CATEGORY:
+                return ELEMENT_CATEGORY;
+            case ELEMENT_CLICK:
+                return ELEMENT_CLICK;
+            case ELEMENT_COMMENT_OPEN:
+                return ELEMENT_COMMENT_OPEN;
+            case ELEMENT_MUTATOR_OPEN:
+                return ELEMENT_MUTATOR_OPEN;
+            case ELEMENT_SELECTED:
+                return ELEMENT_SELECTED;
+            case ELEMENT_WARNING_OPEN:
+                return ELEMENT_WARNING_OPEN;
+
+            default:
+                throw new IllegalArgumentException("Unrecognized UI element: " + uiElement);
+        }
+    }
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/VirtualWorkspaceView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/VirtualWorkspaceView.java
@@ -500,7 +500,7 @@ public class VirtualWorkspaceView extends NonPropagatingViewGroup {
         }
     }
 
-    /** Listener class for scaling and panning the view using pinch-to-zoom gestures. */
+    /** EventsCallback class for scaling and panning the view using pinch-to-zoom gestures. */
     private class ScaleGestureListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
         // Focus point at the start of the pinch gesture. This is used for computing proper scroll
         // offsets during scaling, as well as for simultaneous panning.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -133,7 +133,7 @@ public class BasicFieldNumberView extends EditText implements FieldView {
                 // Replace empty string with value closest to zero.
                 mNumberField.setValue(0);
             }
-            setText(mNumberField.getValueString());
+            setText(mNumberField.getSerializedValue());
             setTextValid(true);
         }
     }
@@ -151,7 +151,7 @@ public class BasicFieldNumberView extends EditText implements FieldView {
         mNumberField = number;
         if (mNumberField != null) {
             updateInputMethod();
-            setText(mNumberField.getValueString());
+            setText(mNumberField.getSerializedValue());
             mNumberField.registerObserver(mFieldObserver);
         } else {
             setText("");

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -134,6 +134,30 @@ public class Block {
     }
 
     /**
+     * Adds to <code>outList</code> all block ids for this block and all child blocks.
+     * This will not include occluded shadow block ids.
+     *
+     * @param outList List of ids to add to.
+     */
+    public void addAllBlockIds(List<String> outList) {
+        outList.add(getId());
+        int inputCount = mInputList.size();
+        for (int i = 0; i < inputCount; ++i) {
+            Input input = mInputList.get(i);
+            Block connectedBlock = input.getConnectedBlock();
+            if (connectedBlock != null) {
+                connectedBlock.addAllBlockIds(outList);
+            }
+        }
+        if (mNextConnection != null) {
+            Block next = mNextConnection.getTargetBlock();
+            if (next != null) {
+                next.addAllBlockIds(outList);
+            }
+        }
+    }
+
+    /**
      * @return The color this block should be drawn in.
      */
     public int getColor() {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -89,7 +89,7 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
             return;
         }
         serializer.startTag(null, "field").attribute(null, "name", mName);
-        serializeInner(serializer);
+        serializer.text(getSerializedValue());
         serializer.endTag(null, "field");
     }
 
@@ -123,6 +123,11 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
      * @return True if the value was set, false otherwise.
      */
     public abstract boolean setFromString(String text);
+
+    /**
+     * @return The value serialized into a string.
+     */
+    public abstract String getSerializedValue();
 
     /**
      * Checks if the given type name is a known field type.
@@ -235,13 +240,4 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
                 return TYPE_UNKNOWN;
         }
     }
-
-    /**
-     * Writes the value of the Field as a string.
-     *
-     * @param serializer The XmlSerializer to write to.
-     *
-     * @throws IOException
-     */
-    protected abstract void serializeInner(XmlSerializer serializer) throws IOException;
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldAngle.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldAngle.java
@@ -92,8 +92,8 @@ public final class FieldAngle extends Field<FieldAngle.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(Integer.toString(mAngle));
+    public String getSerializedValue() {
+        return Integer.toString(mAngle);
     }
 
     private void onAngleChanged(int oldAngle, int newAngle) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
@@ -73,8 +73,8 @@ public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(mChecked ? "true" : "false");
+    public String getSerializedValue() {
+        return mChecked ? "true" : "false";
     }
 
     private void onCheckChanged(boolean newState) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldColor.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldColor.java
@@ -93,9 +93,9 @@ public final class FieldColor extends Field<FieldColor.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(String.format("#%02x%02x%02x",
-                Color.red(mColor), Color.green(mColor), Color.blue(mColor)));
+    public String getSerializedValue() {
+        return String.format("#%02x%02x%02x",
+                Color.red(mColor), Color.green(mColor), Color.blue(mColor));
     }
 
     private void onColorChanged(int oldColor, int newColor) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
@@ -126,8 +126,8 @@ public final class FieldDate extends Field<FieldDate.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(DATE_FORMAT.format(mDate));
+    public String getSerializedValue() {
+        return DATE_FORMAT.format(mDate);
     }
 
     private void onDateChanged(long oldMillis, long newMillis) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
@@ -22,9 +22,7 @@ import com.google.blockly.utils.BlockLoadingException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,7 +101,7 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
      * @param options A list of options consisting of pairs of displayName/value.
      */
     public void setOptions(List<Option> options) {
-        String previousValue = getSelectedValue();
+        String previousValue = getSerializedValue();
         mOptions = options;
         setSelectedValue(previousValue);
     }
@@ -216,8 +214,8 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(getSelectedValue());
+    public String getSerializedValue() {
+        return getSelectedValue();
     }
 
     private void onSelectionChanged(FieldDropdown field, int oldIndex, int newIndex) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldImage.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldImage.java
@@ -106,8 +106,8 @@ public final class FieldImage extends Field<FieldImage.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer xmlSerializer) {
-        // Something to do here?
+    public String getSerializedValue() {
+        return ""; // Image fields do not have value.
     }
 
     private void onImageChanged(String newSource, int newWidth, int newHeight) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
@@ -76,8 +76,8 @@ public final class FieldInput extends Field<FieldInput.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(mText == null ? "" : mText);
+    public String getSerializedValue() {
+        return mText == null ? "" : mText;
     }
 
     private void onTextChanged(String oldText, String newText) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldLabel.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldLabel.java
@@ -71,8 +71,8 @@ public final class FieldLabel extends Field<FieldLabel.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        // Nothing to do.
+    public String getSerializedValue() {
+        return ""; // Label fields do not have value.
     }
 
     private void onTextChanged(String oldText, String newText) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
@@ -216,7 +216,7 @@ public final class FieldNumber extends Field<FieldNumber.Observer> {
     }
 
     /**
-     * @return The formatted string version of the input.
+     * @return The formatted (human readable) string version of the input.
      */
     public String getValueString() {
         return mFormatter.format(mValue);
@@ -258,8 +258,8 @@ public final class FieldNumber extends Field<FieldNumber.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(Double.toString(mValue));
+    public String getSerializedValue() {
+        return Double.toString(mValue);
     }
 
     private void onValueChanged(double oldValue, double newValue) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
@@ -78,8 +78,8 @@ public final class FieldVariable extends Field<FieldVariable.Observer> {
     }
 
     @Override
-    protected void serializeInner(XmlSerializer serializer) throws IOException {
-        serializer.text(mVariable);
+    public String getSerializedValue() {
+        return mVariable;
     }
 
     private void onVariableChanged(com.google.blockly.model.FieldVariable field, String oldVar, String newVar) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
@@ -399,6 +399,11 @@ public abstract class Input implements Cloneable {
         return ALIGN_LEFT;
     }
 
+    @Nullable
+    public Block getConnectedBlock() {
+        return (mConnection == null) ? null : mConnection.getTargetBlock();
+    }
+
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({TYPE_VALUE, TYPE_STATEMENT, TYPE_DUMMY})
     public @interface InputType {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * The root class for the Blockly model.  Keeps track of all the global state used in the workspace.
@@ -39,7 +40,10 @@ public class Workspace {
     private static final String TAG = "Workspace";
     private static final boolean DEBUG = true;
 
+    private final Context mContext;
     private final BlocklyController mController;
+    private BlockFactory mBlockFactory;
+    private String mId;
 
     private final ArrayList<Block> mRootBlocks = new ArrayList<>();
     private final ProcedureManager mProcedureManager = new ProcedureManager();
@@ -49,9 +53,7 @@ public class Workspace {
             new WorkspaceStats(mVariableNameManager, mProcedureManager,
                     mConnectionManager);
     private final List<Block> mDeletedBlocks = new LinkedList<>();
-    private final Context mContext;
     private ToolboxCategory mToolboxCategory;
-    private BlockFactory mBlockFactory;
 
     private List<Connection> mTempConnections = new ArrayList<>();
 
@@ -72,6 +74,11 @@ public class Workspace {
         mContext = context;
         mController = controller;
         mBlockFactory = factory;
+        mId = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return mId;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
@@ -32,6 +32,10 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -80,7 +84,7 @@ public final class BlocklyXmlHelper {
      */
     public static void loadFromXml(InputStream is, BlockFactory blockFactory, WorkspaceStats stats,
             List<Block> result) throws BlocklyParserException {
-        loadBlocksFromXml(is, blockFactory, stats, result);
+        loadBlocksFromXml(is, null, blockFactory, stats, result);
     }
 
     /**
@@ -89,7 +93,7 @@ public final class BlocklyXmlHelper {
     public static List<Block> loadFromXml(InputStream is, BlockFactory blockFactory,
             WorkspaceStats stats) throws BlocklyParserException {
         List<Block> result = new ArrayList<>();
-        loadBlocksFromXml(is, blockFactory, stats, result);
+        loadBlocksFromXml(is, null, blockFactory, stats, result);
         return result;
     }
 
@@ -106,25 +110,78 @@ public final class BlocklyXmlHelper {
     public static Block loadOneBlockFromXml(InputStream is, BlockFactory blockFactory)
             throws BlocklyParserException {
         List<Block> temp = loadFromXml(is, blockFactory, null);
-        if (temp == null || temp.isEmpty()) {
+        if (temp.isEmpty()) {
             return null;
         }
         return temp.get(0);
     }
 
     /**
+     * Convenience function to load only one Block.
+     *
+     * @param xml The XML in string form to read the block from.
+     * @param blockFactory The BlockFactory for the workspace where the Blocks are being loaded.
+     *
+     * @return The first Block read from is, or null if no Block was read.
+     * @throws BlocklyParserException
+     */
+    @Nullable
+    public static Block loadOneBlockFromXml(String xml, BlockFactory blockFactory)
+            throws BlocklyParserException {
+        List<Block> result = new ArrayList<>();
+        loadBlocksFromXml(null, xml, blockFactory, null, result);
+        if (result.isEmpty()) {
+            return null;
+        }
+        return result.get(0);
+    }
+
+    /**
      * Serializes all Blocks in the given list and writes them to the given output stream.
      *
      * @param toSerialize A list of Blocks to serialize.
-     * @param os An OutputStream to which to write them.
+     * @param os An OutputStream to write the blocks to.
      *
      * @throws BlocklySerializerException
      */
     public static void writeToXml(List<Block> toSerialize, OutputStream os)
             throws BlocklySerializerException {
+        writeToXmlImpl(toSerialize, os, null);
+    }
+
+    /**
+     * Serializes all Blocks in the given list and writes them to the given writer.
+     *
+     * @param toSerialize A list of Blocks to serialize.
+     * @param writer A writer to write the blocks to.
+     *
+     * @throws BlocklySerializerException
+     */
+    public static void writeToXml(List<Block> toSerialize, Writer writer)
+            throws BlocklySerializerException {
+        writeToXmlImpl(toSerialize, null, writer);
+    }
+
+    /**
+     * Serializes all Blocks in the given list and writes them to the either the output stream or
+     * writer, whichever is not null.
+     *
+     * @param toSerialize A list of Blocks to serialize.
+     * @param os An OutputStream to write the blocks to.
+     * @param writer A writer to write the blocks to, if {@code os} is null.
+     *
+     * @throws BlocklySerializerException
+     */
+    public static void writeToXmlImpl(List<Block> toSerialize, @Nullable OutputStream os,
+                                      @Nullable Writer writer)
+            throws BlocklySerializerException {
         try {
             XmlSerializer serializer = mParserFactory.newSerializer();
-            serializer.setOutput(os, null);
+            if (os != null) {
+                serializer.setOutput(os, null);
+            } else {
+                serializer.setOutput(writer);
+            }
             serializer.setPrefix("", XML_NAMESPACE);
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
 
@@ -155,21 +212,51 @@ public final class BlocklyXmlHelper {
     }
 
     /**
+     * Convenience function to serialize only one Block.
+     *
+     * @param toSerialize A Block to serialize.
+     * @return XML string for block and all descendant blocks.
+     * @throws BlocklySerializerException
+     */
+    public static String writeOneBlockToXml(Block toSerialize)
+            throws BlocklySerializerException {
+        StringWriter sw = new StringWriter();
+        List<Block> temp = new ArrayList<>();
+        temp.add(toSerialize);
+        writeToXml(temp, sw);
+        String xmlString = sw.toString();
+        try {
+            sw.close();
+            return xmlString;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
      * Loads a list of top-level Blocks from XML.  Each top-level Block may have many Blocks
      * contained in it or descending from it.
      *
-     * @param is The input stream from which to read.
+     * @param inStream The input stream to read blocks from. Maybe null.
+     * @param inString The xml string to read blocks from if {@code insStream} is null.
      * @param blockFactory The BlockFactory for the workspace where the Blocks are being loaded.
      *
      * @return A list of top-level Blocks.
      * @throws BlocklyParserException
      */
     private static void loadBlocksFromXml(
-            InputStream is, BlockFactory blockFactory, WorkspaceStats stats, List<Block> result)
+            InputStream inStream, String inString, BlockFactory blockFactory, WorkspaceStats stats,
+            List<Block> result)
             throws BlocklyParserException {
+        StringReader reader = null;
         try {
             XmlPullParser parser = mParserFactory.newPullParser();
-            parser.setInput(is, null);
+            if (inStream != null) {
+                parser.setInput(inStream, null);
+            } else {
+                reader = new StringReader(inString);
+                parser.setInput(reader);
+            }
             int eventType = parser.getEventType();
             while (eventType != XmlPullParser.END_DOCUMENT) {
                 switch (eventType) {
@@ -192,6 +279,9 @@ public final class BlocklyXmlHelper {
             }
         } catch (XmlPullParserException | IOException e) {
             throw new BlocklyParserException(e);
+        }
+        if (reader != null) {
+            reader.close();
         }
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -59,7 +59,6 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
                 .build();
         mBlockFactory = mController.getBlockFactory();
         mWorkspace = mController.getWorkspace();
-        mHelper = mController.getWorkspaceHelper();
         mConnectionManager = mController.getWorkspace().getConnectionManager();
 
         mWorkspaceView = new WorkspaceView(getContext());

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
@@ -1,0 +1,162 @@
+package com.google.blockly.model;
+
+import com.google.blockly.android.MockitoAndroidTestCase;
+
+import com.google.blockly.android.control.BlocklyEvent;
+import com.google.blockly.utils.BlocklyXmlHelper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link BlocklyEvent} classes.
+ */
+public class BlocklyEventTest extends MockitoAndroidTestCase {
+    private static final String BLOCK_TYPE = "controls_whileUntil";
+    private static final String BLOCK_ID = "block";
+    private static final String FIELD_NAME = "MODE";
+    private static final String WORKSPACE_ID = "workspace";
+
+    private static final int NEW_POSITION_X = 123;
+    private static final int NEW_POSITION_Y = 456;
+    private static final WorkspacePoint NEW_POSITION =
+            new WorkspacePoint(NEW_POSITION_X, NEW_POSITION_Y);
+
+    @Mock Workspace mMockWorkspace;
+
+    BlockFactory mBlockFactory;
+    Block mBlock;
+    Field mField;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        mBlockFactory = new BlockFactory(getContext(),
+                new int[]{com.google.blockly.android.R.raw.test_blocks});
+        mBlock = mBlockFactory.obtainBlock(BLOCK_TYPE, BLOCK_ID);
+        mField = mBlock.getFieldByName(FIELD_NAME);
+        mBlock.setPosition(NEW_POSITION_X, NEW_POSITION_Y);
+
+
+        Mockito.when(mMockWorkspace.getId()).thenReturn(WORKSPACE_ID);
+    }
+
+    public void testChangeEvent_collapsedState() throws JSONException {
+        boolean newValue = mBlock.isCollapsed();
+        boolean oldValue = !newValue;
+        BlocklyEvent.ChangeEvent event =
+                BlocklyEvent.ChangeEvent.newCollapsedStateEvent(mMockWorkspace, mBlock);
+        testChangeEvent(BlocklyEvent.ELEMENT_COLLAPSED, event,
+                        oldValue ? "true" : "false",
+                        newValue ? "true" : "false");
+    }
+
+    public void testChangeEvent_commentText() throws JSONException {
+        String oldValue = "old comment";
+        String newValue = "new comment";
+        BlocklyEvent.ChangeEvent event = BlocklyEvent.ChangeEvent.newCommentTextEvent(
+                mMockWorkspace, mBlock, oldValue, newValue);
+        testChangeEvent(BlocklyEvent.ELEMENT_COMMENT, event, oldValue, newValue);
+    }
+
+    public void testChangeEvent_disabledState() throws JSONException {
+        boolean newValue = mBlock.isDisabled();
+        boolean oldValue = !newValue;
+        BlocklyEvent.ChangeEvent event =
+                BlocklyEvent.ChangeEvent.newDisabledStateEvent(mMockWorkspace, mBlock);
+        testChangeEvent(BlocklyEvent.ELEMENT_DISABLED, event,
+                oldValue ? "true" : "false",
+                newValue ? "true" : "false");
+    }
+
+    public void testChangeEvent_fieldValue() throws JSONException {
+        String oldValue = "UNTIL";
+        String newValue = "WHILE";
+        mField.setFromString(newValue);
+        BlocklyEvent.ChangeEvent event = BlocklyEvent.ChangeEvent.newFieldValueEvent(
+                mMockWorkspace, mBlock, mField, oldValue, newValue);
+        testChangeEvent(BlocklyEvent.ELEMENT_FIELD, event, oldValue, newValue);
+    }
+
+    public void testChangeEvent_inlineState() throws JSONException {
+        boolean newValue = mBlock.getInputsInline();
+        boolean oldValue = !newValue;
+        BlocklyEvent.ChangeEvent event =
+                BlocklyEvent.ChangeEvent.newInlineStateEvent(mMockWorkspace, mBlock);
+        testChangeEvent(BlocklyEvent.ELEMENT_INLINE, event,
+                oldValue ? "true" : "false",
+                newValue ? "true" : "false");
+    }
+
+    public void testChangeEvent_mutation() throws JSONException {
+        String oldValue = "old mutation";
+        String newValue = "new mutation";
+        BlocklyEvent.ChangeEvent event = BlocklyEvent.ChangeEvent.newMutateEvent(
+                mMockWorkspace, mBlock, oldValue, newValue);
+        testChangeEvent(BlocklyEvent.ELEMENT_MUTATE, event, oldValue, newValue);
+    }
+
+    private void testChangeEvent(@BlocklyEvent.ChangeElement String element,
+                                 BlocklyEvent.ChangeEvent event,
+                                 String oldValue, String newValue)
+            throws JSONException {
+        assertSame(event.getTypeId(), BlocklyEvent.TYPE_CHANGE);
+        assertSame(event.getTypeName(), BlocklyEvent.TYPENAME_CHANGE);
+        assertEquals(WORKSPACE_ID, event.getWorkspaceId());
+        // Group id is assigned by the BlocklyController, not tested here.
+        assertEquals(element, event.getElement());
+        assertEquals(oldValue, event.getOldValue());
+        assertEquals(newValue, event.getNewValue());
+        if (element == BlocklyEvent.ELEMENT_FIELD) {
+            assertEquals(FIELD_NAME, event.getFieldName());
+        }
+
+        String serialized = event.toJsonString();
+        JSONObject json = new JSONObject(serialized);
+
+        BlocklyEvent.ChangeEvent deserializedEvent =
+                (BlocklyEvent.ChangeEvent) BlocklyEvent.fromJson(json);
+        assertEquals(event.getTypeName(), deserializedEvent.getTypeName());
+        // Workspace ids are not serialized.
+        // Group id is assigned by the BlocklyController, not tested here.
+        assertEquals(element, deserializedEvent.getElement());
+        assertEquals(BLOCK_ID, deserializedEvent.getBlockId());
+        assertEquals(newValue, deserializedEvent.getNewValue());
+        if (element == BlocklyEvent.ELEMENT_FIELD) {
+            assertEquals(FIELD_NAME, deserializedEvent.getFieldName());
+        }
+    }
+
+    public void testCreateEvent() throws JSONException {
+        BlocklyEvent.CreateEvent event = new BlocklyEvent.CreateEvent(mMockWorkspace, mBlock);
+
+        assertSame(event.getTypeId(), BlocklyEvent.TYPE_CREATE);
+        assertSame(event.getTypeName(), BlocklyEvent.TYPENAME_CREATE);
+        assertEquals(WORKSPACE_ID, event.getWorkspaceId());
+        // Group id is assigned by the BlocklyController, not tested here.
+        assertEquals(1, event.getIds().size());
+        assertEquals(BLOCK_ID, event.getIds().get(0));
+
+        String serialized = event.toJsonString();
+        JSONObject json = new JSONObject(serialized);
+
+        BlocklyEvent.CreateEvent deserializedEvent =
+                (BlocklyEvent.CreateEvent) BlocklyEvent.fromJson(json);
+        assertEquals(event.getTypeName(), deserializedEvent.getTypeName());
+        // Workspace ids are not serialized.
+        // Group id is assigned by the BlocklyController, not tested here.
+        assertEquals(BLOCK_ID, deserializedEvent.getBlockId());
+        assertEquals(1, deserializedEvent.getIds().size());
+        assertEquals(BLOCK_ID, deserializedEvent.getIds().get(0));
+
+        mBlockFactory.clearPriorBlockReferences(); // Prevent duplicate block id errors.
+        Block deserializedBlock =
+                BlocklyXmlHelper.loadOneBlockFromXml(deserializedEvent.getXml(), mBlockFactory);
+        assertEquals(BLOCK_ID, deserializedBlock.getId());
+        assertEquals(BLOCK_TYPE, mBlock.getType());
+        assertEquals(NEW_POSITION, mBlock.getPosition());
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
@@ -38,7 +38,7 @@ public class FieldDropdownTest extends AndroidTestCase {
         assertEquals(displayNames.length, field.getDisplayNames().size());
         for (int i = 0; i < values.length; i++) {
             field.setSelectedIndex(i);
-            assertEquals(values[i], field.getSelectedValue());
+            assertEquals(values[i], field.getSerializedValue());
             assertEquals(displayNames[i], field.getSelectedDisplayName());
             assertEquals(displayNames[i], fieldDisplayNames.get(i));
         }
@@ -56,7 +56,7 @@ public class FieldDropdownTest extends AndroidTestCase {
         assertEquals(displayNames.length, field.getDisplayNames().size());
         for (int i = 0; i < values.length; i++) {
             field.setSelectedIndex(i);
-            assertEquals(values[i], field.getSelectedValue());
+            assertEquals(values[i], field.getSerializedValue());
             assertEquals(displayNames[i], field.getSelectedDisplayName());
             assertEquals(displayNames[i], fieldDisplayNames.get(i));
         }
@@ -65,25 +65,25 @@ public class FieldDropdownTest extends AndroidTestCase {
         field.setSelectedIndex(1);
         assertEquals(1, field.getSelectedIndex());
         assertEquals(displayNames[1], field.getSelectedDisplayName());
-        assertEquals(values[1], field.getSelectedValue());
+        assertEquals(values[1], field.getSerializedValue());
 
         // test setting by value
         field.setSelectedValue(values[2]);
         assertEquals(2, field.getSelectedIndex());
         assertEquals(displayNames[2], field.getSelectedDisplayName());
-        assertEquals(values[2], field.getSelectedValue());
+        assertEquals(values[2], field.getSerializedValue());
 
         // xml parsing
         assertTrue(field.setFromString(values[1]));
         assertEquals(1, field.getSelectedIndex());
         assertEquals(displayNames[1], field.getSelectedDisplayName());
-        assertEquals(values[1], field.getSelectedValue());
+        assertEquals(values[1], field.getSerializedValue());
 
         // xml parsing; setting a non-existent value defaults to 0
         assertTrue(field.setFromString(""));
         assertEquals(0, field.getSelectedIndex());
         assertEquals(displayNames[0], field.getSelectedDisplayName());
-        assertEquals(values[0], field.getSelectedValue());
+        assertEquals(values[0], field.getSerializedValue());
 
         try {
             // test setting out of bounds
@@ -97,13 +97,13 @@ public class FieldDropdownTest extends AndroidTestCase {
         field.setSelectedValue("blah");
         assertEquals(0, field.getSelectedIndex());
         assertEquals(displayNames[0], field.getSelectedDisplayName());
-        assertEquals(values[0], field.getSelectedValue());
+        assertEquals(values[0], field.getSerializedValue());
 
         // swap the values/display names and verify it was updated.
         field.setOptions(Arrays.asList(displayNames), Arrays.asList(values));
         for (int i = 0; i < values.length; i++) {
             field.setSelectedIndex(i);
-            assertEquals(displayNames[i], field.getSelectedValue());
+            assertEquals(displayNames[i], field.getSerializedValue());
             assertEquals(values[i], field.getSelectedDisplayName());
         }
     }


### PR DESCRIPTION
Event classes, listener hooks, and one listener implementation. DevTests activity now has a "Log Events" checkbox in it's action bar menu.  Create event works end-to-end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/335)
<!-- Reviewable:end -->
