### PR TITLE
Start the toolbox closed. Adding custom="VARIABLE"

### DIFF
--- a/blocklydemo/src/main/assets/turtle/toolbox_advanced.xml
+++ b/blocklydemo/src/main/assets/turtle/toolbox_advanced.xml
@@ -223,7 +223,7 @@
         </block>
         <block type="math_random_float"></block>
     </category>
-    <category name="Variables" colour="330">
+    <category name="Variables" colour="330" custom="VARIABLE">
         <block type="variables_get"></block>
         <block type="variables_set">
             <value name="VALUE">

--- a/blocklylib-core/src/main/assets/default/toolbox.xml
+++ b/blocklylib-core/src/main/assets/default/toolbox.xml
@@ -298,7 +298,7 @@
             </value>
         </block>
     </category>
-    <category name="Variables" colour="330">
+    <category name="Variables" colour="330" custom="VARIABLE">
         <block type="variables_get"></block>
         <block type="variables_set">
             <value name="VALUE">

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -376,6 +376,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      */
     protected void onLoadInitialWorkspace() {
         onInitBlankWorkspace();
+        mToolboxFragment.closeBlocksDrawer();
     }
 
     /**


### PR DESCRIPTION
By default, start the toolbox closed. Fixes #94. Behavior defined in onLoadInitialWorkspace(), which applications can override.

Also, adding custom="VARIABLE" to Variable categories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/400)
<!-- Reviewable:end -->
