### PR TITLE
BlocklyController.trashRootBlock(..) now respects the block's deletable flag.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -744,7 +744,10 @@ public class BlocklyController {
 
     /**
      * Remove a block and its descendants from the workspace and put it in the trash, respecting the
-     * block's deletable flag. This is the method to use for user actions.
+     * root block's deletable flag. Use this method for user actions.
+     * <p>
+     * Note: Child blocks marked undeletable may be deleted, and this behavior may change in the
+     * future. See <a href="https://github.com/google/blockly-android/issues/370">issue #370</a>.
      *
      * @param block The block to remove, possibly with descendants attached.
      * @return True if the block was removed, false otherwise.
@@ -758,7 +761,7 @@ public class BlocklyController {
 
     /**
      * Remove a block and its descendants from the workspace and put it in the trash, regardless of
-     * block's deletable state.  This method should only be used by for programmatic manipulation of
+     * block's deletable state.  This method should only be used for programmatic manipulation of
      * the workspace.
      *
      * @param block The block to remove, possibly with descendants attached.
@@ -782,7 +785,8 @@ public class BlocklyController {
      * @param respectDeletable If true, simply returns false when {@code block} is not deletable.
      * @return Whether the block was found among the root blocks and deleted.
      */
-    // TODO(#56) Make this handle any block, not just root blocks.
+    // TODO(#56): Make this handle any block, not just root blocks.
+    // TODO(#370): Handle isDeletable() in child blocks.
     private boolean trashRootBlockImpl(Block block, boolean respectDeletable) {
         if (respectDeletable && !block.isDeletable()) {
             return false;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -52,6 +52,16 @@ public class Dragger {
 
     private static final int TAP_TIMEOUT = ViewConfiguration.getTapTimeout();
 
+    // Modes of finishDragging()
+    private static final int FINISH_BEHAVIOR_DROP = 1;
+    private static final int FINISH_BEHAVIOR_REVERT = 2;
+    private static final int FINISH_BEHAVIOR_DELETED = 3;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({FINISH_BEHAVIOR_DROP, FINISH_BEHAVIOR_REVERT, FINISH_BEHAVIOR_DELETED})
+    public @interface FinishDragBehavior {}
+
+
     /**
      * Interface for processing a drag behavior.
      */
@@ -184,12 +194,18 @@ public class Dragger {
                         // Finalize dragging and reset dragging state flags.
                         // These state flags are still used in the initial phase of figuring out if a
                         // drag has started.
+                        int finishBehavior;
                         if (touchingTrashView(event)) {
-                            dropInTrash();
+                            if (dropInTrash()) {
+                                finishBehavior = FINISH_BEHAVIOR_DELETED;
+                            } else {
+                                finishBehavior = FINISH_BEHAVIOR_REVERT;
+                            }
                         } else {
-                            finishDragging();
+                            maybeConnectDragGroup();
+                            finishBehavior = FINISH_BEHAVIOR_DROP;
                         }
-                        clearPendingDrag();
+                        finishDragging(finishBehavior);
                         return true;    // The drop succeeded.
                     default:
                         break;
@@ -288,16 +304,6 @@ public class Dragger {
         };
     };
 
-    private void clearPendingDrag() {
-        if (mPendingDrag != null) {
-            BlockView blockView = mPendingDrag.getRootDraggedBlockView();
-            if (blockView != null) {
-                ((View) blockView).setPressed(false);
-            } // else, trashing or similar manipulation made the view disappear.
-            mPendingDrag = null;
-        }
-    }
-
     /**
      * Continue dragging the currently moving block.  Called during ACTION_DRAG_LOCATION.
      *
@@ -321,12 +327,9 @@ public class Dragger {
     }
 
     /**
-     * Finish block dragging. Called during ACTION_DRAG_ENDED and ACTION_DROP.
-     * <p/>
-     * This method must be called upon receiving the "up" event that ends an ongoing drag process.
+     * Attempts to connect a dropped drag group with nearby connections
      */
-    @VisibleForTesting
-    void finishDragging() {
+    void maybeConnectDragGroup() {
         Block dragRoot = mPendingDrag.getRootDraggedBlock();
 
         // Maybe snap to connections.
@@ -339,23 +342,42 @@ public class Dragger {
             // new location.
             mController.bumpNeighbors(dragRoot);
         }
+    }
 
-        // Update the drag group so that everything that has been changed will be properly
-        // invalidated. Also, update the positions of all of the connections that were impacted by
-        // the move and add them back to the manager. All of the connection locations will be set
-        // relative to their block views immediately after this loop.  For now we just want to unset
-        // drag mode and add the connections back to the list; 0, 0 is a cheap place to put them.
-        for (int i = 0; i < mDraggedConnections.size(); i++) {
-            Connection cur = mDraggedConnections.get(i);
-            cur.setPosition(0, 0);
-            cur.setDragMode(false);
-            mConnectionManager.addConnection(cur);
+    /**
+     * Finish a drag gesture and clear pending drag info.  Called by event handlers for ACTION_UP,
+     * ACTION_CANCEL, ACTION_DROP, and ACTION_DRAG_ENDED.
+     */
+    // TODO(305): Revert actions when behavior == FINISH_BEHAVIOR_REVERT
+    private void finishDragging(@FinishDragBehavior int behavior) {
+        if (behavior == FINISH_BEHAVIOR_DROP || behavior == FINISH_BEHAVIOR_REVERT) {
+            // Update the drag group so that everything that has been changed will be properly
+            // invalidated. Also, update the positions of all of the connections that were impacted
+            // by the move and add them back to the manager. All of the connection locations will be
+            // set relative to their block views immediately after this loop.  For now we just want
+            // to unset drag mode and add the connections back to the list; 0, 0 is a cheap place to
+            // put them.
+            // Dragged connections may be empty, especially if the
+            for (int i = 0; i < mDraggedConnections.size(); i++) {
+                Connection cur = mDraggedConnections.get(i);
+                cur.setPosition(0, 0);
+                cur.setDragMode(false);
+                mConnectionManager.addConnection(cur);
+            }
         }
         mDraggedConnections.clear();
 
         if (mHighlightedBlockView != null) {
             mHighlightedBlockView.setHighlightedConnection(null);
             mHighlightedBlockView = null;
+        }
+
+        if (mPendingDrag != null) {
+            BlockView blockView = mPendingDrag.getRootDraggedBlockView();
+            if (blockView != null) {
+                ((View) blockView).setPressed(false);
+            } // else, trashing or similar manipulation made the view disappear.
+            mPendingDrag = null;
         }
     }
 
@@ -467,7 +489,7 @@ public class Dragger {
                     if (!interceptMode && mPendingDrag.isClick()) {
                         dragHandler.onBlockClicked(mPendingDrag);
                     }
-                    clearPendingDrag();
+                    finishDragging(FINISH_BEHAVIOR_REVERT);
                 }
                 result = !interceptMode;
             } else {
@@ -586,15 +608,13 @@ public class Dragger {
     /**
      * Ends a drag in the trash can, clearing state and deleting blocks as needed.
      */
-    private void dropInTrash() {
+    private boolean dropInTrash() {
         if (mHighlightedBlockView != null) {
             mHighlightedBlockView.setHighlightedConnection(null);
             mHighlightedBlockView = null;
         }
         mDraggedConnections.clear();
-        if (!mController.trashRootBlock(mPendingDrag.getRootDraggedBlock())) {
-            // TODO(#305):
-        }
+        return mController.trashRootBlock(mPendingDrag.getRootDraggedBlock());
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -592,7 +592,9 @@ public class Dragger {
             mHighlightedBlockView = null;
         }
         mDraggedConnections.clear();
-        mController.trashRootBlock(mPendingDrag.getRootDraggedBlock());
+        if (!mController.trashRootBlock(mPendingDrag.getRootDraggedBlock())) {
+            // TODO(#305):
+        }
     }
 
     /**

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -100,12 +100,38 @@ public class BlocklyControllerTest extends MockitoAndroidTestCase {
         mController.addRootBlock(block);
 
         mEventsFired.clear();
-        mController.trashRootBlock(block);
+        assertTrue(mController.trashRootBlock(block));
 
         assertTrue(mWorkspace.getRootBlocks().isEmpty());
-        assertEquals(mEventsFired.size(), 1);
-        assertEquals(mEventsFired.get(0).getTypeId(), BlocklyEvent.TYPE_DELETE);
-        assertEquals(mEventsFired.get(0).getBlockId(), block.getId());
+        assertEquals(1, mEventsFired.size());
+        assertEquals(BlocklyEvent.TYPE_DELETE, mEventsFired.get(0).getTypeId());
+        assertEquals(block.getId(), mEventsFired.get(0).getBlockId());
+    }
+
+    public void testTrashRootBlockNotDeletable() {
+        Block block = mBlockFactory.obtainBlock("simple_input_output", "connectTarget");
+        block.setDeletable(false);
+        mController.addRootBlock(block);
+
+        mEventsFired.clear();
+        assertFalse(mController.trashRootBlock(block));
+
+        assertEquals(1, mWorkspace.getRootBlocks().size());  // Still there!
+        assertEquals(0, mEventsFired.size());
+    }
+
+    public void testTrashRootBlockIgnoringDeletable() {
+        Block block = mBlockFactory.obtainBlock("simple_input_output", "connectTarget");
+        block.setDeletable(false);
+        mController.addRootBlock(block);
+
+        mEventsFired.clear();
+        assertTrue(mController.trashRootBlockIgnoringDeletable(block));
+
+        assertTrue(mWorkspace.getRootBlocks().isEmpty());
+        assertEquals(1, mEventsFired.size());
+        assertEquals(BlocklyEvent.TYPE_DELETE, mEventsFired.get(0).getTypeId());
+        assertEquals(block.getId(), mEventsFired.get(0).getBlockId());
     }
 
     public void testAddBlockFromTrash() {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
@@ -72,6 +72,8 @@ public class DraggerTest extends MockitoAndroidTestCase {
     DragEvent mDragStartedEvent;
     @Mock
     DragEvent mDragLocationEvent;
+    @Mock
+    DragEvent mDropEvent;
 
     private Context mMockContext;
     private HandlerThread mThread;
@@ -156,6 +158,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
                 // Since we can't create DragEvents...
                 when(mDragStartedEvent.getAction()).thenReturn(DragEvent.ACTION_DRAG_STARTED);
                 when(mDragLocationEvent.getAction()).thenReturn(DragEvent.ACTION_DRAG_LOCATION);
+                when(mDropEvent.getAction()).thenReturn(DragEvent.ACTION_DROP);
             }
         }, TIMEOUT);
 
@@ -167,7 +170,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
         super.tearDown();
     }
 
-/* This set of tests covers the full sequence of dragging operations.
+    /* This set of tests covers the full sequence of dragging operations.
      * Because we're skipping layout, the connector locations will never be exactly perfect.
      * Calling updateConnectorLocations puts all of the connections on a block at the
      * workspace position of that block.
@@ -369,8 +372,7 @@ public class DraggerTest extends MockitoAndroidTestCase {
         runAndSync(new Runnable() {
             @Override
             public void run() {
-                // Pretend to be the last DragEvent that registers, which should be right by the
-                // stationary block.
+                // Mock the last drag location event, which should be right by the stationary block.
                 // getX() returns float, even though we'll cast back to int immediately.
                 when(mDragLocationEvent.getX()).thenReturn(mDragReleaseX);
                 when(mDragLocationEvent.getY()).thenReturn(mDragReleaseY);
@@ -381,7 +383,11 @@ public class DraggerTest extends MockitoAndroidTestCase {
                 mDragGroup.updateAllConnectorLocations();
                 mWorkspaceHelper.getView(mTargetBlock).updateConnectorLocations();
 
-                mDragger.finishDragging();
+                // Mock the drop event, which is in the same place.
+                when(mDropEvent.getX()).thenReturn(mDragReleaseX);
+                when(mDropEvent.getY()).thenReturn(mDragReleaseY);
+
+                mDragger.getDragEventListener().onDrag(mWorkspaceView, mDropEvent);
             }
         }, TIMEOUT);
     }


### PR DESCRIPTION
Also, adding new method .trashRootBlockIgnoringDeletable(..) as a means to override this behavior.
Partial fix for #305.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/368)
<!-- Reviewable:end -->
