### PR TITLE
Fixing call to onCreateOptionsMenu when scrolling checkbox not found.

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -71,8 +71,11 @@ public class DevTestsActivity extends BlocklySectionsActivity {
         boolean isShown = super.onCreateOptionsMenu(menu);
         if (isShown) {
             mScrollableMenuItem = menu.findItem(R.id.scrollable_menuitem);
-            mScrollableMenuItem.setChecked(mWorkspaceFragment.getScrollable());
             mLogEventsMenuItem = menu.findItem(R.id.log_events_menuitem);
+
+            if (mScrollableMenuItem != null) {
+                mScrollableMenuItem.setChecked(mWorkspaceFragment.getScrollable());
+            }
         }
         return isShown;
     }

--- a/blocklylib-core/src/main/res/layout/drawers_and_action_bar.xml
+++ b/blocklylib-core/src/main/res/layout/drawers_and_action_bar.xml
@@ -10,8 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-    <!-- Activity drawers listed below. -->
-    <!-- Drawers are added programmatically in
+    <!-- Drawers are appended programmatically in
       -  AbstractBlocklyActivity.onCreateAppNavigationDrawer()
       -->
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/429)
<!-- Reviewable:end -->
