### PR TITLE
Add basic support for renaming/creating variables

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -126,7 +126,7 @@
             <field name="NOTE">60</field>
         </block>
     </category>
-    <category name="Variables">
+    <category name="Variables" custom="VARIABLE">
         <block type="variables_set"></block>
         <block type="variables_get"></block>
     </category>

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -90,6 +90,9 @@ public class DevTestsActivity extends BlocklySectionsActivity {
         } else if (id == R.id.action_spaghetti) {
             loadSpaghetti();
             return true;
+        } else if (id == R.id.action_create_variable) {
+            getController().requestAddVariable("item");
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/blocklydemo/src/main/res/menu/dev_actionbar.xml
+++ b/blocklydemo/src/main/res/menu/dev_actionbar.xml
@@ -25,5 +25,7 @@
           android:orderInCategory="91" app:showAsAction="never"/>
     <item android:id="@+id/action_spaghetti" android:title="@string/action_spaghetti"
           android:orderInCategory="92" app:showAsAction="never"/>
+    <item android:id="@+id/action_create_variable" android:title="@string/create_variable"
+          android:orderInCategory="93" app:showAsAction="never" />
 
 </menu>

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -46,6 +46,7 @@ import com.google.blockly.android.codegen.CodeGeneratorService;
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.BlockViewFactory;
 import com.google.blockly.android.ui.DeleteVariableDialog;
+import com.google.blockly.android.ui.NameVariableDialog;
 import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.android.ui.BlocklyUnifiedWorkspace;
 import com.google.blockly.android.codegen.CodeGenerationRequest;
@@ -495,7 +496,8 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      */
     protected BlocklyController.VariableCallback getVariableCallback() {
         if (mVariableCb == null) {
-            mVariableCb = new DefaultVariableCallback(new DeleteVariableDialog());
+            mVariableCb = new DefaultVariableCallback(new DeleteVariableDialog(),
+                    new NameVariableDialog());
         }
         return mVariableCb;
     }
@@ -836,10 +838,28 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
 
     private class DefaultVariableCallback extends BlocklyController.VariableCallback {
         private final DeleteVariableDialog mDeleteDialog;
+        private final NameVariableDialog mNameDialog;
+
+        private final NameVariableDialog.Callback mRenameCallback = new NameVariableDialog
+                .Callback() {
+            @Override
+            public void onNameConfirmed(String oldName, String newName) {
+                getController().renameVariable(oldName, newName);
+            }
+        };
+        private final NameVariableDialog.Callback mCreateCallback = new NameVariableDialog
+                .Callback() {
+            @Override
+            public void onNameConfirmed(String originalName, String newName) {
+                getController().addVariable(newName);
+            }
+        };
 
 
-        public DefaultVariableCallback(DeleteVariableDialog deleteVariableDialog) {
+        public DefaultVariableCallback(DeleteVariableDialog deleteVariableDialog,
+                NameVariableDialog nameVariableDialog) {
             mDeleteDialog = deleteVariableDialog;
+            mNameDialog = nameVariableDialog;
         }
 
         @Override
@@ -857,6 +877,20 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
             mDeleteDialog.setController(controller);
             mDeleteDialog.setVariable(variable, blocks.size());
             mDeleteDialog.show(getSupportFragmentManager(), "DeleteVariable");
+            return false;
+        }
+
+        @Override
+        public boolean onRenameVariable(String variable, String newName) {
+            mNameDialog.setVariable(variable, mRenameCallback);
+            mNameDialog.show(getSupportFragmentManager(), "RenameVariable");
+            return false;
+        }
+
+        @Override
+        public boolean onCreateVariable(String variable) {
+            mNameDialog.setVariable(variable, mCreateCallback);
+            mNameDialog.show(getSupportFragmentManager(), "CreateVariable");
             return false;
         }
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/NameVariableDialog.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/NameVariableDialog.java
@@ -1,0 +1,65 @@
+package com.google.blockly.android.ui;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import com.google.blockly.android.R;
+import com.google.blockly.android.control.BlocklyController;
+
+/**
+ * Default dialog window shown when creating or renaming a variable in the workspace.
+ */
+public class NameVariableDialog extends DialogFragment {
+    private String mVariable;
+    private DialogInterface.OnClickListener mListener;
+    private EditText mNameEditText;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceBundle) {
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+        View nameView = inflater.inflate(R.layout.name_variable_view, null);
+        mNameEditText = (EditText) nameView.findViewById(R.id.name);
+        mNameEditText.setText(mVariable);
+
+        AlertDialog.Builder bob = new AlertDialog.Builder(getActivity());
+        bob.setTitle(R.string.name_variable_title);
+        bob.setView(nameView);
+        bob.setPositiveButton(R.string.name_variable_positive, mListener);
+        bob.setNegativeButton(R.string.name_variable_negative, mListener);
+        return bob.create();
+    }
+
+    public void setVariable(String variable, final Callback clickListener) {
+        if (clickListener == null) {
+            throw new IllegalArgumentException("Must have a listener to perform an action.");
+        }
+        mVariable = variable;
+        mListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                switch (which) {
+                    case AlertDialog.BUTTON_POSITIVE:
+                        clickListener.onNameConfirmed(mVariable,
+                                mNameEditText.getText().toString());
+                        break;
+                    case AlertDialog.BUTTON_NEGATIVE:
+                        clickListener.onNameCanceled(mVariable);
+                        break;
+                }
+            }
+        };
+    }
+
+    public abstract static class Callback {
+        public abstract void onNameConfirmed(String originalName, String newName);
+        public void onNameCanceled(String originalName) {
+            // Do nothing by default
+        }
+    }
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -22,6 +22,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
@@ -42,7 +43,7 @@ public class BasicFieldVariableView extends Spinner implements FieldView, Variab
     protected FieldVariable.Observer mFieldObserver = new FieldVariable.Observer() {
         @Override
         public void onVariableChanged(FieldVariable field, String oldVar, String newVar) {
-            setSelection(mVariableField.getVariable());
+            refreshSelection();
         }
     };
 
@@ -86,7 +87,7 @@ public class BasicFieldVariableView extends Spinner implements FieldView, Variab
         mVariableField = variableField;
         if (mVariableField != null) {
             // Update immediately.
-            setSelection(mVariableField.getVariable());
+            refreshSelection();
             mVariableField.registerObserver(mFieldObserver);
         } else {
             setSelection(0);
@@ -139,13 +140,13 @@ public class BasicFieldVariableView extends Spinner implements FieldView, Variab
 
         if (adapter != null) {
             if (mVariableField != null) {
-                setSelection(mVariableField.getVariable());
+                refreshSelection();
             }
             mAdapter.registerDataSetObserver(new DataSetObserver() {
                 @Override
                 public void onChanged() {
                     if (mVariableField != null) {
-                        setSelection(mVariableField.getVariable());
+                        refreshSelection();
                     }
                 }
             });
@@ -163,22 +164,20 @@ public class BasicFieldVariableView extends Spinner implements FieldView, Variab
     }
 
     /**
-     * Set the selection from a variable name, ignoring case. The variable must be a variable in
-     * the workspace.
-     *
-     * @param variableName The name of the variable, ignoring case.
+     * Updates the selection from the field. This is used when the indices may have changed to
+     * ensure the correct index is selected.
      */
-    private void setSelection(final String variableName) {
-        if (TextUtils.isEmpty(variableName)) {
-            throw new IllegalArgumentException("Cannot set an empty variable name.");
-        }
+    private void refreshSelection() {
         if (mAdapter != null) {
             // Because this may change the available indices, we want to make sure each assignment
             // is in its own event tick.
             mMainHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    setSelection(mAdapter.getOrCreateVariableIndex(variableName));
+                    if (mVariableField != null) {
+                        setSelection(mAdapter
+                                .getOrCreateVariableIndex(mVariableField.getVariable()));
+                    }
                 }
             });
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/ToolboxCategory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/ToolboxCategory.java
@@ -43,10 +43,15 @@ public class ToolboxCategory {
     private final List<Block> mBlocks = new ArrayList<>();
     // As displayed in the toolbox.
     private String mCategoryName;
+    private String mCustomType;
     private Integer mColor = null;
 
     public String getCategoryName() {
         return mCategoryName;
+    }
+
+    public String getCustomType() {
+        return mCustomType;
     }
 
     public List<Block> getBlocks() {
@@ -116,6 +121,7 @@ public class ToolboxCategory {
             throws IOException, XmlPullParserException {
         ToolboxCategory result = new ToolboxCategory();
         result.mCategoryName = parser.getAttributeValue("", "name");
+        result.mCustomType = parser.getAttributeValue("", "custom");
         String colourAttr = parser.getAttributeValue("", "colour");
         if (!TextUtils.isEmpty(colourAttr)) {
             try {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
@@ -236,7 +236,12 @@ public class Workspace {
      * @return The list of fields that are using the given variable.
      */
     public List<FieldVariable> getVariableRefs(String variable) {
-        return mStats.getVariableReferences().get(variable);
+        List<FieldVariable> refs = mStats.getVariableReferences().get(variable);
+        List<FieldVariable> copy = new ArrayList<>(refs == null ? 0 : refs.size());
+        if (refs != null) {
+            copy.addAll(refs);
+        }
+        return copy;
     }
 
     /**

--- a/blocklylib-core/src/main/res/layout/blockly_variable_name_dialog.xml
+++ b/blocklylib-core/src/main/res/layout/blockly_variable_name_dialog.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/name_variable_message"
+        android:id="@+id/textView"
+        android:layout_gravity="center_horizontal"/>
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/editText"
+        android:maxLines="1"
+        android:layout_gravity="center_horizontal"/>
+</LinearLayout>

--- a/blocklylib-core/src/main/res/layout/name_variable_view.xml
+++ b/blocklylib-core/src/main/res/layout/name_variable_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/name_variable_message"
+        android:id="@+id/description"
+        android:layout_gravity="center_horizontal"/>
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/name"
+        android:layout_gravity="center_horizontal"
+        android:singleLine="true"/>
+</LinearLayout>

--- a/blocklylib-core/src/main/res/values/strings.xml
+++ b/blocklylib-core/src/main/res/values/strings.xml
@@ -31,4 +31,10 @@
     <string name="delete_variable_confirm">Delete variable %1$s and %2$d blocks using it?</string>
     <string name="delete_variable_positive">Delete</string>
     <string name="delete_variable_negative">Cancel</string>
+    <!-- Message shown when creating or renaming a variable. -->
+    <string name="name_variable_title">Variable name</string>
+    <string name="name_variable_message">New variable name</string>
+    <string name="name_variable_positive">OK</string>
+    <string name="name_variable_negative">Cancel</string>
+
 </resources>


### PR DESCRIPTION
Work on #22. This adds a basic dialog for creating or renaming a variable
and hooks it up to UI elements. Renaming is done through an item in the
variable field's dropdown. Creating is currently a menu item in the
DevTestsActivity.

TODO:
- Add a create variable button to flyouts with the custom="VARIABLE" tag
- Dynamically create getter/setter blocks in VARIABLE flyouts
- Support variable configuration
- Make the variable dialogs prettier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/350)
<!-- Reviewable:end -->
