### PR TITLE
Add code to escape the String sent to the generator on older versions

### DIFF
--- a/blocklylib-core/src/main/assets/background_compiler.html
+++ b/blocklylib-core/src/main/assets/background_compiler.html
@@ -49,11 +49,11 @@
 <script>
     function generate(blocklyxml) {
       // Parse the XML into a tree.
-      var xmlText = blocklyxml;
       var dom;
       try {
-        dom = Blockly.Xml.textToDom(xmlText)
+        dom = Blockly.Xml.textToDom(blocklyxml);
       } catch (e) {
+        console.log(e);
         alert(e);
         return;
       }
@@ -64,9 +64,13 @@
         var code = Blockly.JavaScript.workspaceToCode(workspace);
         BlocklyJavascriptInterface.execute(code);
       } catch (e) {
-        console.log(e.message);
+        console.log(e);
         BlocklyJavascriptInterface.execute("");
       }
+    }
+
+    function generateEscaped(blocklyxml) {
+      generate(unescape(blocklyxml));
     }
   </script>
 </body>

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlocklyActivityTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlocklyActivityTest.java
@@ -95,5 +95,6 @@ public class BlocklyActivityTest extends ActivityInstrumentationTestCase2<Blockl
                 assertEquals(1.0f, virtualWorkspaceView.getViewScale(), 1e-5);
             }
         });
+        mInstrumentation.waitForIdleSync();
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
@@ -147,6 +147,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
                 Mockito.stub(mMockController.getBlockFactory()).toReturn(mBlockFactory);
                 Mockito.stub(mMockController.getWorkspace()).toReturn(mMockWorkspace);
                 Mockito.stub(mMockController.getWorkspaceHelper()).toReturn(mWorkspaceHelper);
+                Mockito.stub(mMockController.getContext()).toReturn(mMockContext);
 
                 mDragger = new Dragger(mMockController);
                 mDragger.setWorkspaceView(mWorkspaceView);


### PR DESCRIPTION
Fixes bug #219

There were problems sending special characters to the old Android WebView. This adds
some code to escape and unescape the String sent to the generator on older versions.
We should wait to see if any other issues show up on older versions as there may have
been poor testing of encode/decode operations on older versions.

Also adds a couple fixes for running tests on older versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/357)
<!-- Reviewable:end -->
