### PR TITLE
Make FieldCheckbox use TRUE/FALSE instead of true/false

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
@@ -74,7 +74,7 @@ public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
 
     @Override
     public String getSerializedValue() {
-        return mChecked ? "true" : "false";
+        return mChecked ? "TRUE" : "FALSE";
     }
 
     private void onCheckChanged(boolean newState) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTestStrings.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTestStrings.java
@@ -59,7 +59,7 @@ public class BlockTestStrings {
             + "    {"
             + "      \"type\": \"field_checkbox\","
             + "      \"name\": \"NAME\","
-            + "      \"checked\": true"
+            + "      \"checked\": TRUE"
             + "    },"
             + "    {"
             + "      \"type\": \"input_value\","
@@ -214,7 +214,7 @@ public class BlockTestStrings {
 
     public static final String FRANKENBLOCK_DEFAULT_VALUES_START =
             "<field name=\"text_input\">something</field>"
-            + "<field name=\"checkbox\">true</field>";
+            + "<field name=\"checkbox\">TRUE</field>";
     public static final String FRANKENBLOCK_DEFAULT_VALUES_END =
             "<field name=\"dropdown\">OPTIONNAME1</field>"
             + "<field name=\"variable\">item</field>"


### PR DESCRIPTION
The JS version of blockly is case sensitive and requires all caps for
true and false values.

See https://github.com/google/blockly/issues/653

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/382)
<!-- Reviewable:end -->
