### PR TITLE
Fix #388. Ignore parent/prior text nodes.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -1016,6 +1016,7 @@ public class Block {
             String tagname = parser.getName();
             switch (eventType) {
                 case XmlPullParser.START_TAG:
+                    text = ""; // Ignore text from parent (or prior) block.
                     if (tagname.equalsIgnoreCase("block")) {
                         childBlock = fromXml(parser, factory);
                     } else if (tagname.equalsIgnoreCase("shadow")) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/389)
<!-- Reviewable:end -->
