### PR TITLE
Adding a demo for alternative configuration of the Blockly fragments.

### DIFF
--- a/blocklydemo/src/main/AndroidManifest.xml
+++ b/blocklydemo/src/main/AndroidManifest.xml
@@ -36,6 +36,17 @@
         </activity>
 
         <activity
+            android:name=".AlwaysOpenToolboxActivity"
+            android:label="@string/always_open_toolbox_activity_name"
+            android:taskAffinity="com.google.blockly.SimpleActivity"
+            android:windowSoftInputMode="stateHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".DevTestsActivity"
             android:label="@string/dev_activity_name"
             android:taskAffinity="com.google.blockly.demo.MainActivity"

--- a/blocklydemo/src/main/assets/simple_playground_toolbox.xml
+++ b/blocklydemo/src/main/assets/simple_playground_toolbox.xml
@@ -1,0 +1,15 @@
+<toolbox>
+    <block type="controls_if"></block>
+    <block type="logic_compare"></block>
+    <block type="logic_operation"></block>
+    <block type="controls_repeat_ext">
+        <value name="TIMES">
+            <shadow type="math_number">
+                <field name="NUM">10</field>
+            </shadow>
+        </value>
+    </block>
+    <block type="logic_operation"></block>
+    <block type="logic_negate"></block>
+    <block type="logic_boolean"></block>
+</toolbox>

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/AlwaysOpenToolboxActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/AlwaysOpenToolboxActivity.java
@@ -1,20 +1,8 @@
-/*
- *  Copyright 2016 Google Inc. All Rights Reserved.
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
 package com.google.blockly.android.demo;
 
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+import android.view.View;
 
 import com.google.blockly.android.AbstractBlocklyActivity;
 import com.google.blockly.android.codegen.CodeGenerationRequest;
@@ -24,27 +12,35 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Simplest implementation of AbstractBlocklyActivity.
+ * Demonstration of how to replace {@code blockly_unified_layout} with a custom layout.
+ * This alternative layout that places the toolbox on top, configured to always remain open.
  */
-public class SimpleActivity extends AbstractBlocklyActivity {
+
+public class AlwaysOpenToolboxActivity extends AbstractBlocklyActivity {
     private static final String TAG = "SimpleActivity";
 
     private static final List<String> BLOCK_DEFINITIONS = Arrays.asList(
             "default/logic_blocks.json",
             "default/loop_blocks.json",
-            "default/math_blocks.json",
-            "default/text_blocks.json",
-            "default/list_blocks.json",
-            "default/colour_blocks.json",
-            "default/variable_blocks.json"
+            "default/math_blocks.json"
     );
     private static final List<String> JAVASCRIPT_GENERATORS = Arrays.asList(
-        // Custom block generators go here. Default blocks are already included.
-        // TODO(#99): Include Javascript defaults when other languages are supported.
+            // Custom block generators go here. Default blocks are already included.
+            // TODO(#99): Include Javascript defaults when other languages are supported.
     );
 
     CodeGenerationRequest.CodeGeneratorCallback mCodeGeneratorCallback =
             new LoggingCodeGeneratorCallback(this, TAG);
+
+    /**
+     * Inflates a layout for the contents of the app that includes a toolbox that is always open.
+     *
+     * @param containerId The container id to target if using a {@link Fragment}
+     * @return The {@link View} constructed. If using a {@link Fragment}, return null.
+     */
+    protected View onCreateContentView(int containerId) {
+        return getLayoutInflater().inflate(R.layout.always_open_toolbox, null);
+    }
 
     @NonNull
     @Override
@@ -55,7 +51,7 @@ public class SimpleActivity extends AbstractBlocklyActivity {
     @NonNull
     @Override
     protected String getToolboxContentsXmlPath() {
-        return "default/toolbox.xml";
+        return "simple_playground_toolbox.xml";
     }
 
     @NonNull
@@ -76,9 +72,5 @@ public class SimpleActivity extends AbstractBlocklyActivity {
         // Initialize variable names.
         // TODO: (#22) Remove this override when variables are supported properly
         getController().addVariable("item");
-        getController().addVariable("leo");
-        getController().addVariable("don");
-        getController().addVariable("mike");
-        getController().addVariable("raf");
     }
 }

--- a/blocklydemo/src/main/res/layout/always_open_toolbox.xml
+++ b/blocklydemo/src/main/res/layout/always_open_toolbox.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A Blockly workspace layout which places the toolbox on the top edge,
+  -  and is configured to always be open.
+  -->
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:blockly="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <fragment android:name="com.google.blockly.android.ToolboxFragment"
+        android:id="@+id/blockly_toolbox"
+        android:layout_width="match_parent"
+        android:layout_height="140dp"
+        android:layout_alignParentTop="true"
+        blockly:closeable="false"
+        blockly:scrollOrientation="horizontal"/>
+
+    <!-- This frame contains the workspace and closeable trash. -->
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_below="@id/blockly_toolbox">
+
+        <fragment android:name="com.google.blockly.android.WorkspaceFragment"
+            android:id="@+id/blockly_workspace"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            />
+
+        <fragment android:name="com.google.blockly.android.TrashFragment"
+            android:id="@+id/blockly_trash"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            blockly:closeable="true"
+            blockly:scrollOrientation="vertical"
+            tools:ignore="MissingPrefix"
+            />
+
+        <LinearLayout android:id="@+id/blockly_overlay_buttons"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:orientation="vertical">
+
+            <ImageButton android:id="@+id/blockly_zoom_in_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:background="@color/translucent"
+                android:padding="2dp"
+                android:src="@drawable/zoom_in"/>
+
+            <ImageButton android:id="@+id/blockly_zoom_out_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:background="@color/translucent"
+                android:padding="2dp"
+                android:src="@drawable/zoom_out"/>
+
+            <ImageButton android:id="@+id/blockly_center_view_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:background="@color/translucent"
+                android:padding="2dp"
+                android:src="@drawable/reset_view"/>
+
+            <ImageButton android:id="@+id/blockly_trash_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentBottom="true"
+                android:background="@color/translucent"
+                android:padding="2dp"
+                android:src="@drawable/trash"/>
+        </LinearLayout>
+    </FrameLayout>
+</RelativeLayout>

--- a/blocklydemo/src/main/res/values/strings.xml
+++ b/blocklydemo/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="level_2">Level 2</string>
     <string name="level_3">Level 3</string>
     <string name="simple_activity_name">Blockly Simple</string>
+    <string name="always_open_toolbox_activity_name">Always-open Toolbox</string>
     <string name="dev_activity_name">Blockly Dev Tests</string>
     <string name="comparison_activity_name">Blockly Web Comparison</string>
     <string name="split_activity_name">Blockly Split</string>

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ToolboxFragment.java
@@ -330,6 +330,13 @@ public class ToolboxFragment extends BlockDrawerFragment {
         outState.putBoolean(ARG_ROTATE_TABS, mRotateTabs);
     }
 
+    /**
+     * @return True if this {@code ToolboxFragment} displays tabs. Otherwise false.
+     */
+    public boolean hasTabs() {
+        return mCloseable || mCategoryTabs.getTabCount() > 1;
+    }
+
     protected CategoryTabs.LabelAdapter onCreateLabelAdapter() {
         return new DefaultTabsAdapter();
     }
@@ -350,7 +357,7 @@ public class ToolboxFragment extends BlockDrawerFragment {
      */
     protected void updateViews() {
         // If there is only one drawer and the drawer is not closeable, we don't need the tab.
-        if (!mCloseable && mCategoryTabs.getTabCount() <= 1) {
+        if (!hasTabs()) {
             mCategoryTabs.setVisibility(View.GONE);
         } else {
             mCategoryTabs.setVisibility(View.VISIBLE);
@@ -404,32 +411,38 @@ public class ToolboxFragment extends BlockDrawerFragment {
             buttonHorizontalPadding = buttonWidth;
         }
         int layoutDir = ViewCompat.getLayoutDirection(mRootView);
+        int spacingForTabs;
         switch (GravityCompat.getAbsoluteGravity(mTabEdge, layoutDir)) {
             case Gravity.LEFT:
-                mScrollablePadding.set(mCategoryTabs.getMeasuredWidth() + buttonHorizontalPadding,
-                        buttonVerticalPadding, 0, 0);
+                spacingForTabs = hasTabs() ? mCategoryTabs.getMeasuredWidth() : 0;  // Horizontal
+                mScrollablePadding.set(
+                        spacingForTabs + buttonHorizontalPadding, buttonVerticalPadding, 0, 0);
                 break;
             case Gravity.TOP:
+                spacingForTabs = hasTabs() ? mCategoryTabs.getMeasuredHeight() : 0;  // Vertical
                 if (layoutDir == ViewCompat.LAYOUT_DIRECTION_LTR) {
-                    mScrollablePadding.set(buttonHorizontalPadding,
-                            mCategoryTabs.getMeasuredHeight() + buttonVerticalPadding, 0, 0);
+                    mScrollablePadding.set(
+                            buttonHorizontalPadding, spacingForTabs + buttonVerticalPadding,
+                            0, 0);
                 } else {
-                    mScrollablePadding.set(0,
-                            mCategoryTabs.getMeasuredHeight() + buttonVerticalPadding,
+                    mScrollablePadding.set(
+                            0, spacingForTabs + buttonVerticalPadding,
                             buttonHorizontalPadding, 0);
                 }
                 break;
             case Gravity.RIGHT:
-                mScrollablePadding.set(0, buttonVerticalPadding,
-                        mCategoryTabs.getMeasuredWidth() + buttonHorizontalPadding, 0);
+                spacingForTabs = hasTabs() ? mCategoryTabs.getMeasuredWidth() : 0;  // Horizontal
+                mScrollablePadding.set(
+                        0, buttonVerticalPadding, spacingForTabs + buttonHorizontalPadding, 0);
                 break;
             case Gravity.BOTTOM:
+                spacingForTabs = hasTabs() ? mCategoryTabs.getMeasuredHeight() : 0;  // Vertical
                 if (layoutDir == ViewCompat.LAYOUT_DIRECTION_LTR) {
-                    mScrollablePadding.set(buttonHorizontalPadding, 0, 0,
-                            mCategoryTabs.getMeasuredHeight() + buttonVerticalPadding);
+                    mScrollablePadding.set(
+                            buttonHorizontalPadding, 0, 0, spacingForTabs + buttonVerticalPadding);
                 } else {
-                    mScrollablePadding.set(0, 0, buttonHorizontalPadding,
-                            mCategoryTabs.getMeasuredHeight() + buttonVerticalPadding);
+                    mScrollablePadding.set(
+                            0, 0, buttonHorizontalPadding, spacingForTabs + buttonVerticalPadding);
                 }
                 break;
         }


### PR DESCRIPTION
Specifically, showing a toolbox on top that is always open.
Fixing a bug in configuration of BlockList block spacing when no tabs are present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/440)
<!-- Reviewable:end -->
