### PR TITLE
TIdy up code to remove some nulls (and their checks).

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -1050,10 +1050,7 @@ public class BlocklyController {
         newVariable = addVariableImpl(newVariable, true);
         List<FieldVariable> varRefs = mWorkspace.getVariableRefs(variable);
         if (varRefs != null) {
-            int count = varRefs.size();
-
-            for (int i = 0; i < count; i++) {
-                FieldVariable field = varRefs.get(i);
+            for (FieldVariable field : varRefs) {
                 field.setVariable(newVariable);
                 BlocklyEvent.ChangeEvent change = BlocklyEvent.ChangeEvent
                         .newFieldValueEvent(getWorkspace(), field.getBlock(), field,

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
@@ -72,8 +72,10 @@ public class WorkspaceStats {
         return mVariableNameManager;
     }
 
-    public SimpleArrayMap<String, List<FieldVariable>> getVariableReferences() {
-        return mVariableReferences;
+    public List<FieldVariable> getVariableReference(String variable) {
+        return mVariableReferences.containsKey(variable) ?
+            mVariableReferences.get(variable) :
+            new ArrayList<FieldVariable>();
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
@@ -236,11 +236,9 @@ public class Workspace {
      * @return The list of fields that are using the given variable.
      */
     public List<FieldVariable> getVariableRefs(String variable) {
-        List<FieldVariable> refs = mStats.getVariableReferences().get(variable);
+        List<FieldVariable> refs = mStats.getVariableReference(variable);
         List<FieldVariable> copy = new ArrayList<>(refs == null ? 0 : refs.size());
-        if (refs != null) {
-            copy.addAll(refs);
-        }
+        copy.addAll(refs);
         return copy;
     }
 
@@ -251,8 +249,7 @@ public class Workspace {
      * @return The number of times that variable appears in this workspace.
      */
     public int getVariableRefCount(String variable) {
-        List<FieldVariable> refs = mStats.getVariableReferences().get(variable);
-        return refs == null ? 0 : refs.size();
+        return mStats.getVariableReference(variable).size();
     }
 
     /**
@@ -264,12 +261,12 @@ public class Workspace {
      * @return A list of all blocks referencing the given variable.
      */
     public List<Block> getBlocksWithVariable(String variable, List<Block> resultList) {
-        List<FieldVariable> refs = mStats.getVariableReferences().get(variable);
+        List<FieldVariable> refs = mStats.getVariableReference(variable);
         if (resultList == null) {
             resultList = new ArrayList<>();
         }
-        for (int i = 0; i < refs.size(); i++) {
-            Block block = refs.get(i).getBlock();
+        for(FieldVariable field : refs) {
+            Block block = field.getBlock();
             if (!resultList.contains(block)) {
                 resultList.add(block);
             }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/WorkspaceStatsTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/WorkspaceStatsTest.java
@@ -98,10 +98,14 @@ public class WorkspaceStatsTest {
         assertTrue(mStats.getVariableNameManager().contains("variable name"));
         assertFalse(mStats.getVariableNameManager().contains("field name"));
 
-        assertEquals(1, mStats.getVariableReferences().size());
-        assertEquals(2, mStats.getVariableReferences().get("variable name").size());
+        assertEquals(2, mStats.getVariableReference("variable name").size());
         assertEquals(variableReference.getFieldByName("field name"),
-                mStats.getVariableReferences().get("variable name").get(0));
+                mStats.getVariableReference("variable name").get(0));
+    }
+
+    @Test
+    public void testVariableReferencesNeverNull() {
+        assertNotNull(mStats.getVariableReference("not a reference"));
     }
 
     @Test


### PR DESCRIPTION
Minor refactoring to remove some null checks around some lists (and return empty lists instead of nulls).

There's a change on WorkspaceStats to make `getVariableReferences()` -> `getVariableReference(String)` as that was always how it was being used. You might potentially not want to do that if we're expecting other people to integrate with the WorkspaceStats class (as it would be a breaking change).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/468)
<!-- Reviewable:end -->
