### PR TITLE
Removing code coverage support from debug builds.

### DIFF
--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -15,11 +15,6 @@ android {
         release {
             minifyEnabled false
         }
-        debug {
-            // To generate code coverage run './gradlew connectedCheck'.
-            // Coverage report at blocklylib/build/reports/coverage/debug/index.html
-            testCoverageEnabled true
-        }
     }
 
     packagingOptions {


### PR DESCRIPTION
Code coverage was unnecessarily pulling in jacoco classes into the debug build .aar, causing problems for several users.  This removes code coverage (which was not working properly, anyway), which will eventually be fixed in another build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/341)
<!-- Reviewable:end -->
