### PR TITLE
Generalized Field events by replacing all subclass Observers with Field.Observer

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
@@ -38,13 +38,13 @@ public class WorkspaceStats {
     private final ProcedureManager mProcedureManager;
     private final ConnectionManager mConnectionManager;
 
-    private final FieldVariable.Observer mVariableObserver =
-            new FieldVariable.Observer() {
+    private final Field.Observer mVariableObserver = new Field.Observer() {
         @Override
-        public void onVariableChanged(FieldVariable field, String oldVar, String newVar) {
+        public void onValueChanged(Field field, String oldVar, String newVar) {
+            FieldVariable varField = (FieldVariable) field;
             List<FieldVariable> list = mVariableReferences.get(oldVar);
             if (list != null) {
-                list.remove(field);
+                list.remove(varField);
             }
 
             if (newVar == null) {
@@ -56,7 +56,7 @@ public class WorkspaceStats {
                 mVariableReferences.put(newVar, list);
                 mVariableNameManager.addName(newVar);
             }
-            list.add(field);
+            list.add(varField);
         }
     };
     private final List<Connection> mTempConnecitons = new ArrayList<>();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldAngleView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldAngleView.java
@@ -30,10 +30,11 @@ import com.google.blockly.model.FieldAngle;
 public class BasicFieldAngleView extends TextView implements FieldView {
     private static final char DEGREE_SYMBOL = '\u00B0';
 
-    protected FieldAngle.Observer mFieldObserver = new FieldAngle.Observer() {
+    protected Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onAngleChanged(Field field, int oldAngle, int newAngle) {
-            String newAngleStr = Integer.toString(newAngle);
+        public void onValueChanged(Field angleField, String oldValue, String newValue) {
+            assert (angleField == mAngleField);
+
             CharSequence curDisplayText = getText();
             int len = curDisplayText.length();
 
@@ -41,8 +42,8 @@ public class BasicFieldAngleView extends TextView implements FieldView {
             if (len > 0 && curDisplayText.charAt(len - 1) == DEGREE_SYMBOL) {
                 curDisplayText = curDisplayText.subSequence(0, len - 1);
             }
-            if (!newAngleStr.contentEquals(curDisplayText)) {
-                setText(newAngleStr + DEGREE_SYMBOL);
+            if (!newValue.contentEquals(curDisplayText)) {
+                setText(newValue + DEGREE_SYMBOL);
             }
         }
     };
@@ -95,7 +96,8 @@ public class BasicFieldAngleView extends TextView implements FieldView {
         }
         mAngleField = angleField;
         if (mAngleField != null) {
-            setText(Integer.toString(mAngleField.getAngle()) + DEGREE_SYMBOL);
+            // TODO(#438): Degree symbol on the left in RTL modes
+            setText(Float.toString(mAngleField.getAngle()) + DEGREE_SYMBOL);
             mAngleField.registerObserver(mFieldObserver);
         } else {
             setText("");

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxView.java
@@ -27,13 +27,10 @@ import com.google.blockly.model.FieldCheckbox;
  * Renders a checkbox as part of a BlockView.
  */
 public class BasicFieldCheckboxView extends CheckBox implements FieldView {
-    protected final FieldCheckbox.Observer mFieldObserver
-            = new FieldCheckbox.Observer() {
+    protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onCheckChanged(FieldCheckbox field, boolean newState) {
-            if (isChecked() != newState) {
-                setChecked(newState);
-            }
+        public void onValueChanged(Field field, String oldStrValue, String newStrValue) {
+            setChecked(mCheckboxField.isChecked());
         }
     };
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldColorView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldColorView.java
@@ -41,10 +41,10 @@ public class BasicFieldColorView extends FrameLayout implements FieldView {
     @VisibleForTesting
     static final int ALPHA_OPAQUE = 0xFF000000;
 
-    private FieldColor.Observer mFieldObserver = new FieldColor.Observer() {
+    private Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onColorChanged(Field field, int oldColor, int newColor) {
-            setColor(newColor);
+        public void onValueChanged(Field field, String oldValue, String newValue) {
+            setColor(mColorField.getColor());
         }
     };
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDateView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDateView.java
@@ -24,14 +24,18 @@ import android.widget.TextView;
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldDate;
 
+import java.text.DateFormat;
+
 /**
  * Renders a date and a date picker as part of a Block.
  */
 public class BasicFieldDateView extends TextView implements FieldView {
-    protected FieldDate.Observer mFieldObserver = new FieldDate.Observer() {
+    private static final DateFormat LOCALIZED_FORMAT = DateFormat.getDateInstance(DateFormat.SHORT);
+
+    protected Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onDateChanged(Field field, long oldMillis, long newMillis) {
-            String dateStr = mDateField.getDateString();
+        public void onValueChanged(Field field, String oldValue, String newValue) {
+            String dateStr = LOCALIZED_FORMAT.format(mDateField.getDate());
             if (!dateStr.contentEquals(getText())) {
                 setText(dateStr);
             }
@@ -83,7 +87,7 @@ public class BasicFieldDateView extends TextView implements FieldView {
         }
         mDateField = dateField;
         if (mDateField != null) {
-            setText(mDateField.getDateString());
+            setText(mDateField.getLocalizedDateString());
             mDateField.registerObserver(mFieldObserver);
         } else {
             setText("");

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
@@ -33,10 +33,10 @@ import java.util.List;
 public class BasicFieldDropdownView extends Spinner implements FieldView {
     private static final String TAG = "BasicFieldDropdownView";
 
-    private FieldDropdown.Observer mFieldObserver = new FieldDropdown.Observer() {
+    private Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onSelectionChanged(FieldDropdown field, int oldIndex, int newIndex) {
-            setSelection(newIndex);
+        public void onValueChanged(Field field, String oldValue, String newValue) {
+            setSelection(mDropdownField.getSelectedIndex());
         }
     };
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -50,15 +50,15 @@ public class BasicFieldInputView extends EditText implements FieldView {
         }
     };
 
-    private final FieldInput.Observer mFieldObserver = new FieldInput.Observer() {
+    private final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onTextChanged(FieldInput field, String oldText, String newText) {
+        public void onValueChanged(Field field, String oldValue, String newValue) {
             if (field != mInputField) {
                 Log.w(TAG, "Received text change from unexpected field.");
                 return;
             }
-            if (!TextUtils.equals(newText, getText())) {
-                setText(newText);
+            if (!TextUtils.equals(newValue, getText())) {
+                setText(newValue);
             }
         }
     };

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
@@ -26,10 +26,10 @@ import com.google.blockly.model.FieldLabel;
  * Renders text as part of a BlockView.
  */
 public class BasicFieldLabelView extends TextView implements FieldView {
-    protected final FieldLabel.Observer mFieldObserver = new FieldLabel.Observer() {
+    protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onTextChanged(FieldLabel field, String oldText, String newText) {
-            setText(newText);
+        public void onValueChanged(Field field, String oldValue, String newValue) {
+            setText(newValue);
         }
     };
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -69,9 +69,9 @@ public class BasicFieldNumberView extends EditText implements FieldView {
         }
     };
 
-    private final FieldNumber.Observer mFieldObserver = new FieldNumber.Observer() {
+    private final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onValueChanged(FieldNumber field, double oldValue, double newValue) {
+        public void onValueChanged(Field field, String oldStrValue, String newStrValue) {
             if (mIsUpdatingField) {
                 return;
             }
@@ -81,24 +81,17 @@ public class BasicFieldNumberView extends EditText implements FieldView {
             }
             try {
                 CharSequence text = getText();
-                try {
-                    // Because numbers can have different string representations,
-                    // only overwrite if the parsed value differs.
-                    if (TextUtils.isEmpty(text)
-                            || Double.parseDouble(text.toString()) != newValue) {
-                        setText(field.getFormattedValue());
-                    }
-                } catch (NumberFormatException e) {
-                    setText(field.getFormattedValue());
+                Double value = mNumberField.getValue();
+
+                // Because numbers can have different string representations,
+                // only overwrite if the parsed value differs.
+                if (TextUtils.isEmpty(text)
+                        || Double.parseDouble(text.toString()) != value) {
+                    setText(mNumberField.getFormattedValue());
                 }
             } catch (NumberFormatException e) {
-                setText(field.getFormattedValue());
+                setText(mNumberField.getFormattedValue());
             }
-        }
-
-        @Override
-        public void onConstraintsChanged(FieldNumber field) {
-            updateInputMethod();
         }
     };
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -20,9 +20,7 @@ import android.database.DataSetObserver;
 import android.os.Handler;
 import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
-import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
@@ -40,9 +38,9 @@ import java.lang.annotation.RetentionPolicy;
  * Renders a dropdown field containing the workspace's variables as part of a Block.
  */
 public class BasicFieldVariableView extends Spinner implements FieldView, VariableChangeView {
-    protected FieldVariable.Observer mFieldObserver = new FieldVariable.Observer() {
+    protected Field.Observer mFieldObserver = new Field.Observer() {
         @Override
-        public void onVariableChanged(FieldVariable field, String oldVar, String newVar) {
+        public void onValueChanged(Field field, String oldValue, String newValue) {
             refreshSelection();
         }
     };

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -16,18 +16,10 @@
 package com.google.blockly.model;
 
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
-import android.util.Log;
 
-import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.ColorUtils;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -17,12 +17,7 @@ package com.google.blockly.model;
 
 import android.database.Observable;
 import android.support.annotation.IntDef;
-import android.util.Log;
 
-import com.google.blockly.utils.BlockLoadingException;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
@@ -33,7 +28,7 @@ import java.lang.annotation.RetentionPolicy;
  * The base class for Fields in Blockly. A field is the smallest piece of a {@link Block} and is
  * wrapped by an {@link Input}.
  */
-public abstract class Field<T> extends Observable<T> implements Cloneable {
+public abstract class Field extends Observable<Field.Observer> implements Cloneable {
     private static final String TAG = "Field";
     public static final int TYPE_UNKNOWN = -1;
     public static final int TYPE_LABEL = 0;
@@ -63,6 +58,20 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
     public static final String TYPE_DROPDOWN_STRING = "field_dropdown";
     public static final String TYPE_IMAGE_STRING = "field_image";
     public static final String TYPE_NUMBER_STRING = "field_number";
+
+    /**
+     * Observer for listening to changes to a field.
+     */
+    public interface Observer {
+        /**
+         * Called when the field's text changed.
+         *
+         * @param field The field that changed.
+         * @param oldValue The field's previous value, in serialized string form.
+         * @param newValue The field's new value, in serialized string form.
+         */
+        void onValueChanged(Field field, String oldValue, String newValue);
+    }
 
     private final String mName;
     private final int mType;
@@ -196,6 +205,12 @@ public abstract class Field<T> extends Observable<T> implements Cloneable {
                 return TYPE_NUMBER;
             default:
                 return TYPE_UNKNOWN;
+        }
+    }
+
+    protected void fireValueChanged(String oldText, String newText) {
+        for (int i = 0; i < mObservers.size(); i++) {
+            mObservers.get(i).onValueChanged(this, oldText, newText);
         }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldCheckbox.java
@@ -20,14 +20,11 @@ import android.text.TextUtils;
 import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
-
-import java.io.IOException;
 
 /**
  * Adds a toggleable checkbox to an Input.
  */
-public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
+public final class FieldCheckbox extends Field {
     private boolean mChecked;
 
     public FieldCheckbox(String name, boolean checked) {
@@ -51,7 +48,7 @@ public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
 
     @Override
     public boolean setFromString(String text) {
-        mChecked = Boolean.parseBoolean(text);
+        setChecked(Boolean.parseBoolean(text));
         return true;
     }
 
@@ -67,32 +64,15 @@ public final class FieldCheckbox extends Field<FieldCheckbox.Observer> {
      */
     public void setChecked(boolean checked) {
         if (mChecked != checked) {
+            String oldValue = getSerializedValue();
             mChecked = checked;
-            onCheckChanged(checked);
+            String newValue = getSerializedValue();
+            fireValueChanged(oldValue, newValue);
         }
     }
 
     @Override
     public String getSerializedValue() {
         return mChecked ? "TRUE" : "FALSE";
-    }
-
-    private void onCheckChanged(boolean newState) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onCheckChanged(this, newState);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to a checkbox field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's checked value changed.
-         *
-         * @param field The field that changed.
-         * @param newState The new state of the checkbox.
-         */
-        void onCheckChanged(FieldCheckbox field, boolean newState);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldColor.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldColor.java
@@ -21,14 +21,11 @@ import android.text.TextUtils;
 import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
-
-import java.io.IOException;
 
 /**
  * Adds a color picker to an Input.
  */
-public final class FieldColor extends Field<FieldColor.Observer> {
+public final class FieldColor extends Field {
     public static final int DEFAULT_COLOR = 0xff0000;  // Red
 
     private int mColor;
@@ -86,9 +83,10 @@ public final class FieldColor extends Field<FieldColor.Observer> {
     public void setColor(int color) {
         final int newColor = 0xFFFFFF & color;
         if (mColor != newColor) {
-            int oldColor = mColor;
+            String oldValue = getSerializedValue();
             mColor = newColor;
-            onColorChanged(oldColor, newColor);
+            String newValue = getSerializedValue();
+            fireValueChanged(oldValue, newValue);
         }
     }
 
@@ -96,25 +94,5 @@ public final class FieldColor extends Field<FieldColor.Observer> {
     public String getSerializedValue() {
         return String.format("#%02x%02x%02x",
                 Color.red(mColor), Color.green(mColor), Color.blue(mColor));
-    }
-
-    private void onColorChanged(int oldColor, int newColor) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onColorChanged(this, oldColor, newColor);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to a color field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's color changed.
-         *
-         * @param field The field that changed.
-         * @param oldColor The field's previous color.
-         * @param newColor The field's new color.
-         */
-        void onColorChanged(Field field, int oldColor, int newColor);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
@@ -22,22 +22,21 @@ import android.util.Log;
 import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
 
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.GregorianCalendar;
 
 /**
  * Adds a date picker to an Input. Dates must be in the format "YYYY-MM-DD"
  */
-public final class FieldDate extends Field<FieldDate.Observer> {
+public final class FieldDate extends Field {
     private static final String TAG = "FieldDate";
 
+    // Date format used for serialization.
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
     private final Date mDate = new Date();
 
     public FieldDate(String name) {
@@ -108,7 +107,7 @@ public final class FieldDate extends Field<FieldDate.Observer> {
     /**
      * @return The string format for the date in this field.
      */
-    public String getDateString() {
+    public String getLocalizedDateString() {
         return DATE_FORMAT.format(mDate);
     }
 
@@ -120,33 +119,15 @@ public final class FieldDate extends Field<FieldDate.Observer> {
     public void setTime(long millis) {
         long oldTime = mDate.getTime();
         if (millis != oldTime) {
+            String oldValue = getSerializedValue();
             mDate.setTime(millis);
-            onDateChanged(oldTime, millis);
+            String newValue = getSerializedValue();
+            fireValueChanged(oldValue, newValue);
         }
     }
 
     @Override
     public String getSerializedValue() {
         return DATE_FORMAT.format(mDate);
-    }
-
-    private void onDateChanged(long oldMillis, long newMillis) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onDateChanged(this, oldMillis, newMillis);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to a date field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's date changed.
-         *
-         * @param field The field that changed.
-         * @param oldMillis The field's previous time in UTC millis since epoch.
-         * @param newMillis The field's new time in UTC millis since epoch.
-         */
-        void onDateChanged(Field field, long oldMillis, long newMillis);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDropdown.java
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * Adds a dropdown list to an Input.
  */
-public final class FieldDropdown extends Field<FieldDropdown.Observer> {
+public final class FieldDropdown extends Field {
     private static final String TAG = "FieldDropdown";
 
     /**
@@ -305,10 +305,10 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
      */
     public void setSelectedValue(String newValue) {
         if (mOptions.isEmpty()) {
-            int oldIndex = mSelectedIndex;
+            String oldValue = getSerializedValue();
             mSelectedIndex = -1;
             mSelectedOption = null;
-            onSelectionChanged(this, oldIndex, mSelectedIndex);
+            fireValueChanged(oldValue, null);
         } else {
             int index = mOptions.getIndexForValue(newValue);
             if (index == -1) {
@@ -346,10 +346,11 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
         // If value selected index has changed, update current selection and (if it exists) let
         // the observers know.
         if (mSelectedIndex != index) {
-            int oldIndex = mSelectedIndex;
+            String oldValue = getSerializedValue();
             mSelectedIndex = index;
             mSelectedOption = mOptions.get(mSelectedIndex);
-            onSelectionChanged(this, oldIndex, index);
+            String newValue = getSerializedValue();
+            fireValueChanged(oldValue, newValue);
         }
     }
 
@@ -370,25 +371,5 @@ public final class FieldDropdown extends Field<FieldDropdown.Observer> {
     @Override
     public String getSerializedValue() {
         return getSelectedValue();
-    }
-
-    private void onSelectionChanged(FieldDropdown field, int oldIndex, int newIndex) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onSelectionChanged(field, oldIndex, newIndex);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to a variable field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's selected index changed.
-         *
-         * @param field The field that changed.
-         * @param oldIndex The field's previously selected index.
-         * @param newIndex The field's new selected index.
-         */
-        void onSelectionChanged(FieldDropdown field, int oldIndex, int newIndex);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldImage.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldImage.java
@@ -18,12 +18,11 @@ package com.google.blockly.model;
 import android.text.TextUtils;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
 
 /**
  * Adds an image to an Input.
  */
-public final class FieldImage extends Field<FieldImage.Observer> {
+public final class FieldImage extends Field {
     private String mSrc;
     private int mWidth;
     private int mHeight;
@@ -86,6 +85,10 @@ public final class FieldImage extends Field<FieldImage.Observer> {
 
     /**
      * Sets a new image to be shown.
+     * <p/>
+     * Changes will induce a {@link Field.Observer#onValueChanged}, even though FieldImages do not
+     * store a value.  This trigger updates to the matching Fieldview, but in might also generate a
+     * no-op {@link com.google.blockly.android.control.BlocklyEvent.ChangeEvent}.
      *
      * @param src A web address or Blockly reference to the image.
      * @param width The display width of the image in dips.
@@ -96,7 +99,8 @@ public final class FieldImage extends Field<FieldImage.Observer> {
             mSrc = src;
             mWidth = width;
             mHeight = height;
-            onImageChanged(src, width, height);
+
+            fireValueChanged("", "");
         }
     }
 
@@ -108,29 +112,5 @@ public final class FieldImage extends Field<FieldImage.Observer> {
     @Override
     public String getSerializedValue() {
         return ""; // Image fields do not have value.
-    }
-
-    private void onImageChanged(String newSource, int newWidth, int newHeight) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onImageChanged(this, newSource, newWidth, newHeight);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to an image field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's image source, width, or height was changed.
-         * <p>
-         * Note: Image fields are not expected to be user editable and are not serialized by
-         * Blockly's core library.
-         *
-         * @param field The field that changed.
-         * @param newSource The new source for the image.
-         * @param newWidth The new width of the image.
-         * @param newHeight The new height of the image.
-         */
-        void onImageChanged(FieldImage field, String newSource, int newWidth, int newHeight);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldInput.java
@@ -20,14 +20,11 @@ import android.text.TextUtils;
 import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
-
-import java.io.IOException;
 
 /**
  * Adds an editable text input to an Input.
  */
-public final class FieldInput extends Field<FieldInput.Observer> {
+public final class FieldInput extends Field {
     private String mText;
 
     public FieldInput(String name, String text) {
@@ -71,32 +68,12 @@ public final class FieldInput extends Field<FieldInput.Observer> {
         if (!TextUtils.equals(text, mText)) {
             String oldText = mText;
             mText = text;
-            onTextChanged(oldText, text);
+            fireValueChanged(oldText, text);
         }
     }
 
     @Override
     public String getSerializedValue() {
         return mText == null ? "" : mText;
-    }
-
-    private void onTextChanged(String oldText, String newText) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onTextChanged(this, oldText, newText);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to an input field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's text changed.
-         *
-         * @param field The field that changed.
-         * @param oldText The field's previous text.
-         * @param newText The field's new text.
-         */
-        void onTextChanged(FieldInput field, String oldText, String newText);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldLabel.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldLabel.java
@@ -18,15 +18,12 @@ package com.google.blockly.model;
 import android.text.TextUtils;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
-
-import java.io.IOException;
 
 /**
  * Adds a text to an Input. This can be used to add text to the block or label
  * another field. The text is not modifiable by the user.
  */
-public final class FieldLabel extends Field<FieldLabel.Observer> {
+public final class FieldLabel extends Field {
     private String mText;
 
     public FieldLabel(String name, String text) {
@@ -59,9 +56,7 @@ public final class FieldLabel extends Field<FieldLabel.Observer> {
      */
     public void setText(String text) {
         if (!TextUtils.equals(text, mText)) {
-            String oldText = mText;
             mText = text;
-            onTextChanged(oldText, text);
         }
     }
 
@@ -73,28 +68,5 @@ public final class FieldLabel extends Field<FieldLabel.Observer> {
     @Override
     public String getSerializedValue() {
         return ""; // Label fields do not have value.
-    }
-
-    private void onTextChanged(String oldText, String newText) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onTextChanged(this, oldText, newText);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to an input field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's text changed.
-         * <p>
-         * Note: Label fields are not expected to be user editable and are not serialized by
-         * Blockly's core library.
-         *
-         * @param field The field that changed.
-         * @param oldText The field's previous text.
-         * @param newText The field's new text.
-         */
-        void onTextChanged(FieldLabel field, String oldText, String newText);
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldVariable.java
@@ -20,14 +20,11 @@ import android.text.TextUtils;
 import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlSerializer;
-
-import java.io.IOException;
 
 /**
  * Adds a variable to an Input.
  */
-public final class FieldVariable extends Field<FieldVariable.Observer> {
+public final class FieldVariable extends Field {
     private String mVariable;
 
     public FieldVariable(String name, String variable) {
@@ -71,34 +68,15 @@ public final class FieldVariable extends Field<FieldVariable.Observer> {
     public void setVariable(String variable) {
         if ((mVariable == null && variable != null)
                 || (mVariable != null && !mVariable.equalsIgnoreCase(variable))) {
-            String oldVar = mVariable;
+            String oldValue = getSerializedValue();
             mVariable = variable;
-            onVariableChanged(this, oldVar, variable);
+            String newValue = getSerializedValue();
+            fireValueChanged(oldValue, newValue);
         }
     }
 
     @Override
     public String getSerializedValue() {
         return mVariable;
-    }
-
-    private void onVariableChanged(com.google.blockly.model.FieldVariable field, String oldVar, String newVar) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onVariableChanged(field, oldVar, newVar);
-        }
-    }
-
-    /**
-     * Observer for listening to changes to a variable field.
-     */
-    public interface Observer {
-        /**
-         * Called when the field's variable name changed.
-         *
-         * @param field The field that changed.
-         * @param oldVar The field's previous variable name.
-         * @param newVar The field's new variable name.
-         */
-        void onVariableChanged(com.google.blockly.model.FieldVariable field, String oldVar, String newVar);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldAngleTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldAngleTest.java
@@ -20,42 +20,62 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldAngle}.
  */
 public class FieldAngleTest extends AndroidTestCase {
-    public void testFieldAngle() {
+    public void testConstructor() {
         FieldAngle field = new FieldAngle("name", 0);
         assertEquals(Field.TYPE_ANGLE, field.getType());
         assertEquals("name", field.getName());
-        assertEquals(0, field.getAngle());
+        assertEquals(0f, field.getAngle());
+    }
 
-        field = new FieldAngle("360", 360);
-        assertEquals("360", field.getName());
-        assertEquals(360, field.getAngle());
+    public void testWrapAround() {
+        FieldAngle field = new FieldAngle("name", 360);
+        assertEquals(0f, field.getAngle());
 
-        field = new FieldAngle("name", 720);
-        assertEquals(0, field.getAngle());
+        field.setAngle(720f);
+        assertEquals(0f, field.getAngle());
 
-        field = new FieldAngle("name", -180);
-        assertEquals(180, field.getAngle());
+        field.setAngle(-180f);
+        assertEquals(180f, field.getAngle());
 
-        field = new FieldAngle("name", 10000);
-        assertEquals(280, field.getAngle());
+        field.setAngle(10000f);
+        assertEquals(280f, field.getAngle());
 
-        field = new FieldAngle("name", -10000);
-        assertEquals(80, field.getAngle());
+        field.setAngle(-10000f);
+        assertEquals(80f, field.getAngle());
 
-        field.setAngle(360);
-        assertEquals(360, field.getAngle());
-        field.setAngle(27);
-        assertEquals(27, field.getAngle());
-        field.setAngle(-10001);
-        assertEquals(79, field.getAngle());
+        field.setAngle(27f);
+        assertEquals(27f, field.getAngle());
+
+        field.setAngle(-10001f);
+        assertEquals(79f, field.getAngle());
+    }
+
+    public void testParseValue() {
+        FieldAngle field = new FieldAngle("name", 0);
 
         // xml parsing
         assertTrue(field.setFromString("-180"));
-        assertEquals(180, field.getAngle());
+        assertEquals(180f, field.getAngle());
         assertTrue(field.setFromString("27"));
-        assertEquals(27, field.getAngle());
+        assertEquals(27f, field.getAngle());
         assertFalse(field.setFromString("this is not a number"));
+    }
+
+    public void testClone() {
+        FieldAngle field = new FieldAngle("name", 5);
+        FieldAngle clone = field.clone();
 
         assertNotSame(field, field.clone());
+        assertEquals(field.getName(), clone.getName());
+        assertEquals(field.getAngle(), clone.getAngle());
+    }
+
+    public void testObserverEvent() {
+        FieldTestHelper.testObserverEvent(new FieldAngle("ANGLE", 0),
+                /* New value to assign */ "15",
+                /* oldValue */ "0",
+                /* newValue */ "15");
+        FieldTestHelper.testObserverNoEvent(new FieldAngle("ANGLE", 0));
+        FieldTestHelper.testObserverNoEvent(new FieldAngle("ANGLE", 0), "360");
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldCheckboxTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldCheckboxTest.java
@@ -21,9 +21,9 @@ import android.test.AndroidTestCase;
  */
 public class FieldCheckboxTest extends AndroidTestCase {
     public void testFieldCheckbox() {
-        FieldCheckbox field = new FieldCheckbox("fname", true);
+        FieldCheckbox field = new FieldCheckbox("checkbox", true);
         assertEquals(Field.TYPE_CHECKBOX, field.getType());
-        assertEquals("fname", field.getName());
+        assertEquals("checkbox", field.getName());
         assertEquals(true, field.isChecked());
         field.setChecked(false);
         assertEquals(false, field.isChecked());
@@ -49,7 +49,36 @@ public class FieldCheckboxTest extends AndroidTestCase {
         field.setChecked(true);
         assertTrue(field.setFromString("t"));
         assertFalse(field.isChecked());
+    }
 
-        assertNotSame(field, field.clone());
+    public void testClone() {
+        FieldCheckbox field = new FieldCheckbox("checkbox", true);
+        FieldCheckbox clone = field.clone();
+
+        assertNotSame(field, clone);
+        assertEquals(field.getName(), field.getName());
+        assertEquals(field.isChecked(), clone.isChecked());
+
+        // Test with false
+        field = new FieldCheckbox("checkbox", false);
+        clone = field.clone();
+        assertEquals(field.isChecked(), clone.isChecked());
+    }
+
+    public void testObserverEvent() {
+        FieldTestHelper.testObserverEvent(new FieldCheckbox("CHECKBOX", true),
+                /* New value to assign */ "FALSE",
+                /* oldValue */ "TRUE",
+                /* newValue */ "FALSE");
+        FieldTestHelper.testObserverEvent(new FieldCheckbox("CHECKBOX", false),
+                /* New value to assign */ "TRUE",
+                /* oldValue */ "FALSE",
+                /* newValue */ "TRUE");
+
+        // No change assignments
+        FieldTestHelper.testObserverNoEvent(new FieldCheckbox("CHECKBOX", true));
+        FieldTestHelper.testObserverNoEvent(new FieldCheckbox("CHECKBOX", false));
+        FieldTestHelper.testObserverNoEvent(new FieldCheckbox("CHECKBOX", true), "TrUe");
+        FieldTestHelper.testObserverNoEvent(new FieldCheckbox("CHECKBOX", false), "ugly false");
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldColorTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldColorTest.java
@@ -20,33 +20,66 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldColor}.
  */
 public class FieldColorTest extends AndroidTestCase {
-    public void testFieldColour() {
-        FieldColor field = new FieldColor("fname", 0xaa00aa);
-        assertEquals(Field.TYPE_COLOR, field.getType());
-        assertEquals("fname", field.getName());
-        assertEquals(0xaa00aa, field.getColor());
+    private static final int INITIAL_COLOR = 0xaabbcc;
+    private static final String INITIAL_COLOR_STRING = "#aabbcc";
 
-        field = new FieldColor("fname");
-        assertEquals("fname", field.getName());
-        assertEquals(FieldColor.DEFAULT_COLOR, field.getColor());
+    FieldColor mField;
 
-        field.setColor(0xb0bb1e);
-        assertEquals(0xb0bb1e, field.getColor());
+    public void setUp() {
+        mField = new FieldColor("fname", INITIAL_COLOR);
+    }
 
-        // xml parsing
-        assertTrue(field.setFromString("#ffcc66"));
-        assertEquals(0xffcc66, field.getColor());
-        assertTrue(field.setFromString("#00cc66"));
-        assertEquals(0x00cc66, field.getColor());
-        assertTrue(field.setFromString("#1000cc66"));
-        assertEquals(0x00cc66, field.getColor());
-        assertFalse(field.setFromString("This is not a color"));
-        // Color does not change
-        assertEquals(0x00cc66, field.getColor());
-        assertFalse(field.setFromString("#fc6"));
-        // Color does not change
-        assertEquals(0x00cc66, field.getColor());
+    public void testConstructors() {
+        assertEquals(Field.TYPE_COLOR, mField.getType());
+        assertEquals("fname", mField.getName());
+        assertEquals(INITIAL_COLOR, mField.getColor());
 
-        assertNotSame(field, field.clone());
+        mField = new FieldColor("fname");
+        assertEquals("fname", mField.getName());
+        assertEquals(FieldColor.DEFAULT_COLOR, mField.getColor());
+    }
+
+    public void testSetColor() {
+        mField.setColor(0xb0bb1e);
+        assertEquals(0xb0bb1e, mField.getColor());
+    }
+
+    public void testSetFromString() {
+        assertTrue(mField.setFromString("#ffcc66"));
+        assertEquals(0xffcc66, mField.getColor());
+        assertTrue(mField.setFromString("#00cc66"));
+        assertEquals(0x00cc66, mField.getColor());
+
+        // Ignore alpha channel
+        assertTrue(mField.setFromString("#1000cc66"));
+        assertEquals(0x00cc66, mField.getColor());
+
+        // Invalid color strings. Value should not change.
+        assertFalse(mField.setFromString("This is not a color"));
+        assertEquals(0x00cc66, mField.getColor());
+        assertFalse(mField.setFromString("#fc6"));
+        assertEquals(0x00cc66, mField.getColor());
+    }
+
+    public void testClone() {
+        FieldColor clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertEquals(mField.getColor(), clone.getColor());
+    }
+
+    public void testObserverEvents() {
+        FieldTestHelper.testObserverEvent(new FieldColor("normal", INITIAL_COLOR),
+                /* New value */ "#ffcc66",
+                /* Expected old value */ INITIAL_COLOR_STRING,
+                /* Expected new value */ "#ffcc66");
+
+        // No Change
+        FieldTestHelper.testObserverNoEvent(
+                new FieldColor("normal", INITIAL_COLOR),
+                /* New value */ INITIAL_COLOR_STRING);
+        FieldTestHelper.testObserverNoEvent(
+                new FieldColor("normal", INITIAL_COLOR),
+                /* New value */ INITIAL_COLOR_STRING.toUpperCase());
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
@@ -22,29 +22,53 @@ import java.util.Date;
  * Tests for {@link FieldDate}.
  */
 public class FieldDateTest extends AndroidTestCase {
-    public void testFieldDate() {
-        FieldDate field = new FieldDate("alphabet", "2015-09-14");
-        assertEquals(Field.TYPE_DATE, field.getType());
-        assertEquals("alphabet", field.getName());
-        assertEquals("2015-09-14", field.getDateString());
+    private static final String INITIAL_VALUE = "2015-09-14";
 
+    FieldDate mField;
+
+    public void setUp() {
+        mField = new FieldDate("alphabet", INITIAL_VALUE);
+    }
+
+    public void testConstructor() {
+        assertEquals(Field.TYPE_DATE, mField.getType());
+        assertEquals("alphabet", mField.getName());
+        assertEquals(INITIAL_VALUE, mField.getSerializedValue());
+    }
+
+    public void testSetDate() {
         Date date = new Date();
-        field.setDate(date);
-        assertEquals(date, field.getDate());
+        mField.setDate(date);
+        assertEquals(date, mField.getDate());
         date.setTime(date.getTime() + 86400000);
-        field.setTime(date.getTime());
-        assertEquals(date, field.getDate());
+        mField.setTime(date.getTime());
+        assertEquals(date, mField.getDate());
 
-        assertTrue(field.setFromString("2017-03-23"));
-        assertEquals("2017-03-23", field.getDateString());
+        assertTrue(mField.setFromString("2017-03-23"));
+        assertEquals("2017-03-23", mField.getLocalizedDateString());
+    }
 
-        // xml parsing
-        assertFalse(field.setFromString("today"));
-        assertFalse(field.setFromString("2017/03/03"));
-        assertFalse(field.setFromString(""));
+    public void testSetFromString() {
+        assertFalse(mField.setFromString("today"));
+        assertFalse(mField.setFromString("2017/03/03"));
+        assertFalse(mField.setFromString(""));
+    }
 
-        FieldDate clone = field.clone();
-        assertNotSame(field, clone);
-        assertNotSame(field.getDate(), clone.getDate());
+    public void testClone() {
+        FieldDate clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertNotSame(mField.getDate(), clone.getDate());
+        assertEquals(mField.getDate(), clone.getDate());
+    }
+
+    public void testObserverEvents() {
+        FieldTestHelper.testObserverEvent(mField,
+                /* New value */ "2017-03-23",
+                /* Expected old value */ INITIAL_VALUE,
+                /* Expected new value */ "2017-03-23");
+
+        // No events if no change
+        FieldTestHelper.testObserverNoEvent(mField);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
@@ -155,4 +155,13 @@ public class FieldDropdownTest extends AndroidTestCase {
             assertEquals(VALUES.get(i), mDropDown.getSelectedDisplayName());
         }
     }
+
+    public void testObserverEvents() {
+        FieldTestHelper.testObserverEvent(mDropDown,
+                /* New value */ VALUES.get(2),
+                /* Expected old value */ VALUES.get(0),
+                /* Expected new value */ VALUES.get(2));
+
+        FieldTestHelper.testObserverNoEvent(mDropDown);
+    }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldImageTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldImageTest.java
@@ -20,16 +20,53 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldImage}.
  */
 public class FieldImageTest extends AndroidTestCase {
-    public void testFieldImage() {
-        String url = "https://www.gstatic.com/codesite/ph/images/star_on.gif";
-        FieldImage field = new FieldImage("fname", url, 15, 21, "altText");
-        assertEquals(Field.TYPE_IMAGE, field.getType());
-        assertEquals("fname", field.getName());
-        assertEquals(url, field.getSource());
-        assertEquals(15, field.getWidth());
-        assertEquals(21, field.getHeight());
-        assertEquals("altText", field.getAltText());
+    static final String FIELD_NAME = "whatever";
+    static final String SOURCE = "https://www.gstatic.com/codesite/ph/images/star_on.gif";
+    static final int WIDTH = 15;
+    static final int HEIGHT = 21;
+    static final String ALT_TEXT = "altText";
 
-        assertNotSame(field, field.clone());
+    FieldImage mField;
+
+    public void setUp() {
+        mField = new FieldImage(FIELD_NAME, SOURCE, WIDTH, HEIGHT, ALT_TEXT);
+    }
+
+    public void testFieldImage() {
+        assertEquals(Field.TYPE_IMAGE, mField.getType());
+        assertEquals(FIELD_NAME, mField.getName());
+        assertEquals(SOURCE, mField.getSource());
+        assertEquals(WIDTH, mField.getWidth());
+        assertEquals(HEIGHT, mField.getHeight());
+        assertEquals(ALT_TEXT, mField.getAltText());
+    }
+
+    public void testClone() {
+        FieldImage clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertEquals(mField.getSource(), clone.getSource());
+        assertEquals(mField.getWidth(), clone.getWidth());
+        assertEquals(mField.getHeight(), clone.getHeight());
+        assertEquals(mField.getAltText(), clone.getAltText());
+    }
+
+    public void testObserverEvents() {
+        final int[] eventCount = {0};
+        mField.registerObserver(new Field.Observer() {
+            @Override
+            public void onValueChanged(Field field, String oldValue, String newValue) {
+                assertSame(mField, field);
+                eventCount[0] += 1;
+            }
+        });
+
+        // Same source, new metadata
+        mField.setImage(SOURCE, 101, 202);
+        assertEquals(1, eventCount[0]);
+
+        // New source
+        mField.setImage(SOURCE + "2", 101, 202);
+        assertEquals(2, eventCount[0]);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldInputTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldInputTest.java
@@ -20,19 +20,43 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldInput}.
  */
 public class FieldInputTest extends AndroidTestCase {
-    public void testFieldInput() {
-        FieldInput field = new FieldInput("field name", "start text");
-        assertEquals(Field.TYPE_INPUT, field.getType());
-        assertEquals("field name", field.getName());
-        assertEquals("start text", field.getText());
+    static final String FIELD_NAME = "Robert";
+    static final String INITIAL_VALUE = "start text";
 
-        field.setText("new text");
-        assertEquals("new text", field.getText());
+    FieldInput mField;
 
-        // xml parsing
-        assertTrue(field.setFromString("newest text"));
-        assertEquals("newest text", field.getText());
+    public void setUp() {
+        mField = new FieldInput(FIELD_NAME, INITIAL_VALUE);
+    }
 
-        assertNotSame(field, field.clone());
+    public void testConstructor() {
+        assertEquals(Field.TYPE_INPUT, mField.getType());
+        assertEquals(FIELD_NAME, mField.getName());
+        assertEquals(INITIAL_VALUE, mField.getText());
+    }
+
+    public void testSetText() {
+        mField.setText("new text");
+        assertEquals("new text", mField.getText());
+    }
+
+    public void testSetFromString() {
+        assertTrue(mField.setFromString("newest text"));
+        assertEquals("newest text", mField.getText());
+    }
+
+    public void testClone() {
+        FieldInput clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertEquals(mField.getText(), clone.getText());
+    }
+
+    public void testObserverEvents() {
+        FieldTestHelper.testObserverEvent(mField,
+                /* New value */ "asdf",
+                /* Expected old value */ INITIAL_VALUE,
+                /* Expected new value */ "asdf");
+        FieldTestHelper.testObserverNoEvent(mField);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldLabelTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldLabelTest.java
@@ -20,16 +20,24 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldLabel}.
  */
 public class FieldLabelTest extends AndroidTestCase {
-    public void testFieldLabel() {
-        FieldLabel field = new FieldLabel("field name", "some text");
-        assertEquals(Field.TYPE_LABEL, field.getType());
-        assertEquals("field name", field.getName());
-        assertEquals("some text", field.getText());
+    public static final String FIELD_NAME = "mField name";
+    public static final String INITIAL_VALUE = "some text";
+    FieldLabel mField;
 
-        field = new FieldLabel("name", null);
-        assertEquals("name", field.getName());
-        assertEquals("", field.getText());
+    public void setUp() {
+        mField = new FieldLabel(FIELD_NAME, INITIAL_VALUE);
+    }
 
-        assertNotSame(field, field.clone());
+    public void testConstructor() {
+        assertEquals(Field.TYPE_LABEL, mField.getType());
+        assertEquals(FIELD_NAME, mField.getName());
+        assertEquals(INITIAL_VALUE, mField.getText());
+    }
+
+    public void testClone() {
+        FieldLabel clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertEquals(mField.getText(), clone.getText());
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
@@ -418,4 +418,16 @@ public class FieldNumberTest extends MockitoAndroidTestCase {
         mField.setFromString("1.23e-4");
         assertEquals(0.000123, mField.getValue());
     }
+
+    public void testObserverEvent() {
+        mField.setValue(789);
+        FieldTestHelper.testObserverEvent(mField,
+                /* New Value */ "42",
+                /* Expected old value */ "789",
+                /* Expected new value */ "42");
+
+        // No events if the value doesn't change.
+        FieldTestHelper.testObserverNoEvent(mField);
+        FieldTestHelper.testObserverNoEvent(mField, "42.0000000");
+    }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTestHelper.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTestHelper.java
@@ -1,0 +1,76 @@
+package com.google.blockly.model;
+
+import org.junit.Assert;
+
+/**
+ * Helper methods for testing fields.
+ */
+public class FieldTestHelper {
+    /**
+     * Tests {@link Field.Observer} event on an {@link Field} object, including single call per
+     * change per observer, multiple observers.
+     *
+     * @param field The field to test.
+     * @param newValue The value to assign, using the serialized format of the value.
+     * @param expectedOldValue The expected {@code oldValue}, in serialized form.
+     * @param expectedNewValue The expected {@code newValue}, in serialized form.
+     */
+    public static void testObserverEvent(final Field field,
+                                         final String newValue,
+                                         final String expectedOldValue,
+                                         final String expectedNewValue) {
+        final int[] observerOneCount = {0};
+        final int[] observerTwoCount = {0};
+
+        field.registerObserver(new Field.Observer() {
+            @Override
+            public void onValueChanged(Field eventField, String oldValue, String newValue) {
+                observerOneCount[0]++;
+                Assert.assertSame(field, eventField);
+                Assert.assertEquals(expectedOldValue, oldValue);
+                Assert.assertEquals(expectedNewValue, newValue);
+
+            }
+        });
+        field.registerObserver(new Field.Observer() {
+            @Override
+            public void onValueChanged(Field field, String oldValue, String newValue) {
+                observerTwoCount[0]++;
+            }
+        });
+
+        field.setFromString(newValue);
+        Assert.assertEquals("Exactly one observation per Observer", 1, observerOneCount[0]);
+        Assert.assertEquals("Exactly one observation per Observer", 1, observerTwoCount[0]);
+    }
+
+    /**
+     * Tests updating a {@link Field} with a value that is expected to be the same, and thus
+     * should not invoke an {@link Field.Observer} call.
+     *
+     * @param field The field to test.
+     * @param writeValue The value to write, in serialized form.
+     */
+    public static void testObserverNoEvent(final Field field, final String writeValue) {
+        field.registerObserver(new Field.Observer() {
+            @Override
+            public void onValueChanged(Field eventField, String oldValue, String newValue) {
+                Assert.fail("Observer should not be call if value does not change.\n"
+                        + "writeValue = " + (writeValue == null ? "null" : "\"" + writeValue + "\"")
+                        + "\noldValue = " + (oldValue == null ? "null" : "\"" + oldValue + "\"")
+                        + "\nnewValue = " + (newValue == null ? "null" : "\"" + newValue + "\""));
+            }
+        });
+        field.setFromString(writeValue);
+    }
+
+    /**
+     * Tests updating a {@link Field} with its existing value, and thus should not invoke an
+     * {@link Field.Observer} call.
+     *
+     * @param field The field to test.
+     */
+    public static void testObserverNoEvent(final Field field) {
+        testObserverNoEvent(field, field.getSerializedValue());
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldVariableTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldVariableTest.java
@@ -20,20 +20,44 @@ import android.test.AndroidTestCase;
  * Tests for {@link FieldVariable}.
  */
 public class FieldVariableTest extends AndroidTestCase {
-    public void testFieldVariable() {
-        FieldVariable field = new FieldVariable("fname", "varName");
-        assertEquals(Field.TYPE_VARIABLE, field.getType());
-        assertEquals("fname", field.getName());
-        assertEquals("varName", field.getVariable());
+    public static final String FIELD_NAME = "fname";
+    public static final String VARIABLE_NAME = "var";
 
-        field.setVariable("newVar");
-        assertEquals("newVar", field.getVariable());
+    FieldVariable mField = new FieldVariable(FIELD_NAME, VARIABLE_NAME);
 
-        // xml parsing
-        assertTrue(field.setFromString("newestVar"));
-        assertEquals("newestVar", field.getVariable());
-        assertFalse(field.setFromString(""));
+    public void setUp() {
+        mField = new FieldVariable(FIELD_NAME, VARIABLE_NAME);
+    }
 
-        assertNotSame(field, field.clone());
+    public void testConstructor() {
+        assertEquals(Field.TYPE_VARIABLE, mField.getType());
+        assertEquals(FIELD_NAME, mField.getName());
+        assertEquals(VARIABLE_NAME, mField.getVariable());
+    }
+
+    public void testSetVariable() {
+        mField.setVariable("newVar");
+        assertEquals("newVar", mField.getVariable());
+    }
+
+    public void testSetFromString() {
+        assertTrue(mField.setFromString("newestVar"));
+        assertEquals("newestVar", mField.getVariable());
+        assertFalse(mField.setFromString(""));
+        assertEquals("newestVar", mField.getVariable());
+    }
+
+    public void testClone() {
+        FieldVariable clone = mField.clone();
+        assertNotSame(mField, clone);
+        assertEquals(mField.getName(), clone.getName());
+        assertEquals(mField.getVariable(), clone.getVariable());
+    }
+
+    public void testObserverEvents() {
+        FieldTestHelper.testObserverEvent(mField,
+                /* New value */ "zip",
+                /* Expected old value */ VARIABLE_NAME,
+                /* Expected new value */ "zip");
     }
 }


### PR DESCRIPTION
Generalized Field events by replacing all subclass Observers with a single Field.Observer class. This is more convenient as Blocks become observers of their own fields, and is more compatible with the ChangeEvent class.

Along the way...
 * FieldAngle is now a floating value, like web Blockly, but it will only serialize with a decimal point if it is not an integer.
 * FieldAngle no longer supports 360 as an angular value, like web Blockly, and has a constant to determine when to wrap.
 * FieldNumber will only serialize the decimal point if it isn't an integer, and is will render all decimal digits.
 * FieldDate.getLocalizedDateString() replaces .getDateString().
 * Refactored large monolithic test methods for various Field subclasses. Added tests for Observer calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/439)
<!-- Reviewable:end -->
