### PR TITLE
Dynamic dropdown options

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockTypeFieldName.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockTypeFieldName.java
@@ -1,0 +1,49 @@
+package com.google.blockly.model;
+
+/**
+ * Id for a particular field on blocks of a particular type.
+ */
+
+public final class BlockTypeFieldName {
+    private final String mBlockType;
+    private final String mFieldName;
+
+    public BlockTypeFieldName(String blockType, String fieldName) {
+        mBlockType = blockType;
+        mFieldName = fieldName;
+    }
+
+    /**
+     * @return The block type id the field belongs to.
+     */
+    public String getBlockType() {
+        return mBlockType;
+    }
+
+    /**
+     * @return The name of the field within the blocks.
+     */
+    public String getFieldName() {
+        return mFieldName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        BlockTypeFieldName other = (BlockTypeFieldName) obj;
+
+        if (mBlockType != null ? !mBlockType.equals(other.mBlockType) : other.mBlockType != null)
+            return false;
+        return mFieldName != null ? mFieldName.equals(other.mFieldName) : other.mFieldName == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mBlockType != null ? mBlockType.hashCode() : 0;
+        result = 31 * result + (mFieldName != null ? mFieldName.hashCode() : 0);
+        return result;
+    }
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -158,65 +158,6 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
     }
 
     /**
-     * Create a new {@link Field} instance from JSON.  If the type is not recognized
-     * null will be returned. If the JSON is invalid or there is an error reading the data a
-     * {@link RuntimeException} will be thrown.
-     *
-     * @param json The JSON to generate the Field from.
-     *
-     * @return A Field of the appropriate type.
-     *
-     * @throws RuntimeException
-     */
-    public static Field fromJson(JSONObject json) throws BlockLoadingException {
-        String type = null;
-        try {
-            type = json.getString("type");
-        } catch (JSONException e) {
-            throw new BlockLoadingException("Error getting the field type.", e);
-        }
-
-        // If new fields are added here FIELD_TYPES should also be updated.
-        Field field = null;
-        switch (type) {
-            case TYPE_LABEL_STRING:
-                field = FieldLabel.fromJson(json);
-                break;
-            case TYPE_INPUT_STRING:
-                field = FieldInput.fromJson(json);
-                break;
-            case TYPE_ANGLE_STRING:
-                field = FieldAngle.fromJson(json);
-                break;
-            case TYPE_CHECKBOX_STRING:
-                field = FieldCheckbox.fromJson(json);
-                break;
-            case TYPE_COLOR_STRING:
-                field = FieldColor.fromJson(json);
-                break;
-            case TYPE_DATE_STRING:
-                field = FieldDate.fromJson(json);
-                break;
-            case TYPE_VARIABLE_STRING:
-                field = FieldVariable.fromJson(json);
-                break;
-            case TYPE_DROPDOWN_STRING:
-                field = FieldDropdown.fromJson(json);
-                break;
-            case TYPE_IMAGE_STRING:
-                field = FieldImage.fromJson(json);
-                break;
-            case TYPE_NUMBER_STRING:
-                field = FieldNumber.fromJson(json);
-                break;
-            default:
-                Log.w(TAG, "Unknown field type.");
-                break;
-        }
-        return field;
-    }
-
-    /**
      * Convert string representation of field type to internal integer Id.
      *
      * @param typeString The field type string, e.g., TYPE_LABEL_STRING ("field_label").

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownViewTest.java
@@ -20,11 +20,14 @@ import android.support.v4.util.SimpleArrayMap;
 
 import com.google.blockly.android.MockitoAndroidTestCase;
 import com.google.blockly.android.ui.WorkspaceHelper;
+import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldDropdown;
 
 import org.mockito.Mock;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,19 +40,20 @@ public class BasicFieldDropdownViewTest extends MockitoAndroidTestCase {
 
     // Cannot mock final classes.
     private FieldDropdown mFieldDropdown;
-    private List<FieldDropdown.Option> mOptions = new ArrayList<>(3);
+    private FieldDropdown.Options mOptions;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        mOptions.add(new FieldDropdown.Option("Value1", "Label1"));
-        mOptions.add(new FieldDropdown.Option("Value2", "Label2"));
-        mOptions.add(new FieldDropdown.Option("Value3", "Label3"));
+        mOptions = new FieldDropdown.Options(Arrays.asList(
+                new FieldDropdown.Option("Value1", "Label1"),
+                new FieldDropdown.Option("Value2", "Label2"),
+                new FieldDropdown.Option("Value3", "Label3")));
+        mFieldDropdown = new FieldDropdown("FieldDropdown", mOptions);
 
-        mFieldDropdown = new FieldDropdown("FieldCheckbox", mOptions);
         assertNotNull(mFieldDropdown);
-        assertEquals(mOptions.size(), mFieldDropdown.getOptionCount());
+        assertEquals(mOptions.size(), mFieldDropdown.getOptions().size());
     }
 
     // Verify object instantiation.


### PR DESCRIPTION
Adds central management of available dropdown options. Each `FieldDropdown` stores a reference to an `Options` set, which is effectively an observable list of `FieldDropdown.Option` instances.

The set of options for known block types (i.e., loaded via JSON) can be updated via the new methods `BlockFactory.updateDropDownOptions(blockType, fieldName, newOptions)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/431)
<!-- Reviewable:end -->
