### PR TITLE
Fixing Toolbar in #405

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
@@ -294,13 +294,10 @@ public class CategoryTabs extends RecyclerView {
         }
 
         @Override
-        public void onViewDetachedFromWindow(TabLabelHolder holder) {
+        public void onViewRecycled(TabLabelHolder holder) {
             holder.mRotator.setTag(null);  // Remove reference to holder.
             holder.mCategory = null;
             holder.mLabel.setOnClickListener(null);
-            super.onViewDetachedFromWindow(holder);
         }
-
-
     }
 }


### PR DESCRIPTION
Click handler and view reference were disposed of too soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/407)
<!-- Reviewable:end -->
