### PR TITLE
#432 Include current variable name when renaming a variable.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -916,14 +916,14 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
 
         @Override
         public boolean onRenameVariable(String variable, String newName) {
-            mNameDialog.setVariable(variable, mRenameCallback);
+            mNameDialog.setVariable(variable, mRenameCallback, true);
             mNameDialog.show(getSupportFragmentManager(), "RenameVariable");
             return false;
         }
 
         @Override
         public boolean onCreateVariable(String variable) {
-            mNameDialog.setVariable(variable, mCreateCallback);
+            mNameDialog.setVariable(variable, mCreateCallback, false);
             mNameDialog.show(getSupportFragmentManager(), "CreateVariable");
             return false;
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/NameVariableDialog.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/NameVariableDialog.java
@@ -8,9 +8,9 @@ import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import com.google.blockly.android.R;
-import com.google.blockly.android.control.BlocklyController;
 
 /**
  * Default dialog window shown when creating or renaming a variable in the workspace.
@@ -19,6 +19,7 @@ public class NameVariableDialog extends DialogFragment {
     private String mVariable;
     private DialogInterface.OnClickListener mListener;
     private EditText mNameEditText;
+    private boolean mIsRename;
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceBundle) {
@@ -26,6 +27,12 @@ public class NameVariableDialog extends DialogFragment {
         View nameView = inflater.inflate(R.layout.name_variable_view, null);
         mNameEditText = (EditText) nameView.findViewById(R.id.name);
         mNameEditText.setText(mVariable);
+
+        if (mIsRename) {
+            TextView description = (TextView) nameView.findViewById(R.id.description);
+            description.setText(
+                String.format(getString(R.string.rename_variable_message), mVariable));
+        }
 
         AlertDialog.Builder bob = new AlertDialog.Builder(getActivity());
         bob.setTitle(R.string.name_variable_title);
@@ -35,11 +42,12 @@ public class NameVariableDialog extends DialogFragment {
         return bob.create();
     }
 
-    public void setVariable(String variable, final Callback clickListener) {
+    public void setVariable(String variable, final Callback clickListener, boolean isRename) {
         if (clickListener == null) {
             throw new IllegalArgumentException("Must have a listener to perform an action.");
         }
         mVariable = variable;
+        mIsRename = isRename;
         mListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {

--- a/blocklylib-core/src/main/res/layout/name_variable_view.xml
+++ b/blocklylib-core/src/main/res/layout/name_variable_view.xml
@@ -9,12 +9,19 @@
         android:layout_height="wrap_content"
         android:text="@string/name_variable_message"
         android:id="@+id/description"
-        android:layout_gravity="center_horizontal"/>
+        android:layout_gravity="left"
+        android:layout_marginTop="8dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"/>
 
     <EditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/name"
         android:layout_gravity="center_horizontal"
-        android:singleLine="true"/>
+        android:singleLine="true"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"/>
 </LinearLayout>

--- a/blocklylib-core/src/main/res/values/strings.xml
+++ b/blocklylib-core/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <!-- Message shown when creating or renaming a variable. -->
     <string name="name_variable_title">Variable name</string>
     <string name="name_variable_message">New variable name</string>
+    <string name="rename_variable_message">Rename variable from: %s</string>
     <string name="name_variable_positive">OK</string>
     <string name="name_variable_negative">Cancel</string>
 

--- a/blocklylib-core/src/main/res/values/strings.xml
+++ b/blocklylib-core/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <!-- Message shown when creating or renaming a variable. -->
     <string name="name_variable_title">Variable name</string>
     <string name="name_variable_message">New variable name</string>
-    <string name="rename_variable_message">Rename variable from: %s</string>
+    <string name="rename_variable_message">Rename variable from "%s"</string>
     <string name="name_variable_positive">OK</string>
     <string name="name_variable_negative">Cancel</string>
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/NameVariableDialogTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/NameVariableDialogTest.java
@@ -1,0 +1,55 @@
+package com.google.blockly.android.ui;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.google.blockly.android.BlocklyTestActivity;
+import com.google.blockly.android.BlocklyTestCase;
+import com.google.blockly.android.test.R;
+
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.mockito.Mockito.mock;
+
+@RunWith(AndroidJUnit4.class)
+public class NameVariableDialogTest extends BlocklyTestCase {
+
+  private NameVariableDialog mNameVariableDialogFragment;
+  private BlocklyTestActivity mActivity;
+
+  @Rule
+  public final ActivityTestRule<BlocklyTestActivity> mActivityRule =
+      new ActivityTestRule<>(BlocklyTestActivity.class);
+
+  @Before
+  public void setUp() throws Exception {
+    configureForUIThread();
+    mNameVariableDialogFragment = new NameVariableDialog();
+
+    mActivity = mActivityRule.getActivity();
+  }
+
+  @Test
+  public void dialogShowsOldVariableNameWhenRenaming() throws Exception {
+    String variableName = "oldVariableName";
+
+    mNameVariableDialogFragment.setVariable(variableName, mock(NameVariableDialog.Callback.class), true);
+    mNameVariableDialogFragment.show(mActivity.getSupportFragmentManager(), "RenameFragment");
+    onView(withId(R.id.description)).check(matches(withText(new StringContains(variableName))));
+  }
+
+  @Test
+  public void dialogShowsGenericTextForNewVariable() throws Exception {
+    mNameVariableDialogFragment.setVariable("", mock(NameVariableDialog.Callback.class), false);
+    mNameVariableDialogFragment.show(mActivity.getSupportFragmentManager(), "CreateFragment");
+    onView(withId(R.id.description)).check(matches(withText("New variable name")));
+  }
+}


### PR DESCRIPTION
The "name variable" popup now contains the old name in the text if it's being renamed.

I've also added tests around the old and new functionality.

I also tweaked the layout of the popup to be a bit less cramped (but happy to revert that file if you don't like the changes).

Screenshot of updated layout included

![screenshot_20161221-184810](https://cloud.githubusercontent.com/assets/3234691/21401929/1943a856-c7ae-11e6-83b3-0bc4e85d5610.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/469)
<!-- Reviewable:end -->
