### PR TITLE
Fixed #348, incorrect field_number precision rendering.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -86,13 +86,13 @@ public class BasicFieldNumberView extends EditText implements FieldView {
                     // only overwrite if the parsed value differs.
                     if (TextUtils.isEmpty(text)
                             || Double.parseDouble(text.toString()) != newValue) {
-                        setText(field.getValueString());
+                        setText(field.getFormattedValue());
                     }
                 } catch (NumberFormatException e) {
-                    setText(field.getValueString());
+                    setText(field.getFormattedValue());
                 }
             } catch (NumberFormatException e) {
-                setText(field.getValueString());
+                setText(field.getFormattedValue());
             }
         }
 
@@ -133,7 +133,7 @@ public class BasicFieldNumberView extends EditText implements FieldView {
                 // Replace empty string with value closest to zero.
                 mNumberField.setValue(0);
             }
-            setText(mNumberField.getSerializedValue());
+            setText(mNumberField.getFormattedValue());
             setTextValid(true);
         }
     }
@@ -151,7 +151,7 @@ public class BasicFieldNumberView extends EditText implements FieldView {
         mNumberField = number;
         if (mNumberField != null) {
             updateInputMethod();
-            setText(mNumberField.getSerializedValue());
+            setText(mNumberField.getFormattedValue());
             mNumberField.registerObserver(mFieldObserver);
         } else {
             setText("");

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
@@ -218,7 +218,7 @@ public final class FieldNumber extends Field<FieldNumber.Observer> {
     /**
      * @return The formatted (human readable) string version of the input.
      */
-    public String getValueString() {
+    public CharSequence getFormattedValue() {
         return mFormatter.format(mValue);
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
@@ -179,47 +179,47 @@ public class FieldNumberTest extends MockitoAndroidTestCase {
         // Exact values
         mField.setValue(0.0);
         assertEquals(0.0, mField.getValue());
-        assertEquals("0", mField.getValueString());
+        assertEquals("0", mField.getFormattedValue());
 
         mField.setValue(0.25);
         assertEquals(0.25, mField.getValue());
-        assertEquals("0.25", mField.getValueString());
+        assertEquals("0.25", mField.getFormattedValue());
 
         mField.setValue(1.0);
         assertEquals(1.0, mField.getValue());
-        assertEquals("1", mField.getValueString());
+        assertEquals("1", mField.getFormattedValue());
 
         mField.setValue(1.25);
         assertEquals(1.25, mField.getValue());
-        assertEquals("1.25", mField.getValueString());
+        assertEquals("1.25", mField.getFormattedValue());
 
         mField.setValue(2.50);
         assertEquals(2.5, mField.getValue());
-        assertEquals("2.5", mField.getValueString());
+        assertEquals("2.5", mField.getFormattedValue());
 
         mField.setValue(25);
         assertEquals(25.0, mField.getValue());
-        assertEquals("25", mField.getValueString());
+        assertEquals("25", mField.getFormattedValue());
 
         mField.setValue(-0.25);
         assertEquals(-0.25, mField.getValue());
-        assertEquals("-0.25", mField.getValueString());
+        assertEquals("-0.25", mField.getFormattedValue());
 
         mField.setValue(-1.0);
         assertEquals(-1.0, mField.getValue());
-        assertEquals("-1", mField.getValueString());
+        assertEquals("-1", mField.getFormattedValue());
 
         mField.setValue(-1.25);
         assertEquals(-1.25, mField.getValue());
-        assertEquals("-1.25", mField.getValueString());
+        assertEquals("-1.25", mField.getFormattedValue());
 
         mField.setValue(-2.50);
         assertEquals(-2.5, mField.getValue());
-        assertEquals("-2.5", mField.getValueString());
+        assertEquals("-2.5", mField.getFormattedValue());
 
         mField.setValue(-25);
         assertEquals(-25.0, mField.getValue());
-        assertEquals("-25", mField.getValueString());
+        assertEquals("-25", mField.getFormattedValue());
 
         // Rounded Values
         mField.setValue(0.2);
@@ -252,55 +252,55 @@ public class FieldNumberTest extends MockitoAndroidTestCase {
         // Exact values
         mField.setValue(0.0);
         assertEquals(0.0, mField.getValue());
-        assertEquals("0", mField.getValueString());
+        assertEquals("0", mField.getFormattedValue());
 
         mField.setValue(1.0);
         assertEquals(1.0, mField.getValue());
-        assertEquals("1", mField.getValueString());
+        assertEquals("1", mField.getFormattedValue());
 
         mField.setValue(2.0);
         assertEquals(2.0, mField.getValue());
-        assertEquals("2", mField.getValueString());
+        assertEquals("2", mField.getFormattedValue());
 
         mField.setValue(7.0);
         assertEquals(7.0, mField.getValue());
-        assertEquals("7", mField.getValueString());
+        assertEquals("7", mField.getFormattedValue());
 
         mField.setValue(10.0);
         assertEquals(10.0, mField.getValue());
-        assertEquals("10", mField.getValueString());
+        assertEquals("10", mField.getFormattedValue());
 
         mField.setValue(100.0);
         assertEquals(100.0, mField.getValue());
-        assertEquals("100", mField.getValueString());
+        assertEquals("100", mField.getFormattedValue());
 
         mField.setValue(1000000.0);
         assertEquals(1000000.0, mField.getValue());
-        assertEquals("1000000", mField.getValueString());
+        assertEquals("1000000", mField.getFormattedValue());
 
         mField.setValue(-1.0);
         assertEquals(-1.0, mField.getValue());
-        assertEquals("-1", mField.getValueString());
+        assertEquals("-1", mField.getFormattedValue());
 
         mField.setValue(-2.0);
         assertEquals(-2.0, mField.getValue());
-        assertEquals("-2", mField.getValueString());
+        assertEquals("-2", mField.getFormattedValue());
 
         mField.setValue(-7.0);
         assertEquals(-7.0, mField.getValue());
-        assertEquals("-7", mField.getValueString());
+        assertEquals("-7", mField.getFormattedValue());
 
         mField.setValue(-10.0);
         assertEquals(-10.0, mField.getValue());
-        assertEquals("-10", mField.getValueString());
+        assertEquals("-10", mField.getFormattedValue());
 
         mField.setValue(-100.0);
         assertEquals(-100.0, mField.getValue());
-        assertEquals("-100", mField.getValueString());
+        assertEquals("-100", mField.getFormattedValue());
 
         mField.setValue(-1000000.0);
         assertEquals(-1000000.0, mField.getValue());
-        assertEquals("-1000000", mField.getValueString());
+        assertEquals("-1000000", mField.getFormattedValue());
 
 
         // Rounded Values
@@ -346,27 +346,27 @@ public class FieldNumberTest extends MockitoAndroidTestCase {
         // Exact values
         mField.setValue(0.0);
         assertEquals(0.0, mField.getValue());
-        assertEquals("0", mField.getValueString());
+        assertEquals("0", mField.getFormattedValue());
 
         mField.setValue(2.0);
         assertEquals(2.0, mField.getValue());
-        assertEquals("2", mField.getValueString());
+        assertEquals("2", mField.getFormattedValue());
 
         mField.setValue(8.0);
         assertEquals(8.0, mField.getValue());
-        assertEquals("8", mField.getValueString());
+        assertEquals("8", mField.getFormattedValue());
 
         mField.setValue(10.0);
         assertEquals(10.0, mField.getValue());
-        assertEquals("10", mField.getValueString());
+        assertEquals("10", mField.getFormattedValue());
 
         mField.setValue(-2.0);
         assertEquals(-2.0, mField.getValue());
-        assertEquals("-2", mField.getValueString());
+        assertEquals("-2", mField.getFormattedValue());
 
         mField.setValue(-8.0);
         assertEquals(-8.0, mField.getValue());
-        assertEquals("-8", mField.getValueString());
+        assertEquals("-8", mField.getFormattedValue());
 
         // Rounded Values
         mField.setValue(0.2);


### PR DESCRIPTION
Fixed #348, incorrect field_number precision rendering.
Also, renamed FieldNumber.getValueString() to .getReadableValueString().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/361)
<!-- Reviewable:end -->
