### PR TITLE
#466 Add fluent assertions across all tests.

### DIFF
--- a/blocklytest/build.gradle
+++ b/blocklytest/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
 
+        multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -29,6 +30,7 @@ android {
 dependencies {
     androidTestCompile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
+    androidTestCompile 'com.google.truth:truth:0.31'
     androidTestCompile 'com.android.support:appcompat-v7:23.3.+'
     compile project(':blocklylib-vertical')
     // For UI testing with Espresso.

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Unit tests for CodeGeneratorService
@@ -50,9 +50,9 @@ public class CodeGeneratorServiceTest {
 
         Matcher matcher = Pattern.compile("javascript:generate\\('(.*)'\\);",
                 Pattern.DOTALL | Pattern.MULTILINE).matcher(url);
-        assertTrue(matcher.matches());
+        assertThat(matcher.matches()).isTrue();
         String jsString = matcher.group(1);
-        assertTrue(jsString.contains("apostrophe \\' end"));
+        assertThat(jsString.contains("apostrophe \\' end")).isTrue();
     }
 
     /**
@@ -73,9 +73,9 @@ public class CodeGeneratorServiceTest {
         String url = CodeGeneratorService.buildCodeGenerationUrl(xml);
 
         Matcher matcher = Pattern.compile("javascript:generateEscaped\\('(.*)'\\);").matcher(url);
-        assertTrue(matcher.matches());
+        assertThat(matcher.matches()).isTrue();
         String jsString = matcher.group(1);
-        assertTrue(jsString.contains("apostrophe%20%27%20end"));
+        assertThat(jsString.contains("apostrophe%20%27%20end")).isTrue();
     }
 
     private String toXml(Block block) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -38,13 +38,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Unit tests for {@link BlocklyController}.
@@ -96,15 +91,15 @@ public class BlocklyControllerTest extends BlocklyTestCase {
 
     @Test
     public void testAddRootBlock() {
-        assertTrue(mEventsFired.isEmpty());
+        assertThat(mEventsFired.isEmpty()).isTrue();
 
         Block block = mBlockFactory.obtainBlock("simple_input_output", "connectTarget");
         mController.addRootBlock(block);
 
-        assertTrue(mWorkspace.getRootBlocks().contains(block));
-        assertEquals(mEventsFired.size(), 1);
-        assertEquals(mEventsFired.get(0).getTypeId(), BlocklyEvent.TYPE_CREATE);
-        assertEquals(mEventsFired.get(0).getBlockId(), block.getId());
+        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+        assertThat(1).isEqualTo(mEventsFired.size());
+        assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
+        assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
     }
 
     @Test
@@ -113,12 +108,12 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.addRootBlock(block);
 
         mEventsFired.clear();
-        assertTrue(mController.trashRootBlock(block));
+        assertThat(mController.trashRootBlock(block)).isTrue();
 
-        assertTrue(mWorkspace.getRootBlocks().isEmpty());
-        assertEquals(1, mEventsFired.size());
-        assertEquals(BlocklyEvent.TYPE_DELETE, mEventsFired.get(0).getTypeId());
-        assertEquals(block.getId(), mEventsFired.get(0).getBlockId());
+        assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
+        assertThat(mEventsFired.size()).isEqualTo(1);
+        assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
+        assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
     }
 
     @Test
@@ -128,10 +123,10 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.addRootBlock(block);
 
         mEventsFired.clear();
-        assertFalse(mController.trashRootBlock(block));
+        assertThat(mController.trashRootBlock(block)).isFalse();
 
-        assertEquals(1, mWorkspace.getRootBlocks().size());  // Still there!
-        assertEquals(0, mEventsFired.size());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);  // Still there!
+        assertThat(mEventsFired.size()).isEqualTo(0);
     }
 
     @Test
@@ -141,12 +136,12 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.addRootBlock(block);
 
         mEventsFired.clear();
-        assertTrue(mController.trashRootBlockIgnoringDeletable(block));
+        assertThat(mController.trashRootBlockIgnoringDeletable(block)).isTrue();
 
-        assertTrue(mWorkspace.getRootBlocks().isEmpty());
-        assertEquals(1, mEventsFired.size());
-        assertEquals(BlocklyEvent.TYPE_DELETE, mEventsFired.get(0).getTypeId());
-        assertEquals(block.getId(), mEventsFired.get(0).getBlockId());
+        assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
+        assertThat(mEventsFired.size()).isEqualTo(1);
+        assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
+        assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
     }
 
     @Test
@@ -158,10 +153,10 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mEventsFired.clear();
         mController.addBlockFromTrash(block);
 
-        assertTrue(mWorkspace.getRootBlocks().contains(block));
-        assertEquals(mEventsFired.size(), 1);
-        assertEquals(mEventsFired.get(0).getTypeId(), BlocklyEvent.TYPE_CREATE);
-        assertEquals(mEventsFired.get(0).getBlockId(), block.getId());
+        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+        assertThat(1).isEqualTo(mEventsFired.size());
+        assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
+        assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
     }
 
     @Test
@@ -192,48 +187,48 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             // Validate initial view state.
             BlockView targetView = mHelper.getView(target);
             BlockView sourceView = mHelper.getView(source);
-            assertNotNull(targetView);
-            assertNotNull(sourceView);
-            assertNotSame(mHelper.getRootBlockGroup(target),
-                    mHelper.getRootBlockGroup(source));
+            assertThat(targetView).isNotNull();
+            assertThat(sourceView).isNotNull();
+            assertThat(mHelper.getRootBlockGroup(target))
+                .isNotSameAs(mHelper.getRootBlockGroup(source));
         }
 
         // Perform test: connection source's output to target's input.
         mController.connect(sourceConnection, targetConnection);
 
         // Validate model changes.
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, sourceConnection.getTargetBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(sourceConnection.getTargetBlock());
 
         if (withViews) {
             // Validate view changes
             BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
         }
 
         // Add the shadow connection and disconnect the block
         targetConnection.setShadowConnection(shadow.getOutputConnection());
         mController.extractBlockAsRoot(source);
-        assertNull(source.getParentBlock());
+        assertThat(source.getParentBlock()).isNull();
         // Validate the block was replaced by the shadow
-        assertEquals(targetConnection.getTargetBlock(), shadow);
+        assertThat(shadow).isEqualTo(targetConnection.getTargetBlock());
 
         if (withViews) {
             // Check that the shadow block now has views
-            assertNotNull(mHelper.getView(shadow));
+            assertThat(mHelper.getView(shadow)).isNotNull();
             BlockGroup shadowGroup = mHelper.getParentBlockGroup(target);
-            assertSame(shadowGroup, mHelper.getRootBlockGroup(shadow));
+            assertThat(shadowGroup).isSameAs(mHelper.getRootBlockGroup(shadow));
         }
 
         // Reattach the block and verify the shadow is hidden again
         mController.connect(sourceConnection, targetConnection);
-        assertEquals(targetConnection.getTargetBlock(), source);
-        assertNull(shadow.getOutputConnection().getTargetBlock());
+        assertThat(source).isEqualTo(targetConnection.getTargetBlock());
+        assertThat(shadow.getOutputConnection().getTargetBlock()).isNull();
 
         if (withViews) {
-            assertNull(mHelper.getView(shadow));
+            assertThat(mHelper.getView(shadow)).isNull();
         }
     }
 
@@ -264,36 +259,36 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         }
 
         // Validate preconditions
-        assertEquals(2, mWorkspace.getRootBlocks().size());
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertTrue(mWorkspace.isRootBlock(source));
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isTrue();
 
         // Perform test: Connect the source to where the tail is currently attached.
         mController.connect(
                 source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
         // source is now a child of target, and tail is a new root block
-        assertEquals(2, mWorkspace.getRootBlocks().size());
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertTrue(mWorkspace.isRootBlock(tail));
-        assertSame(target, target.getRootBlock());
-        assertSame(target, source.getRootBlock());
-        assertSame(tail, tail.getRootBlock());
-        assertNull(tail.getOutputConnection().getTargetBlock());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
+        assertThat(target).isSameAs(target.getRootBlock());
+        assertThat(target).isSameAs(source.getRootBlock());
+        assertThat(tail).isSameAs(tail.getRootBlock());
+        assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
 
         if (withViews) {
             BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
             BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
-            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
-            assertSame(tailGroup, mHelper.getRootBlockGroup(tail));
-            assertNotSame(targetGroup, tailGroup);
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(targetGroup).isNotSameAs(tailGroup);
 
             // Check that tail has been bumped far enough away.
-            assertTrue(mHelper.getMaxSnapDistance() <=
-                    tail.getOutputConnection().distanceFrom(source.getOutputConnection()));
+            assertThat(mHelper.getMaxSnapDistance() <=
+                    tail.getOutputConnection().distanceFrom(source.getOutputConnection())).isTrue();
         }
     }
 
@@ -328,14 +323,14 @@ public class BlocklyControllerTest extends BlocklyTestCase {
                 source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
         // Source is now a child of target
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, source.getOutputConnection().getTargetBlock());
-        assertSame(target, source.getRootBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
+        assertThat(target).isSameAs(source.getRootBlock());
 
         // Tail has been returned to the workspace root, bumped some distance.
-        assertNull(tail.getOutputConnection().getTargetBlock());
-        assertTrue(mWorkspace.isRootBlock(tail));
+        assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
+        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
 
         if (withViews) {
             BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
@@ -344,12 +339,12 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             targetGroup.updateAllConnectorLocations();
             tailGroup.updateAllConnectorLocations();
 
-            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
-            assertSame(tailGroup, mHelper.getRootBlockGroup(tail));
-            assertNotSame(targetGroup, tailGroup);
-            assertTrue(mHelper.getMaxSnapDistance() <=
-                    source.getOutputConnection().distanceFrom(tail.getOutputConnection()));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(targetGroup).isNotSameAs(tailGroup);
+            assertThat(mHelper.getMaxSnapDistance() <=
+                    source.getOutputConnection().distanceFrom(tail.getOutputConnection())).isTrue();
         }
     }
 
@@ -385,31 +380,31 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         }
 
         // Validate preconditions
-        assertEquals(2, mWorkspace.getRootBlocks().size());
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertTrue(mWorkspace.isRootBlock(source));
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isTrue();
 
         // Perform test: Connect the source to where the tail is currently attached.
         mController.connect(
                 source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
         // source is now a child of target, and tail replaced the shadow
-        assertEquals(1, mWorkspace.getRootBlocks().size());
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertSame(target, target.getRootBlock());
-        assertSame(target, source.getRootBlock());
-        assertSame(target, tail.getRootBlock());
-        assertSame(source, tail.getParentBlock());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(target).isSameAs(target.getRootBlock());
+        assertThat(target).isSameAs(source.getRootBlock());
+        assertThat(target).isSameAs(tail.getRootBlock());
+        assertThat(source).isSameAs(tail.getParentBlock());
 
         if (withViews) {
             BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(tail));
-            assertNull(mHelper.getView(shadow));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(mHelper.getView(shadow)).isNull();
         }
     }
 
@@ -449,17 +444,17 @@ public class BlocklyControllerTest extends BlocklyTestCase {
                 source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
         // Validate
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, source.getOutputConnection().getTargetBlock());
-        assertSame(source, tail.getOutputConnection().getTargetBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
+        assertThat(source).isSameAs(tail.getOutputConnection().getTargetBlock());
 
         if (withViews) {
             BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertSame(targetGroup, mHelper.getRootBlockGroup(target));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(tail));
-            assertSame(targetGroup, mHelper.getRootBlockGroup(source));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
         }
     }
 
@@ -489,48 +484,48 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             targetView = mHelper.getView(target);
             sourceView = mHelper.getView(source);
 
-            assertNotNull(targetView);
-            assertNotNull(sourceView);
+            assertThat(targetView).isNotNull();
+            assertThat(sourceView).isNotNull();
         }
 
         // Connect source after target. No prior connection to bump or splice.
         mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
         // Validate
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, source.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(source.getPreviousBlock());
 
         if (withViews) {
             BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mHelper.getParentBlockGroup(source));
-            assertSame(targetView, rootGroup.getChildAt(0));
-            assertSame(sourceView, rootGroup.getChildAt(1));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
+            assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
+            assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));
         }
 
         // Add the shadow to the target's next connection so the view will be created.
         target.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
         mController.extractBlockAsRoot(source);
 
-        assertTrue(mWorkspace.isRootBlock(source));
-        assertSame(target.getNextBlock(), shadow);
+        assertThat(mWorkspace.isRootBlock(source)).isTrue();
+        assertThat(target.getNextBlock()).isSameAs(shadow);
 
         if (withViews) {
             BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mHelper.getParentBlockGroup(shadow));
-            assertNotSame(rootGroup, mHelper.getParentBlockGroup(source));
-            assertSame(mHelper.getView(shadow), rootGroup.getChildAt(1));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(shadow));
+            assertThat(rootGroup).isNotSameAs(mHelper.getParentBlockGroup(source));
+            assertThat(mHelper.getView(shadow)).isSameAs(rootGroup.getChildAt(1));
         }
 
         // Reattach the source and verify the shadow went away.
         mController.connect(source.getPreviousConnection(), target.getNextConnection());
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target.getNextBlock(), source);
-        assertNull(shadow.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target.getNextBlock()).isSameAs(source);
+        assertThat(shadow.getPreviousBlock()).isNull();
 
         if (withViews) {
-            assertNull(mHelper.getView(shadow));
+            assertThat(mHelper.getView(shadow)).isNull();
         }
     }
 
@@ -566,25 +561,25 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             tailView = mHelper.getView(tail);
             sourceView = mHelper.getView(source);
 
-            assertNotNull(targetView);
-            assertNotNull(tailView);
-            assertNotNull(sourceView);
+            assertThat(targetView).isNotNull();
+            assertThat(tailView).isNotNull();
+            assertThat(sourceView).isNotNull();
         }
 
         // Connect source after target, where tail is currently attached, causing a splice.
         mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
-        assertSame(target, source.getPreviousBlock());
-        assertSame(source, tail.getPreviousBlock());
+        assertThat(target).isSameAs(source.getPreviousBlock());
+        assertThat(source).isSameAs(tail.getPreviousBlock());
 
         if (withViews) {
             BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mHelper.getParentBlockGroup(tail));
-            assertSame(rootGroup, mHelper.getParentBlockGroup(source));
-            assertSame(targetView, rootGroup.getChildAt(0));
-            assertSame(sourceView, rootGroup.getChildAt(1));  // Spliced in between.
-            assertSame(tailView, rootGroup.getChildAt(2));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
+            assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
+            assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));  // Spliced in between.
+            assertThat(tailView).isSameAs(rootGroup.getChildAt(2));
         }
     }
 
@@ -621,10 +616,10 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             tailView2 = mHelper.getView(tail2);
             sourceView = mHelper.getView(source);
 
-            assertNotNull(targetView);
-            assertNotNull(tailView1);
-            assertNotNull(tailView2);
-            assertNotNull(sourceView);
+            assertThat(targetView).isNotNull();
+            assertThat(tailView1).isNotNull();
+            assertThat(tailView2).isNotNull();
+            assertThat(sourceView).isNotNull();
         }
 
         // Run test: Connect source after target, where tail is currently attached.
@@ -632,32 +627,32 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
         // Target and source are connected.
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertSame(target, source.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(target).isSameAs(source.getPreviousBlock());
 
         // Tail has been returned to the workspace root.
-        assertTrue(mWorkspace.isRootBlock(tail1));
-        assertNull(tail1.getPreviousBlock());
-        assertFalse(mWorkspace.isRootBlock(tail2));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(tail1, tail1.getRootBlock());
-        assertSame(tail1, tail2.getRootBlock());
+        assertThat(mWorkspace.isRootBlock(tail1)).isTrue();
+        assertThat(tail1.getPreviousBlock()).isNull();
+        assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(tail1).isSameAs(tail1.getRootBlock());
+        assertThat(tail1).isSameAs(tail2.getRootBlock());
 
         if (withViews) {
             BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
             BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail1);
-            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
-            assertNotSame(targetRootGroup, tailRootGroup);
-            assertSame(tailRootGroup, mHelper.getRootBlockGroup(tail2));
-            assertSame(targetView, targetRootGroup.getChildAt(0));
-            assertSame(sourceView, targetRootGroup.getChildAt(1));
-            assertSame(tailView1, tailRootGroup.getChildAt(0));
-            assertSame(tailView2, tailRootGroup.getChildAt(1));
+            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
+            assertThat(tailRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
+            assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
+            assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
+            assertThat(tailView1).isSameAs(tailRootGroup.getChildAt(0));
+            assertThat(tailView2).isSameAs(tailRootGroup.getChildAt(1));
 
             // Check that tail has been bumped far enough away.
-            assertTrue(mHelper.getMaxSnapDistance() <=
-                    tail1.getPreviousConnection().distanceFrom(target.getNextConnection()));
+            assertThat(mHelper.getMaxSnapDistance() <=
+                    tail1.getPreviousConnection().distanceFrom(target.getNextConnection())).isTrue();
         }
     }
 
@@ -698,11 +693,11 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             tailView2 = mHelper.getView(tail2);
             sourceView = mHelper.getView(source);
 
-            assertNotNull(targetView);
-            assertNotNull(tailView1);
-            assertNotNull(tailView2);
-            assertNotNull(sourceView);
-            assertNotNull(mHelper.getView(shadowTail));
+            assertThat(targetView).isNotNull();
+            assertThat(tailView1).isNotNull();
+            assertThat(tailView2).isNotNull();
+            assertThat(sourceView).isNotNull();
+            assertThat(mHelper.getView(shadowTail)).isNotNull();
         }
 
         // Run test: Connect source after target, where tail is currently attached.
@@ -710,31 +705,31 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
         // Target and source are connected.
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertSame(target, source.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(target).isSameAs(source.getPreviousBlock());
 
         // Tail has replaced the shadow.
-        assertFalse(mWorkspace.isRootBlock(tail1));
-        assertNull(shadowTail.getPreviousBlock());
-        assertSame(source, tail1.getParentBlock());
-        assertFalse(mWorkspace.isRootBlock(tail2));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, tail1.getRootBlock());
-        assertSame(target, tail2.getRootBlock());
+        assertThat(mWorkspace.isRootBlock(tail1)).isFalse();
+        assertThat(shadowTail.getPreviousBlock()).isNull();
+        assertThat(source).isSameAs(tail1.getParentBlock());
+        assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(tail1.getRootBlock());
+        assertThat(target).isSameAs(tail2.getRootBlock());
 
         if (withViews) {
             BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
-            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(tail1));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(tail2));
+            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail1));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
 
-            assertSame(targetView, targetRootGroup.getChildAt(0));
-            assertSame(sourceView, targetRootGroup.getChildAt(1));
-            assertSame(tailView1, targetRootGroup.getChildAt(2));
-            assertSame(tailView2, targetRootGroup.getChildAt(3));
+            assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
+            assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
+            assertThat(tailView1).isSameAs(targetRootGroup.getChildAt(2));
+            assertThat(tailView2).isSameAs(targetRootGroup.getChildAt(3));
 
-            assertNull(mHelper.getView(shadowTail));
+            assertThat(mHelper.getView(shadowTail)).isNull();
         }
     }
 
@@ -766,14 +761,14 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         // Run test: Connect source inside target. No prior connection to bump.
         mController.connect(source.getPreviousConnection(), statementConnection);
 
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, source.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(source.getPreviousBlock());
 
         if (withViews) {
             BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertSame(rootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(rootGroup, mHelper.getRootBlockGroup(source));
+            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(source));
         }
 
         // Add the shadow block
@@ -781,24 +776,24 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         // disconnect the real blocks which should attach the shadow to replace it.
         mController.extractBlockAsRoot(source);
 
-        assertTrue(mWorkspace.isRootBlock(source));
-        assertFalse(mWorkspace.isRootBlock(shadow));
-        assertSame(statementConnection.getTargetBlock(), shadow);
+        assertThat(mWorkspace.isRootBlock(source)).isTrue();
+        assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
+        assertThat(statementConnection.getTargetBlock()).isSameAs(shadow);
 
         if (withViews) {
-            assertNotNull(mHelper.getView(shadow));
-            assertSame(mHelper.getRootBlockGroup(target), mHelper.getRootBlockGroup(shadow));
+            assertThat(mHelper.getView(shadow)).isNotNull();
+            assertThat(mHelper.getRootBlockGroup(target)).isSameAs(mHelper.getRootBlockGroup(shadow));
         }
 
         // Reconnect the source and make sure the shadow goes away
         mController.connect(source.getPreviousConnection(), statementConnection);
-        assertNull(shadow.getPreviousBlock());
-        assertSame(statementConnection.getTargetBlock(), source);
-        assertFalse(mWorkspace.isRootBlock(shadow));
+        assertThat(shadow.getPreviousBlock()).isNull();
+        assertThat(statementConnection.getTargetBlock()).isSameAs(source);
+        assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
 
         if (withViews) {
-            assertNull(mHelper.getView(shadow));
-            assertSame(mHelper.getRootBlockGroup(target), mHelper.getRootBlockGroup(source));
+            assertThat(mHelper.getView(shadow)).isNull();
+            assertThat(mHelper.getRootBlockGroup(target)).isSameAs(mHelper.getRootBlockGroup(source));
         }
     }
 
@@ -836,29 +831,29 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             tailView = mHelper.getView(tail);
             sourceView = mHelper.getView(source);
 
-            assertNotNull(targetView);
-            assertNotNull(tailView);
-            assertNotNull(sourceView);
+            assertThat(targetView).isNotNull();
+            assertThat(tailView).isNotNull();
+            assertThat(sourceView).isNotNull();
         }
 
         // Run test: Connect source inside target, where tail is attached, resulting in a splice.
         mController.connect(source.getPreviousConnection(), statementConnection);
 
         // Validate result.
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target, source.getPreviousBlock());
-        assertSame(source, tail.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target).isSameAs(source.getPreviousBlock());
+        assertThat(source).isSameAs(tail.getPreviousBlock());
 
         if (withViews) {
             BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
             BlockGroup secondGroup = mHelper.getParentBlockGroup(tail);
-            assertSame(rootGroup, mHelper.getRootBlockGroup(tail));
-            assertNotSame(rootGroup, secondGroup);
-            assertSame(secondGroup, mHelper.getParentBlockGroup(source));
-            assertSame(sourceView, secondGroup.getChildAt(0));
-            assertSame(tailView, secondGroup.getChildAt(1));
+            assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(rootGroup).isNotSameAs(secondGroup);
+            assertThat(secondGroup).isSameAs(mHelper.getParentBlockGroup(source));
+            assertThat(sourceView).isSameAs(secondGroup.getChildAt(0));
+            assertThat(tailView).isSameAs(secondGroup.getChildAt(1));
         }
     }
 
@@ -889,7 +884,7 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             fakeOnAttachToWindow(target, source);
 
             sourceView = mHelper.getView(source);
-            assertNotNull(sourceView);
+            assertThat(sourceView).isNotNull();
         }
 
         // Connect source inside target, where tail is attached.  Source does not have a next, so
@@ -898,25 +893,25 @@ public class BlocklyControllerTest extends BlocklyTestCase {
                             target.getInputByName("statement input").getConnection());
 
         // Validate
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertTrue(mWorkspace.isRootBlock(tail));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(target.getInputByName("statement input").getConnection(),
-                source.getPreviousConnection().getTargetConnection());
-        assertNull(tail.getPreviousBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(target.getInputByName("statement input").getConnection())
+            .isSameAs(source.getPreviousConnection().getTargetConnection());
+        assertThat(tail.getPreviousBlock()).isNull();
 
         if (withViews) {
             BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
             BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail);
             BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
-            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
-            assertNotSame(targetRootGroup, tailRootGroup);
-            assertSame(tailRootGroup, mHelper.getParentBlockGroup(tail));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
-            assertSame(sourceGroup.getParent(), target.getInputByName("statement input").getView());
-            assertSame(sourceView, sourceGroup.getChildAt(0));
-            assertTrue(mHelper.getMaxSnapDistance() <=
-                    source.getPreviousConnection().distanceFrom(tail.getPreviousConnection()));
+            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
+            assertThat(tailRootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(sourceGroup.getParent()).isSameAs(target.getInputByName("statement input").getView());
+            assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
+            assertThat(mHelper.getMaxSnapDistance() <=
+                    source.getPreviousConnection().distanceFrom(tail.getPreviousConnection())).isTrue();
         }
     }
 
@@ -952,8 +947,8 @@ public class BlocklyControllerTest extends BlocklyTestCase {
             fakeOnAttachToWindow(target, source);
 
             sourceView = mHelper.getView(source);
-            assertNotNull(sourceView);
-            assertNotNull(mHelper.getView(shadow));
+            assertThat(sourceView).isNotNull();
+            assertThat(mHelper.getView(shadow)).isNotNull();
         }
 
         // Connect source inside target, where tail is attached.  Source has a shadow on next, so
@@ -961,25 +956,25 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.connect(source.getPreviousConnection(), statementConnection);
 
         // Validate
-        assertTrue(mWorkspace.isRootBlock(target));
-        assertFalse(mWorkspace.isRootBlock(tail));
-        assertFalse(mWorkspace.isRootBlock(source));
-        assertSame(statementConnection, source.getPreviousConnection().getTargetConnection());
-        assertSame(source, tail.getPreviousBlock());
-        assertNull(shadow.getParentBlock());
+        assertThat(mWorkspace.isRootBlock(target)).isTrue();
+        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+        assertThat(mWorkspace.isRootBlock(source)).isFalse();
+        assertThat(statementConnection).isSameAs(source.getPreviousConnection().getTargetConnection());
+        assertThat(source).isSameAs(tail.getPreviousBlock());
+        assertThat(shadow.getParentBlock()).isNull();
 
         if (withViews) {
             BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
             BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
-            assertSame(targetRootGroup, mHelper.getParentBlockGroup(target));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(tail));
-            assertSame(sourceGroup, mHelper.getParentBlockGroup(tail));
-            assertSame(targetRootGroup, mHelper.getRootBlockGroup(source));
-            assertSame(sourceGroup.getParent(), target.getInputByName("statement input").getView());
-            assertSame(sourceView, sourceGroup.getChildAt(0));
-            assertSame(mHelper.getView(tail), sourceGroup.getChildAt(1));
+            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+            assertThat(sourceGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+            assertThat(sourceGroup.getParent()).isSameAs(target.getInputByName("statement input").getView());
+            assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
+            assertThat(mHelper.getView(tail)).isSameAs(sourceGroup.getChildAt(1));
 
-            assertNull(mHelper.getView(shadow));
+            assertThat(mHelper.getView(shadow)).isNull();
         }
 
         // Make sure nothing breaks when we detach the tail and the shadow comes back
@@ -1006,19 +1001,19 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         }
 
         // Check Preconditions
-        assertEquals(mWorkspace.getRootBlocks().size(), 1);
-        assertTrue(mWorkspace.getRootBlocks().contains(block));
+        assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
+        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
 
         // Run test: Make block a root (even though it already is).
         mController.extractBlockAsRoot(block);
 
         // Validate (no change)
-        assertEquals(mWorkspace.getRootBlocks().size(), 1);
-        assertTrue(mWorkspace.getRootBlocks().contains(block));
+        assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
+        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
 
         if (withViews) {
             BlockGroup firstGroup = mHelper.getParentBlockGroup(block);
-            assertSame(firstGroup, mHelper.getRootBlockGroup(block));
+            assertThat(firstGroup).isSameAs(mHelper.getRootBlockGroup(block));
         }
     }
 
@@ -1045,25 +1040,25 @@ public class BlocklyControllerTest extends BlocklyTestCase {
 
         // Check preconditions
         List<Block> rootBlocks = mWorkspace.getRootBlocks();
-        assertEquals(rootBlocks.size(), 1);
-        assertEquals(rootBlocks.get(0), first);
+        assertThat(1).isEqualTo(rootBlocks.size());
+        assertThat(first).isEqualTo(rootBlocks.get(0));
 
         // Run test: Extract second out from under first.
         mController.extractBlockAsRoot(second);
 
         rootBlocks = mWorkspace.getRootBlocks();
-        assertEquals(rootBlocks.size(), 2);
-        assertTrue(rootBlocks.contains(first));
-        assertTrue(rootBlocks.contains(second));
-        assertFalse(first.getOnlyValueInput().getConnection().isConnected());
-        assertFalse(second.getOutputConnection().isConnected());
+        assertThat(2).isEqualTo(rootBlocks.size());
+        assertThat(rootBlocks.contains(first)).isTrue();
+        assertThat(rootBlocks.contains(second)).isTrue();
+        assertThat(first.getOnlyValueInput().getConnection().isConnected()).isFalse();
+        assertThat(second.getOutputConnection().isConnected()).isFalse();
 
         if (withViews) {
             BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
-            assertNotNull(firstGroup);
+            assertThat(firstGroup).isNotNull();
             BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
-            assertNotNull(secondGroup);
-            assertNotSame(secondGroup, firstGroup);
+            assertThat(secondGroup).isNotNull();
+            assertThat(secondGroup).isNotSameAs(firstGroup);
         }
     }
 
@@ -1090,12 +1085,12 @@ public class BlocklyControllerTest extends BlocklyTestCase {
 
         // Check preconditions
         List<Block> rootBlocks = mWorkspace.getRootBlocks();
-        assertEquals(rootBlocks.size(), 1);
-        assertEquals(rootBlocks.get(0), first);
-        assertEquals(second, first.getNextConnection().getTargetBlock());
+        assertThat(1).isEqualTo(rootBlocks.size());
+        assertThat(first).isEqualTo(rootBlocks.get(0));
+        assertThat(first.getNextConnection().getTargetBlock()).isEqualTo(second);
         if (withViews) {
-            assertSame(mHelper.getParentBlockGroup(first),
-                    mHelper.getParentBlockGroup(second));
+            assertThat(mHelper.getParentBlockGroup(first))
+                .isSameAs(mHelper.getParentBlockGroup(second));
         }
 
         // Run test: Extract second out from under first.
@@ -1103,18 +1098,18 @@ public class BlocklyControllerTest extends BlocklyTestCase {
 
         // Validate
         rootBlocks = mWorkspace.getRootBlocks();
-        assertEquals(rootBlocks.size(), 2);
-        assertTrue(rootBlocks.contains(first));
-        assertTrue(rootBlocks.contains(second));
-        assertFalse(first.getNextConnection().isConnected());
-        assertFalse(second.getPreviousConnection().isConnected());
+        assertThat(2).isEqualTo(rootBlocks.size());
+        assertThat(rootBlocks.contains(first)).isTrue();
+        assertThat(rootBlocks.contains(second)).isTrue();
+        assertThat(first.getNextConnection().isConnected()).isFalse();
+        assertThat(second.getPreviousConnection().isConnected()).isFalse();
 
         if (withViews) {
             BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
-            assertNotNull(firstGroup);
+            assertThat(firstGroup).isNotNull();
             BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
-            assertNotNull(secondGroup);
-            assertNotSame(secondGroup, firstGroup);
+            assertThat(secondGroup).isNotNull();
+            assertThat(secondGroup).isNotSameAs(firstGroup);
         }
     }
 
@@ -1124,26 +1119,26 @@ public class BlocklyControllerTest extends BlocklyTestCase {
                 (NameManager.VariableNameManager) mController.getWorkspace()
                         .getVariableNameManager();
 
-        assertNull(mVariableCallback.onCreateVariable);
+        assertThat(mVariableCallback.onCreateVariable).isNull();
 
         // Calling requestAddVariable and the callback blocking creation
         mVariableCallback.whenOnCreateCalled = false;
         mController.requestAddVariable("var1");
-        assertEquals("var1", mVariableCallback.onCreateVariable);
-        assertEquals(0, nameManager.getUsedNames().size());
+        assertThat(mVariableCallback.onCreateVariable).isEqualTo("var1");
+        assertThat(nameManager.getUsedNames().size()).isEqualTo(0);
 
         // Calling addVariable bypasses the callback
         mVariableCallback.onCreateVariable = null;
         mController.addVariable("var1");
-        assertNull(mVariableCallback.onCreateVariable);
-        assertTrue(nameManager.contains("var1"));
+        assertThat(mVariableCallback.onCreateVariable).isNull();
+        assertThat(nameManager.contains("var1")).isTrue();
 
         // Calling requestAddVariable and the callback allows creation
         mVariableCallback.reset();
         mVariableCallback.whenOnCreateCalled = true;
         mController.requestAddVariable("var2");
-        assertEquals("var2", mVariableCallback.onCreateVariable);
-        assertTrue(nameManager.contains("var2"));
+        assertThat(mVariableCallback.onCreateVariable).isEqualTo("var2");
+        assertThat(nameManager.contains("var2")).isTrue();
     }
 
     @Test
@@ -1157,26 +1152,26 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         // Calling rename without forcing and the callback blocks it
         mVariableCallback.whenOnRenameCalled = false;
         mController.requestRenameVariable("var1", "var3");
-        assertEquals("var1", mVariableCallback.onRenameVariable);
-        assertFalse(nameManager.contains("var3"));
-        assertTrue(nameManager.contains("var1"));
+        assertThat(mVariableCallback.onRenameVariable).isEqualTo("var1");
+        assertThat(nameManager.contains("var3")).isFalse();
+        assertThat(nameManager.contains("var1")).isTrue();
 
         // Calling rename with forcing skips the callback
         mVariableCallback.onRenameVariable = null;
         mController.renameVariable("var1", "var3");
-        assertNull(mVariableCallback.onRenameVariable);
-        assertTrue(nameManager.contains("var3"));
-        assertFalse(nameManager.contains("var1"));
+        assertThat(mVariableCallback.onRenameVariable).isNull();
+        assertThat(nameManager.contains("var3")).isTrue();
+        assertThat(nameManager.contains("var1")).isFalse();
 
         // Calling rename without forcing and the callback allows it
         mVariableCallback.whenOnRenameCalled = true;
         mController.requestRenameVariable("var2", "var4");
-        assertEquals("var2", mVariableCallback.onRenameVariable);
-        assertTrue(nameManager.contains("var4"));
-        assertFalse(nameManager.contains("var2"));
+        assertThat(mVariableCallback.onRenameVariable).isEqualTo("var2");
+        assertThat(nameManager.contains("var4")).isTrue();
+        assertThat(nameManager.contains("var2")).isFalse();
 
         // Verify that we have two variables still
-        assertEquals(2, nameManager.size());
+        assertThat(nameManager.size()).isEqualTo(2);
     }
 
     @Test
@@ -1190,23 +1185,23 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         // Calling delete without forcing and the callback blocks it
         mVariableCallback.whenOnDeleteCalled = false;
         mController.requestDeleteVariable("var3");
-        assertEquals("var3", mVariableCallback.onDeleteVariable);
-        assertTrue(nameManager.contains("var3"));
+        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var3");
+        assertThat(nameManager.contains("var3")).isTrue();
 
         // Calling delete with forcing skips callback
         mVariableCallback.onDeleteVariable = null;
         mController.deleteVariable("var3");
-        assertNull(mVariableCallback.onDeleteVariable);
-        assertFalse(nameManager.contains("var3"));
+        assertThat(mVariableCallback.onDeleteVariable).isNull();
+        assertThat(nameManager.contains("var3")).isFalse();
 
         // Calling delete without forcing and callback allows it
         mVariableCallback.whenOnDeleteCalled = true;
         mController.requestDeleteVariable("var4");
-        assertEquals("var4", mVariableCallback.onDeleteVariable);
-        assertFalse(nameManager.contains("var4"));
+        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var4");
+        assertThat(nameManager.contains("var4")).isFalse();
 
         // Verify that we have no variables left
-        assertEquals(0, nameManager.size());
+        assertThat(nameManager.size()).isEqualTo(0);
     }
 
     @Test
@@ -1276,44 +1271,44 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         //     set2 "var2"
         //     set4 "var 3"
         List<Block> rootBlocks = mController.getWorkspace().getRootBlocks();
-        assertEquals(3, rootBlocks.size());
+        assertThat(rootBlocks.size()).isEqualTo(3);
 
         mVariableCallback.whenOnDeleteCalled = true;
         mVariableCallback.onDeleteVariable = null;
         mController.requestDeleteVariable("var1");
 
-        assertEquals("var1", mVariableCallback.onDeleteVariable);
-        assertEquals(1, rootBlocks.size());
+        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var1");
+        assertThat(rootBlocks.size()).isEqualTo(1);
 
         Block block = rootBlocks.get(0);
-        assertSame(block, statement);
+        assertThat(block).isSameAs(statement);
         block = block.getInputs().get(0).getConnectedBlock();
-        assertSame(block, set2);
+        assertThat(block).isSameAs(set2);
 
         block = block.getNextBlock();
-        assertSame(block, set4);
+        assertThat(block).isSameAs(set4);
 
         block = block.getNextBlock();
-        assertNull(block);
+        assertThat(block).isNull();
     }
 
     @Test
     public void testLoadWorkspaceContents_andReset() {
         mController.initWorkspaceView(mWorkspaceView);
-        assertEquals(0, mWorkspace.getRootBlocks().size());
-        assertEquals(0, mWorkspaceView.getChildCount());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(0);
+        assertThat(mWorkspaceView.getChildCount()).isEqualTo(0);
 
         mController.loadWorkspaceContents(
                 BlockTestStrings.EMPTY_BLOCK_WITH_POSITION +
                 BlockTestStrings.EMPTY_BLOCK_WITH_POSITION.replace(
                         BlockTestStrings.EMPTY_BLOCK_ID,
                         BlockTestStrings.EMPTY_BLOCK_ID + '2'));
-        assertEquals(2, mWorkspace.getRootBlocks().size());
-        assertEquals(2, mWorkspaceView.getChildCount());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+        assertThat(mWorkspaceView.getChildCount()).isEqualTo(2);
 
         mController.resetWorkspace();
-        assertEquals(0, mWorkspace.getRootBlocks().size());
-        assertEquals(0, mWorkspaceView.getChildCount());
+        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(0);
+        assertThat(mWorkspaceView.getChildCount()).isEqualTo(0);
     }
 
     /**

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/ConnectionManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/ConnectionManagerTest.java
@@ -26,9 +26,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link ConnectionManager}
@@ -45,19 +43,19 @@ public class ConnectionManagerTest {
     public void testAdd() {
         Connection conn = new Connection(Connection.CONNECTION_TYPE_PREVIOUS, null);
         manager.addConnection(conn);
-        assertTrue(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn));
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn)).isTrue();
 
         conn = new Connection(Connection.CONNECTION_TYPE_NEXT, null);
         manager.addConnection(conn);
-        assertTrue(manager.getConnections(Connection.CONNECTION_TYPE_NEXT).contains(conn));
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_NEXT).contains(conn)).isTrue();
 
         conn = new Connection(Connection.CONNECTION_TYPE_INPUT, null);
         manager.addConnection(conn);
-        assertTrue(manager.getConnections(Connection.CONNECTION_TYPE_INPUT).contains(conn));
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_INPUT).contains(conn)).isTrue();
 
         conn = new Connection(Connection.CONNECTION_TYPE_OUTPUT, null);
         manager.addConnection(conn);
-        assertTrue(manager.getConnections(Connection.CONNECTION_TYPE_OUTPUT).contains(conn));
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_OUTPUT).contains(conn)).isTrue();
     }
 
     @Test
@@ -71,10 +69,10 @@ public class ConnectionManagerTest {
         int moveX = 15;
         int moveY = 20;
         manager.moveConnectionTo(conn, new WorkspacePoint(moveX, moveY), offset);
-        assertEquals(moveX + offsetX, conn.getPosition().x);
-        assertEquals(moveY + offsetY, conn.getPosition().y);
+        assertThat(conn.getPosition().x).isEqualTo(moveX + offsetX);
+        assertThat(conn.getPosition().y).isEqualTo(moveY + offsetY);
         // Connection should still be in the list
-        assertTrue(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn));
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn)).isTrue();
 
         manager.removeConnection(conn);
         conn.setDragMode(true);
@@ -83,9 +81,9 @@ public class ConnectionManagerTest {
         moveX = 10;
         moveY = 100;
         manager.moveConnectionTo(conn, new WorkspacePoint(moveX, moveY), offset);
-        assertFalse(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn));
-        assertEquals(moveX + offsetX, conn.getPosition().x);
-        assertEquals(moveY + offsetY, conn.getPosition().y);
+        assertThat(manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).contains(conn)).isFalse();
+        assertThat(conn.getPosition().x).isEqualTo(moveX + offsetX);
+        assertThat(conn.getPosition().y).isEqualTo(moveY + offsetY);
     }
 
     @Test
@@ -96,33 +94,33 @@ public class ConnectionManagerTest {
         Connection two = createConnection(10 /* x */, 15 /* y */, Connection.CONNECTION_TYPE_OUTPUT,
                 false);
 
-        assertTrue(manager.isConnectionAllowed(one, two, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, two, 20.0, false)).isTrue();
         // Move connections farther apart
         two.setPosition(100, 100);
-        assertFalse(manager.isConnectionAllowed(one, two, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, two, 20.0, false)).isFalse();
 
         // Don't offer to connect an already connected left (male) value plug to
         // an available right (female) value plug.
         Connection three = createConnection(0, 0, Connection.CONNECTION_TYPE_OUTPUT, false);
-        assertTrue(manager.isConnectionAllowed(one, three, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, three, 20.0, false)).isTrue();
         Connection four = createConnection(0, 0, Connection.CONNECTION_TYPE_INPUT, false);
         three.connect(four);
-        assertFalse(manager.isConnectionAllowed(one, three, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, three, 20.0, false)).isFalse();
 
         // Don't connect two connections on the same block
         two.setBlock(one.getBlock());
-        assertFalse(manager.isConnectionAllowed(one, two, 1000.0, false));
+        assertThat(manager.isConnectionAllowed(one, two, 1000.0, false)).isFalse();
 
         Connection five = createConnection(0, 0, Connection.CONNECTION_TYPE_INPUT, true);
         Connection six = createConnection(0, 0, Connection.CONNECTION_TYPE_OUTPUT, true);
         Connection seven = createConnection(0, 0, Connection.CONNECTION_TYPE_OUTPUT, false);
 
         // Verify that shadows can be parents of other shadows
-        assertTrue(manager.isConnectionAllowed(five, six, 1000.0, false));
+        assertThat(manager.isConnectionAllowed(five, six, 1000.0, false)).isTrue();
         // But not parents of non-shadows
-        assertFalse(manager.isConnectionAllowed(five, seven, 1000.0, false));
+        assertThat(manager.isConnectionAllowed(five, seven, 1000.0, false)).isFalse();
         // Unless shadow parents are explicitly allowed
-        assertTrue(manager.isConnectionAllowed(five, seven, 1000.0, true));
+        assertThat(manager.isConnectionAllowed(five, seven, 1000.0, true)).isTrue();
     }
 
     @Test
@@ -135,20 +133,20 @@ public class ConnectionManagerTest {
 
         // Don't offer to connect the bottom of a statement block to one that's already connected.
         Connection three = createConnection(0, 0, Connection.CONNECTION_TYPE_PREVIOUS, false);
-        assertTrue(manager.isConnectionAllowed(one, three, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, three, 20.0, false)).isTrue();
         three.connect(two);
-        assertFalse(manager.isConnectionAllowed(one, three, 20.0, false));
+        assertThat(manager.isConnectionAllowed(one, three, 20.0, false)).isFalse();
 
         Connection four = createConnection(0, 0, Connection.CONNECTION_TYPE_NEXT, true);
         Connection five = createConnection(0, 0, Connection.CONNECTION_TYPE_PREVIOUS, true);
         Connection six = createConnection(0, 0, Connection.CONNECTION_TYPE_PREVIOUS, false);
 
         // Verify that shadows can be parents of other shadows
-        assertTrue(manager.isConnectionAllowed(four, five, 1000.0, false));
+        assertThat(manager.isConnectionAllowed(four, five, 1000.0, false)).isTrue();
         // But not parents of non-shadows
-        assertFalse(manager.isConnectionAllowed(four, six, 1000.0, false));
+        assertThat(manager.isConnectionAllowed(four, six, 1000.0, false)).isFalse();
         // Unless shadow parents are explicitly allowed
-        assertTrue(manager.isConnectionAllowed(four, six, 1000.0, true));
+        assertThat(manager.isConnectionAllowed(four, six, 1000.0, true)).isTrue();
     }
 
     // Test YSortedList
@@ -162,9 +160,9 @@ public class ConnectionManagerTest {
         list.addConnection(createConnection(0, 4, Connection.CONNECTION_TYPE_PREVIOUS, false));
         list.addConnection(createConnection(0, 5, Connection.CONNECTION_TYPE_PREVIOUS, false));
 
-        assertEquals(5, list.size());
+        assertThat(list.size()).isEqualTo(5);
         Connection conn = createConnection(0, 3, Connection.CONNECTION_TYPE_PREVIOUS, false);
-        assertEquals(3, list.findPositionForConnection(conn));
+        assertThat(list.findPositionForConnection(conn)).isEqualTo(3);
     }
 
     // Test YSortedList
@@ -181,10 +179,10 @@ public class ConnectionManagerTest {
 
         Connection conn = createConnection(3, 3, Connection.CONNECTION_TYPE_PREVIOUS, false);
         previous.addConnection(conn);
-        assertEquals(conn, previous.get(previous.findConnection(conn)));
+        assertThat(previous.get(previous.findConnection(conn))).isEqualTo(conn);
 
         conn = createConnection(3, 3, Connection.CONNECTION_TYPE_PREVIOUS, false);
-        assertEquals(-1, previous.findConnection(conn));
+        assertThat(previous.findConnection(conn)).isEqualTo(-1);
     }
 
     @Test
@@ -197,7 +195,7 @@ public class ConnectionManagerTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            assertEquals(i, list.get(i).getPosition().y);
+            assertThat(list.get(i).getPosition().y).isEqualTo(i);
         }
 
         // quasi-random
@@ -219,7 +217,7 @@ public class ConnectionManagerTest {
         }
 
         for (int i = 1; i < xCoords.length; i++) {
-            assertTrue(list.get(i).getPosition().y >= list.get(i - 1).getPosition().y);
+            assertThat(list.get(i).getPosition().y >= list.get(i - 1).getPosition().y).isTrue();
         }
     }
 
@@ -230,10 +228,10 @@ public class ConnectionManagerTest {
                 manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS);
 
         // search an empty list
-        assertEquals(null, searchList(list, 10 /* x */, 10 /* y */, 100 /* radius */));
+        assertThat(searchList(list, 10 /* x */, 10 /* y */, 100 /* radius */)).isNull();
 
         list.addConnection(createConnection(100, 0, Connection.CONNECTION_TYPE_PREVIOUS, false));
-        assertEquals(null, searchList(list, 0, 0, 5));
+        assertThat(searchList(list, 0, 0, 5)).isNull();
         list.clear();
 
         for (int i = 0; i < 10; i++) {
@@ -243,18 +241,18 @@ public class ConnectionManagerTest {
         // should be at 0, 9
         Connection last = list.get(list.size() - 1);
         // correct connection is last in list; many connections in radius
-        assertEquals(last, searchList(list, 0, 10, 15));
+        assertThat(searchList(list, 0, 10, 15)).isEqualTo(last);
         // Nothing nearby.
-        assertEquals(null, searchList(list, 100, 100, 3));
+        assertThat(searchList(list, 100, 100, 3)).isNull();
         // first in list, exact match
-        assertEquals(list.get(0), searchList(list, 0, 0, 0));
+        assertThat(searchList(list, 0, 0, 0)).isEqualTo(list.get(0));
 
         list.addConnection(createConnection(6, 6, Connection.CONNECTION_TYPE_PREVIOUS, false));
         list.addConnection(createConnection(5, 5, Connection.CONNECTION_TYPE_PREVIOUS, false));
 
         Connection result = searchList(list, 4, 6, 3);
-        assertEquals(5, result.getPosition().x);
-        assertEquals(5, result.getPosition().y);
+        assertThat(result.getPosition().x).isEqualTo(5);
+        assertThat(result.getPosition().y).isEqualTo(5);
     }
 
     @Test
@@ -264,7 +262,7 @@ public class ConnectionManagerTest {
                 manager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS);
 
         // Search an empty list
-        assertTrue(getNeighbourHelper(list, 10 /* x */, 10 /* y */, 100 /* radius */).isEmpty());
+        assertThat(getNeighbourHelper(list, 10 /* x */, 10 /* y */, 100 /* radius */).isEmpty()).isTrue();
 
         // Make a list
         for (int i = 0; i < 10; i++) {
@@ -273,36 +271,36 @@ public class ConnectionManagerTest {
 
         // Test block belongs at beginning
         List<Connection> result = getNeighbourHelper(list, 0, 0, 4);
-        assertEquals(5, result.size());
+        assertThat(result.size()).isEqualTo(5);
         for (int i = 0; i < result.size(); i++) {
-            assertTrue(result.contains(list.get(i)));
+            assertThat(result.contains(list.get(i))).isTrue();
         }
 
         // Test block belongs at middle
         result = getNeighbourHelper(list, 0, 4, 2);
-        assertEquals(5, result.size());
+        assertThat(result.size()).isEqualTo(5);
         for (int i = 0; i < result.size(); i++) {
-            assertTrue(result.contains(list.get(i + 2)));
+            assertThat(result.contains(list.get(i + 2))).isTrue();
         }
 
         // Test block belongs at end
         result = getNeighbourHelper(list, 0, 9, 4);
-        assertEquals(5, result.size());
+        assertThat(result.size()).isEqualTo(5);
         for (int i = 0; i < result.size(); i++) {
-            assertTrue(result.contains(list.get(i + 5)));
+            assertThat(result.contains(list.get(i + 5))).isTrue();
         }
 
         // Test block has no neighbours due to being out of range in the x direction
         result = getNeighbourHelper(list, 10, 9, 4);
-        assertTrue(result.isEmpty());
+        assertThat(result.isEmpty()).isTrue();
 
         // Test block has no neighbours due to being out of range in the y direction
         result = getNeighbourHelper(list, 0, 19, 4);
-        assertTrue(result.isEmpty());
+        assertThat(result.isEmpty()).isTrue();
 
         // Test block has no neighbours due to being out of range diagonally
         result = getNeighbourHelper(list, -2, -2, 2);
-        assertTrue(result.isEmpty());
+        assertThat(result.isEmpty()).isTrue();
     }
 
     private List<Connection> getNeighbourHelper(ConnectionManager.YSortedList list, int x, int y,

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/NameManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/NameManagerTest.java
@@ -18,10 +18,7 @@ package com.google.blockly.android.control;
 import org.junit.Before;
 import org.junit.Test;
 
-import static android.test.MoreAsserts.assertNotEqual;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link NameManager}.
@@ -37,62 +34,62 @@ public class NameManagerTest {
     @Test
     public void testGenerateUniqueName() throws Exception {
         String name1 = mNameManager.generateUniqueName("string", true /* addName */);
-        assertNotEqual(name1, mNameManager.generateUniqueName("string", true /* addName */));
+        assertThat(mNameManager.generateUniqueName("string", true /* addName */)).isNotEqualTo(name1);
 
-        assertEquals("foo", mNameManager.generateUniqueName("foo", true /* addName */));
-        assertEquals("foo2", mNameManager.generateUniqueName("foo", true /* addName */));
-        assertEquals("foo3", mNameManager.generateUniqueName("foo2", true /* addName */));
-        assertEquals("222", mNameManager.generateUniqueName("222", true /* addName */));
-        assertEquals("223", mNameManager.generateUniqueName("222", true /* addName */));
+        assertThat(mNameManager.generateUniqueName("foo", true /* addName */)).isEqualTo("foo");
+        assertThat(mNameManager.generateUniqueName("foo", true /* addName */)).isEqualTo("foo2");
+        assertThat(mNameManager.generateUniqueName("foo2", true /* addName */)).isEqualTo("foo3");
+        assertThat(mNameManager.generateUniqueName("222", true /* addName */)).isEqualTo("222");
+        assertThat(mNameManager.generateUniqueName("222", true /* addName */)).isEqualTo("223");
     }
 
     @Test
     public void testCaseInsensitive() {
         String name1 = mNameManager.generateUniqueName("string", true /* addName */);
         String name2 = mNameManager.generateUniqueName("String", true /* addName */);
-        assertNotEqual(name1, name2);
-        assertNotEqual(name1.toLowerCase(), name2.toLowerCase());
+        assertThat(name2).isNotEqualTo(name1);
+        assertThat(name2.toLowerCase()).isNotEqualTo(name1.toLowerCase());
     }
 
     @Test
     public void testListFunctions() {
         mNameManager.addName("foo");
-        assertEquals(1, mNameManager.getUsedNames().size());
+        assertThat(mNameManager.getUsedNames().size()).isEqualTo(1);
         mNameManager.generateUniqueName("bar", true /* addName */);
-        assertEquals(2, mNameManager.getUsedNames().size());
+        assertThat(mNameManager.getUsedNames().size()).isEqualTo(2);
 
         mNameManager.generateUniqueName("bar", false /* addName */);
-        assertEquals(2, mNameManager.getUsedNames().size());
+        assertThat(mNameManager.getUsedNames().size()).isEqualTo(2);
 
         mNameManager.clearUsedNames();
-        assertTrue(mNameManager.getUsedNames().isEmpty());
+        assertThat(mNameManager.getUsedNames().isEmpty()).isTrue();
     }
 
     @Test
     public void testGenerateVariableName() {
         NameManager.VariableNameManager nameManager = new NameManager.VariableNameManager();
-        assertEquals("i", nameManager.generateVariableName(false /* addName */));
-        assertEquals("i", nameManager.generateVariableName(true /* addName */));
-        assertEquals("j", nameManager.generateVariableName(true /* addName */));
-        assertEquals("k", nameManager.generateVariableName(true /* addName */));
-        assertEquals("m", nameManager.generateVariableName(true /* addName */));
+        assertThat(nameManager.generateVariableName(false /* addName */)).isEqualTo("i");
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("i");
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("j");
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("k");
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("m");
 
         for (int i = 0; i < 21; i++) {
             nameManager.generateVariableName(true /* addName */);
         }
 
-        assertEquals("i2", nameManager.generateVariableName(true /* addName */));
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("i2");
 
         nameManager.addName("j2");
-        assertEquals("k2", nameManager.generateVariableName(true /* addName */));
+        assertThat(nameManager.generateVariableName(true /* addName */)).isEqualTo("k2");
     }
 
     @Test
     public void testRemove() {
         mNameManager.addName("foo");
-        assertTrue(mNameManager.contains("FOO"));
+        assertThat(mNameManager.contains("FOO")).isTrue();
         mNameManager.remove("Foo");
-        assertFalse(mNameManager.contains("foo"));
+        assertThat(mNameManager.contains("foo")).isFalse();
         // Remove something that wasn't there; expect no problems.
         mNameManager.remove("foo");
     }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
@@ -27,10 +27,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link ProcedureManager}.
@@ -65,9 +62,9 @@ public class ProcedureManagerTest {
     @Test
     public void testAddProcedureDefinition() {
         mProcedureManager.addDefinition(mProcedureDefinition);
-        assertTrue(mProcedureManager.containsDefinition(mProcedureDefinition));
-        assertNotNull(mProcedureManager.getReferences(PROCEDURE_NAME));
-        assertEquals(0, mProcedureManager.getReferences(PROCEDURE_NAME).size());
+        assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isTrue();
+        assertThat(mProcedureManager.getReferences(PROCEDURE_NAME)).isNotNull();
+        assertThat(mProcedureManager.getReferences(PROCEDURE_NAME).size()).isEqualTo(0);
     }
 
     @Test
@@ -82,9 +79,9 @@ public class ProcedureManagerTest {
         Block secondProcedureDefinition = (new Block.Builder(mProcedureDefinition)).build();
 
         mProcedureManager.addDefinition(secondProcedureDefinition);
-        assertFalse(PROCEDURE_NAME.equalsIgnoreCase(
+        assertThat(PROCEDURE_NAME.equalsIgnoreCase(
                 ((FieldInput) secondProcedureDefinition.getFieldByName("name"))
-                        .getText()));
+                        .getText())).isFalse();
     }
 
     @Test
@@ -92,29 +89,29 @@ public class ProcedureManagerTest {
         mProcedureManager.addDefinition(mProcedureDefinition);
 
         mProcedureManager.addReference(mProcedureReference);
-        assertTrue(mProcedureManager.hasReferences(mProcedureDefinition));
+        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isTrue();
     }
 
     @Test
     // Remove definition should also remove all references.
     public void testRemoveProcedureDefinition() {
         mProcedureManager.addDefinition(mProcedureDefinition);
-        assertTrue(mProcedureManager.containsDefinition(mProcedureDefinition));
+        assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isTrue();
 
         mProcedureManager.removeDefinition(mProcedureDefinition);
-        assertFalse(mProcedureManager.containsDefinition(mProcedureDefinition));
-        assertFalse(mProcedureManager.hasReferences(mProcedureDefinition));
+        assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isFalse();
+        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isFalse();
 
         mProcedureManager.addDefinition(mProcedureDefinition);
         mProcedureManager.addReference(mProcedureReference);
         List<Block> references =
                 mProcedureManager.removeDefinition(mProcedureDefinition);
-        assertNotNull(references);
-        assertEquals(1, references.size());
-        assertEquals(mProcedureReference, references.get(0));
+        assertThat(references).isNotNull();
+        assertThat(references.size()).isEqualTo(1);
+        assertThat(references.get(0)).isEqualTo(mProcedureReference);
 
-        assertFalse(mProcedureManager.containsDefinition(mProcedureDefinition));
-        assertFalse(mProcedureManager.hasReferences(mProcedureDefinition));
+        assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isFalse();
+        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isFalse();
     }
 
     @Test
@@ -123,7 +120,7 @@ public class ProcedureManagerTest {
         mProcedureManager.addReference(mProcedureReference);
 
         mProcedureManager.removeReference(mProcedureReference);
-        assertFalse(mProcedureManager.hasReferences(mProcedureReference));
+        assertThat(mProcedureManager.hasReferences(mProcedureReference)).isFalse();
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/WorkspaceStatsTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/WorkspaceStatsTest.java
@@ -27,14 +27,9 @@ import com.google.blockly.model.Input;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 
 /**
  * Tests for {@link WorkspaceStats}.
@@ -97,17 +92,17 @@ public class WorkspaceStatsTest {
         Block variableReference = blockBuilder.build();
         mStats.collectStats(variableReference, false);
 
-        assertTrue(mStats.getVariableNameManager().contains("variable name"));
-        assertFalse(mStats.getVariableNameManager().contains("field name"));
+        assertThat(mStats.getVariableNameManager().contains("variable name")).isTrue();
+        assertThat(mStats.getVariableNameManager().contains("field name")).isFalse();
 
-        assertEquals(2, mStats.getVariableReference("variable name").size());
-        assertEquals(variableReference.getFieldByName("field name"),
-                mStats.getVariableReference("variable name").get(0));
+        assertThat(mStats.getVariableReference("variable name").size()).isEqualTo(2);
+        assertThat(mStats.getVariableReference("variable name").get(0))
+            .isEqualTo(variableReference.getFieldByName("field name"));
     }
 
     @Test
     public void testVariableReferencesNeverNull() {
-        assertNotNull(mStats.getVariableReference("not a reference"));
+        assertThat(mStats.getVariableReference("not a reference")).isNotNull();
     }
 
     @Test
@@ -139,13 +134,12 @@ public class WorkspaceStatsTest {
         thirdBlock.getPreviousConnection().connect(secondBlock.getNextConnection());
 
         mStats.collectStats(secondBlock, true);
-        assertTrue(mStats.getVariableNameManager().contains("third block variable name"));
-        assertFalse(mStats.getVariableNameManager().contains("variable name"));
-        assertTrue(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_INPUT).isEmpty());
-        assertTrue(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_OUTPUT).isEmpty());
-        assertEquals(2,
-                mConnectionManager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).size());
-        assertEquals(1, mConnectionManager.getConnections(Connection.CONNECTION_TYPE_NEXT).size());
+        assertThat(mStats.getVariableNameManager().contains("third block variable name")).isTrue();
+        assertThat(mStats.getVariableNameManager().contains("variable name")).isFalse();
+        assertThat(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_INPUT).isEmpty()).isTrue();
+        assertThat(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_OUTPUT).isEmpty()).isTrue();
+        assertThat(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_PREVIOUS).size()).isEqualTo(2);
+        assertThat(mConnectionManager.getConnections(Connection.CONNECTION_TYPE_NEXT).size()).isEqualTo(1);
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractBlockViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractBlockViewTest.java
@@ -30,9 +30,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
-
 
 /**
  * Tests for {@link AbstractBlockView}.
@@ -63,7 +62,7 @@ public class AbstractBlockViewTest {
         final BlockView blockView = makeBlockView(mEmptyBlock);
 
         // Verify Block and BlockView are linked both ways.
-        assertSame(mEmptyBlock, blockView.getBlock());
+        assertThat(mEmptyBlock).isSameAs(blockView.getBlock());
     }
 
     // Make a BlockView for the given Block and default mock objects otherwise.

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractInputViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractInputViewTest.java
@@ -32,9 +32,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -57,7 +55,7 @@ public class AbstractInputViewTest {
                 new int[]{R.raw.test_blocks});
         Block block = factory.obtainBlock("test_block_one_input_each_type", "fake_id");
         mDummyInput = block.getInputs().get(0);
-        assertEquals(Input.TYPE_DUMMY, mDummyInput.getType());
+        assertThat(mDummyInput.getType()).isEqualTo(Input.TYPE_DUMMY);
     }
 
     // Verify correct object state after construction.
@@ -66,20 +64,20 @@ public class AbstractInputViewTest {
         final AbstractInputView inputView = makeDefaultInputView();
 
         // Verify Input and InputView are linked both ways.
-        assertSame(mDummyInput, inputView.getInput());
-        assertSame(inputView, mDummyInput.getView());
+        assertThat(mDummyInput).isSameAs(inputView.getInput());
+        assertThat(inputView).isSameAs(mDummyInput.getView());
     }
 
     // Verify child view can be set.
     @Test
     public void testSetChildView() {
         final AbstractInputView inputView = makeDefaultInputView();
-        assertEquals(0, inputView.getChildCount());
+        assertThat(inputView.getChildCount()).isEqualTo(0);
 
         final BlockGroup mockGroup = mock(BlockGroup.class);
         inputView.setConnectedBlockGroup(mockGroup);
-        assertSame(mockGroup, inputView.getConnectedBlockGroup());
-        assertEquals(1, inputView.getChildCount());
+        assertThat(mockGroup).isSameAs(inputView.getConnectedBlockGroup());
+        assertThat(inputView.getChildCount()).isEqualTo(1);
     }
 
     // Verify child view can be set, unset, then set again.
@@ -90,12 +88,12 @@ public class AbstractInputViewTest {
         final BlockGroup mockGroup = mock(BlockGroup.class);
         inputView.setConnectedBlockGroup(mockGroup);
         inputView.setConnectedBlockGroup(null);
-        assertNull(inputView.getConnectedBlockGroup());
-        assertEquals(0, inputView.getChildCount());
+        assertThat(inputView.getConnectedBlockGroup()).isNull();
+        assertThat(inputView.getChildCount()).isEqualTo(0);
 
         inputView.setConnectedBlockGroup(mockGroup);
-        assertSame(mockGroup, inputView.getConnectedBlockGroup());
-        assertEquals(1, inputView.getChildCount());
+        assertThat(mockGroup).isSameAs(inputView.getConnectedBlockGroup());
+        assertThat(inputView.getChildCount()).isEqualTo(1);
     }
 
     // Verify exception is thrown when calling setChildView repeatedly without disconnectBlockGroup.

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlockViewInActivityTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlockViewInActivityTest.java
@@ -33,11 +33,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
-
 
 /**
  * {@link BlockView} tests in the context of an attached Activity.
@@ -84,7 +81,7 @@ public class BlockViewInActivityTest {
      */
     private void loadWhileUntilBlocksIntoWorkspaceView() {
         mRootBlock = mBlockFactory.obtainBlock("controls_whileUntil", "1");
-        assertNotNull(mRootBlock);
+        assertThat(mRootBlock).isNotNull();
         mChildInputBlock = mBlockFactory.obtainBlock("output_no_input", "2");
         mRootBlock.getInputByName("TIMES").getConnection()
                 .connect(mChildInputBlock.getOutputConnection());
@@ -114,15 +111,14 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, (View) mViewFactory.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildStatementBlockView,
-                (View) mHelper.getView(mRootBlock)));
+        assertThat(isDescendentOf(mFieldView, (View) mViewFactory.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildStatementBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
 
-        assertFalse(((View) mRootView).isActivated());
-        assertFalse(((View) mFieldView).isActivated());
-        assertFalse(((View) mChildInputBlockView).isActivated());
-        assertFalse(((View) mChildStatementBlockView).isActivated());
+        assertThat(((View) mRootView).isActivated()).isFalse();
+        assertThat(((View) mFieldView).isActivated()).isFalse();
+        assertThat(((View) mChildInputBlockView).isActivated()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isActivated()).isFalse();
 
         mActivity.runOnUiThread(new Runnable() {
             @Override
@@ -133,10 +129,10 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Only mRootView should be activated.
-        assertTrue(((View) mRootView).isActivated());
-        assertFalse(((View) mFieldView).isActivated());
-        assertFalse(((View) mChildInputBlockView).isActivated());
-        assertFalse(((View) mChildStatementBlockView).isActivated());
+        assertThat(((View) mRootView).isActivated()).isTrue();
+        assertThat(((View) mFieldView).isActivated()).isFalse();
+        assertThat(((View) mChildInputBlockView).isActivated()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isActivated()).isFalse();
     }
 
     /** Tests that pressed {@link View} state does not propagate to child BlockViews. */
@@ -151,15 +147,14 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildStatementBlockView,
-                (View) mHelper.getView(mRootBlock)));
+        assertThat(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildStatementBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
 
-        assertFalse(((View) mRootView).isPressed());
-        assertFalse(((View) mFieldView).isPressed());
-        assertFalse(((View) mChildInputBlockView).isPressed());
-        assertFalse(((View) mChildStatementBlockView).isPressed());
+        assertThat(((View) mRootView).isPressed()).isFalse();
+        assertThat(((View) mFieldView).isPressed()).isFalse();
+        assertThat(((View) mChildInputBlockView).isPressed()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isPressed()).isFalse();
 
         mActivity.runOnUiThread(new Runnable() {
             @Override
@@ -170,10 +165,10 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Only mRootView should be pressed.
-        assertTrue(((View) mRootView).isPressed());
-        assertFalse(((View) mFieldView).isPressed());
-        assertFalse(((View) mChildInputBlockView).isPressed());
-        assertFalse(((View) mChildStatementBlockView).isPressed());
+        assertThat(((View) mRootView).isPressed()).isTrue();
+        assertThat(((View) mFieldView).isPressed()).isFalse();
+        assertThat(((View) mChildInputBlockView).isPressed()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isPressed()).isFalse();
     }
 
     /** Tests that focused {@link View} state does not propagate to child BlockViews. */
@@ -188,15 +183,14 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildStatementBlockView,
-                (View) mHelper.getView(mRootBlock)));
+        assertThat(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildStatementBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
 
-        assertFalse(((View) mRootView).isFocused());
-        assertFalse(mFieldView.isFocused());
-        assertFalse(((View) mChildInputBlockView).isFocused());
-        assertFalse(((View) mChildStatementBlockView).isFocused());
+        assertThat(((View) mRootView).isFocused()).isFalse();
+        assertThat(mFieldView.isFocused()).isFalse();
+        assertThat(((View) mChildInputBlockView).isFocused()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isFocused()).isFalse();
 
         mActivity.runOnUiThread(new Runnable() {
             @Override
@@ -207,10 +201,10 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Only mRootView should be focused.
-        assertTrue(((View) mRootView).isFocused());
-        assertFalse(mFieldView.isFocused());
-        assertFalse(((View) mChildInputBlockView).isFocused());
-        assertFalse(((View) mChildStatementBlockView).isFocused());
+        assertThat(((View) mRootView).isFocused()).isTrue();
+        assertThat(mFieldView.isFocused()).isFalse();
+        assertThat(((View) mChildInputBlockView).isFocused()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isFocused()).isFalse();
     }
 
     /** Tests that selected {@link View} state does not propagate to child BlockViews. */
@@ -225,15 +219,14 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Preconditions
-        assertTrue(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock)));
-        assertTrue(isDescendentOf((View) mChildStatementBlockView,
-                (View) mHelper.getView(mRootBlock)));
+        assertThat(isDescendentOf(mFieldView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildInputBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
+        assertThat(isDescendentOf((View) mChildStatementBlockView, (View) mHelper.getView(mRootBlock))).isTrue();
 
-        assertFalse(((View) mRootView).isSelected());
-        assertFalse(mFieldView.isSelected());
-        assertFalse(((View) mChildInputBlockView).isSelected());
-        assertFalse(((View) mChildStatementBlockView).isSelected());
+        assertThat(((View) mRootView).isSelected()).isFalse();
+        assertThat(mFieldView.isSelected()).isFalse();
+        assertThat(((View) mChildInputBlockView).isSelected()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isSelected()).isFalse();
 
         mActivity.runOnUiThread(new Runnable() {
             @Override
@@ -244,15 +237,15 @@ public class BlockViewInActivityTest {
         mInstrumentation.waitForIdleSync();
 
         // Only mRootView should be selected.
-        assertTrue(((View) mRootView).isSelected());
-        assertFalse(mFieldView.isSelected());
-        assertFalse(((View) mChildInputBlockView).isSelected());
-        assertFalse(((View) mChildStatementBlockView).isSelected());
+        assertThat(((View) mRootView).isSelected()).isTrue();
+        assertThat(mFieldView.isSelected()).isFalse();
+        assertThat(((View) mChildInputBlockView).isSelected()).isFalse();
+        assertThat(((View) mChildStatementBlockView).isSelected()).isFalse();
     }
 
     private static boolean isDescendentOf(View child, View ancestor) {
-        assertNotNull(child);
-        assertNotNull(ancestor);
+        assertThat(child).isNotNull();
+        assertThat(ancestor).isNotNull();
 
         ViewParent parent = child.getParent();
         while (parent != null && parent instanceof View) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlocklyActivityTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/BlocklyActivityTest.java
@@ -26,8 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Test Activity lifecycle events using {@link BlocklyTestActivity}.
@@ -75,9 +74,9 @@ public class BlocklyActivityTest {
         mActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                assertEquals(1.0f, virtualWorkspaceView.getViewScale(), 1e-5);
+                assertThat(virtualWorkspaceView.getViewScale()).isWithin(1e-5f).of(1.0f);
                 mActivity.getController().zoomIn();
-                assertTrue(virtualWorkspaceView.getViewScale() > 1.0f);
+                assertThat(virtualWorkspaceView.getViewScale() > 1.0f).isTrue();
             }
         });
 
@@ -85,7 +84,7 @@ public class BlocklyActivityTest {
             @Override
             public void run() {
                 mActivity.getController().zoomOut();
-                assertEquals(1.0f, virtualWorkspaceView.getViewScale(), 1e-5);
+                assertThat(virtualWorkspaceView.getViewScale()).isWithin(1e-5f).of(1.0f);
             }
         });
 
@@ -93,7 +92,7 @@ public class BlocklyActivityTest {
             @Override
             public void run() {
                 mActivity.getController().zoomOut();
-                assertTrue(virtualWorkspaceView.getViewScale() < 1.0f);
+                assertThat(virtualWorkspaceView.getViewScale() < 1.0f).isTrue();
             }
         });
 
@@ -101,7 +100,7 @@ public class BlocklyActivityTest {
             @Override
             public void run() {
                 mActivity.getController().recenterWorkspace();
-                assertEquals(1.0f, virtualWorkspaceView.getViewScale(), 1e-5);
+                assertThat(virtualWorkspaceView.getViewScale()).isWithin(1e-5f).of(1.0f);
             }
         });
         mInstrumentation.waitForIdleSync();

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
@@ -46,10 +46,8 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -238,7 +236,7 @@ public class DraggerTest extends BlocklyTestCase {
 
         ArrayList<Connection> draggedConnections = new ArrayList<>();
         mDraggedBlock.getAllConnectionsRecursive(draggedConnections);
-        assertEquals(5, draggedConnections.size());
+        assertThat(draggedConnections.size()).isEqualTo(5);
 
         final ArrayList<Connection> removedConnections = new ArrayList<>();
         final ArrayList<Connection> addedConnections = new ArrayList<>();
@@ -260,26 +258,26 @@ public class DraggerTest extends BlocklyTestCase {
         setupDrag();
         dragTouch();
 
-        assertEquals(0, addedConnections.size());
-        assertEquals(0, removedConnections.size());
+        assertThat(addedConnections.size()).isEqualTo(0);
+        assertThat(removedConnections.size()).isEqualTo(0);
 
         dragMove();
 
-        assertEquals(draggedConnections.size(), removedConnections.size());
-        assertEquals(0, addedConnections.size());
+        assertThat(removedConnections.size()).isEqualTo(draggedConnections.size());
+        assertThat(addedConnections.size()).isEqualTo(0);
         for (Connection conn : draggedConnections) {
-            assertTrue(removedConnections.contains(conn));
-            assertTrue(conn.inDragMode());
+            assertThat(removedConnections.contains(conn)).isTrue();
+            assertThat(conn.inDragMode()).isTrue();
         }
 
         // Complete the drag.
         dragRelease();
 
-        assertEquals(draggedConnections.size(), removedConnections.size());
-        assertEquals(draggedConnections.size(), addedConnections.size());
+        assertThat(removedConnections.size()).isEqualTo(draggedConnections.size());
+        assertThat(addedConnections.size()).isEqualTo(draggedConnections.size());
         for (Connection conn : draggedConnections) {
-            assertTrue(addedConnections.contains(conn));
-            assertFalse(conn.inDragMode());
+            assertThat(addedConnections.contains(conn)).isTrue();
+            assertThat(conn.inDragMode()).isFalse();
         }
     }
 
@@ -358,16 +356,15 @@ public class DraggerTest extends BlocklyTestCase {
                 long time = mDragStartTime + 10L;
                 MotionEvent me =
                         MotionEvent.obtain(time, time, MotionEvent.ACTION_MOVE, 30, -10, 0);
-                assertTrue("Events that initiate drags must be claimed",
+                assertWithMessage("Events that initiate drags must be claimed").that(
                         mDragger.onTouchBlockImpl(
-                                Dragger.DRAG_MODE_SLOPPY, mDragHandler, mTouchedView, me, false));
+                                Dragger.DRAG_MODE_SLOPPY, mDragHandler, mTouchedView, me, false)).isTrue();
             }
         }, TIMEOUT);
 
         // Allow mDragGroupCreator to run.
         await(mDragGroupCreatorLatch, TIMEOUT);
-        assertEquals("Dragger must call Runnable to construct draggable BlockGroup", 1,
-                mDragGroupCreatorCallCount);
+        assertWithMessage("Dragger must call Runnable to construct draggable BlockGroup").that(mDragGroupCreatorCallCount).isEqualTo(1);
 
         runAndSync(new Runnable() {
             @Override
@@ -403,7 +400,7 @@ public class DraggerTest extends BlocklyTestCase {
     }
 
     private void runAndSync(final Runnable runnable, long timeoutMilliseconds) {
-        assertNull(mExceptionInThread);
+        assertThat(mExceptionInThread).isNull();
 
         final CountDownLatch latch = new CountDownLatch(1);
         mHandler.post(new Runnable() {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/WorkspaceHelperTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/WorkspaceHelperTest.java
@@ -30,8 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -86,14 +85,9 @@ public class WorkspaceHelperTest extends BlocklyTestCase {
 
         TestUtils.createViews(blocks, mViewFactory, mockConnectionManager, mWorkspaceView);
 
-        assertSame(mWorkspaceHelper.getParentBlockGroup(root),
-                mWorkspaceHelper.getParentBlockGroup(cur));
-
-        assertNotSame(mWorkspaceHelper.getParentBlockGroup(blocks.get(0)),
-                mWorkspaceHelper.getParentBlockGroup(blocks.get(1)));
-
-        assertNotSame(mWorkspaceHelper.getParentBlockGroup(root),
-                mWorkspaceHelper.getParentBlockGroup(hasOutput));
+        assertThat(mWorkspaceHelper.getParentBlockGroup(root)).isSameAs(mWorkspaceHelper.getParentBlockGroup(cur));
+        assertThat(mWorkspaceHelper.getParentBlockGroup(blocks.get(0))).isNotSameAs(mWorkspaceHelper.getParentBlockGroup(blocks.get(1)));
+        assertThat(mWorkspaceHelper.getParentBlockGroup(root)).isNotSameAs(mWorkspaceHelper.getParentBlockGroup(hasOutput));
     }
 
 
@@ -122,14 +116,9 @@ public class WorkspaceHelperTest extends BlocklyTestCase {
 
         TestUtils.createViews(blocks, mViewFactory, mockConnectionManager, mWorkspaceView);
 
-        assertSame(mWorkspaceHelper.getRootBlockGroup(root),
-                mWorkspaceHelper.getRootBlockGroup(cur));
-
-        assertSame(mWorkspaceHelper.getRootBlockGroup(root),
-                mWorkspaceHelper.getRootBlockGroup(finalBlock));
-
-        assertNotSame(Arrays.toString(blocks.toArray()),
-                mWorkspaceHelper.getRootBlockGroup(blocks.get(0)),
-                mWorkspaceHelper.getRootBlockGroup(blocks.get(1)));
+        assertThat(mWorkspaceHelper.getRootBlockGroup(root)).isSameAs(mWorkspaceHelper.getRootBlockGroup(cur));
+        assertThat(mWorkspaceHelper.getRootBlockGroup(root)).isSameAs(mWorkspaceHelper.getRootBlockGroup(finalBlock));
+        assertThat(Arrays.toString(blocks.toArray())).isNotSameAs(mWorkspaceHelper.getRootBlockGroup(blocks.get(0)));
+        assertThat(Arrays.toString(blocks.toArray())).isNotSameAs(mWorkspaceHelper.getRootBlockGroup(blocks.get(1)));
     }
  }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxViewTest.java
@@ -24,9 +24,7 @@ import com.google.blockly.model.FieldCheckbox;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link BasicFieldCheckboxView}.
@@ -44,30 +42,30 @@ public class BasicFieldCheckboxViewTest extends BlocklyTestCase {
     @Test
     public void testFieldUpdatesFromView() {
         final BasicFieldCheckboxView view = makeFieldCheckboxView();
-        assertFalse(mFieldCheckbox.isChecked());
-        assertEquals(mFieldCheckbox.isChecked(), view.isChecked());
+        assertThat(mFieldCheckbox.isChecked()).isFalse();
+        assertThat(view.isChecked()).isEqualTo(mFieldCheckbox.isChecked());
 
         view.performClick();
-        assertTrue(mFieldCheckbox.isChecked());
+        assertThat(mFieldCheckbox.isChecked()).isTrue();
 
         view.performClick();
-        assertFalse(mFieldCheckbox.isChecked());
+        assertThat(mFieldCheckbox.isChecked()).isFalse();
     }
 
     // Verify that view gets updated if field changes.
     @Test
     public void testViewUpdatesFromField() {
         final BasicFieldCheckboxView view = makeFieldCheckboxView();
-        assertEquals(mFieldCheckbox.isChecked(), view.isChecked());
+        assertThat(view.isChecked()).isEqualTo(mFieldCheckbox.isChecked());
 
         mFieldCheckbox.setChecked(true);
-        assertTrue(view.isChecked());
+        assertThat(view.isChecked()).isTrue();
 
         mFieldCheckbox.setChecked(false);
-        assertFalse(view.isChecked());
+        assertThat(view.isChecked()).isFalse();
 
         mFieldCheckbox.setChecked(false);
-        assertFalse(view.isChecked());
+        assertThat(view.isChecked()).isFalse();
     }
 
     @NonNull

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldColorViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldColorViewTest.java
@@ -31,10 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link BasicFieldColorView}.
@@ -75,10 +72,10 @@ public class BasicFieldColorViewTest extends BlocklyTestCase {
         mFieldColorView.performClick();
         final PopupWindow popupWindow = mFieldColorView.getColorPopupWindow();
 
-        assertNotNull(popupWindow);
-        assertTrue(popupWindow.isShowing());
-        assertTrue(popupWindow.isTouchable());
-        assertTrue(popupWindow.isFocusable());
+        assertThat(popupWindow).isNotNull();
+        assertThat(popupWindow.isShowing()).isTrue();
+        assertThat(popupWindow.isTouchable()).isTrue();
+        assertThat(popupWindow.isFocusable()).isTrue();
     }
 
     // Verify that clicking on popup window selects a color.
@@ -87,11 +84,11 @@ public class BasicFieldColorViewTest extends BlocklyTestCase {
         mFieldColorView.performClick();
         final PopupWindow popupWindow = mFieldColorView.getColorPopupWindow();
         final View popupWindowContentView = popupWindow.getContentView();
-        assertNotNull(popupWindowContentView);
+        assertThat(popupWindowContentView).isNotNull();
 
         // Reset color before test.
         mFieldColor.setColor(0);
-        assertEquals(0, mFieldColor.getColor());
+        assertThat(mFieldColor.getColor()).isEqualTo(0);
 
         // Simulate click on the color panel.
         popupWindowContentView.onTouchEvent(
@@ -100,35 +97,29 @@ public class BasicFieldColorViewTest extends BlocklyTestCase {
 
         // Verify both field and field view background have been set to correct color.
         final int expectedColour = 0xffffff;
-        assertEquals(expectedColour, mFieldColor.getColor());  // setColour() masks out alpha.
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE | expectedColour,
-                ((ColorDrawable) mFieldColorView.getBackground()).getColor());
+        assertThat(mFieldColor.getColor()).isEqualTo(expectedColour);  // setColour() masks out alpha.
+        assertThat(((ColorDrawable) mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE | expectedColour);
 
         // Popup window should have disappeared.
-        assertFalse(popupWindow.isShowing());
+        assertThat(popupWindow.isShowing()).isFalse();
     }
 
     // Verify that changing color in the field updates the UI.
     @Test
     public void testFieldUpdatesView() {
         mFieldColor.setColor(0);
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE,
-                ((ColorDrawable)mFieldColorView.getBackground()).getColor());
+        assertThat(((ColorDrawable)mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE);
 
         mFieldColor.setColor(Color.RED);
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE | Color.RED,
-                ((ColorDrawable)mFieldColorView.getBackground()).getColor());
+        assertThat(((ColorDrawable)mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE | Color.RED);
 
         mFieldColor.setColor(Color.GREEN);
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE | Color.GREEN,
-                ((ColorDrawable)mFieldColorView.getBackground()).getColor());
+        assertThat(((ColorDrawable)mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE | Color.GREEN);
 
         mFieldColor.setColor(Color.BLUE);
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE | Color.BLUE,
-                ((ColorDrawable)mFieldColorView.getBackground()).getColor());
+        assertThat(((ColorDrawable)mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE | Color.BLUE);
 
         mFieldColor.setColor(Color.WHITE);
-        assertEquals(BasicFieldColorView.ALPHA_OPAQUE | Color.WHITE,
-                ((ColorDrawable)mFieldColorView.getBackground()).getColor());
+        assertThat(((ColorDrawable)mFieldColorView.getBackground()).getColor()).isEqualTo(BasicFieldColorView.ALPHA_OPAQUE | Color.WHITE);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownViewTest.java
@@ -27,9 +27,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -53,8 +51,8 @@ public class BasicFieldDropdownViewTest extends BlocklyTestCase {
                 new FieldDropdown.Option("Value3", "Label3")));
         mFieldDropdown = new FieldDropdown("FieldDropdown", mOptions);
 
-        assertNotNull(mFieldDropdown);
-        assertEquals(mOptions.size(), mFieldDropdown.getOptions().size());
+        assertThat(mFieldDropdown).isNotNull();
+        assertThat(mFieldDropdown.getOptions().size()).isEqualTo(mOptions.size());
     }
 
     // Verify object instantiation.
@@ -62,10 +60,10 @@ public class BasicFieldDropdownViewTest extends BlocklyTestCase {
     public void testInstantiation() {
         mFieldDropdown.setSelectedIndex(2);
         final BasicFieldDropdownView view = makeFieldDropdownView();
-        assertSame(mFieldDropdown, view.getField());
-        assertEquals(mOptions.size(), view.getCount());
-        assertEquals(mFieldDropdown.getSelectedIndex(), view.getSelectedItemPosition());
-        assertEquals(mFieldDropdown.getSelectedDisplayName(), view.getSelectedItem().toString());
+        assertThat(mFieldDropdown).isSameAs(view.getField());
+        assertThat(view.getCount()).isEqualTo(mOptions.size());
+        assertThat(view.getSelectedItemPosition()).isEqualTo(mFieldDropdown.getSelectedIndex());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mFieldDropdown.getSelectedDisplayName());
     }
 
     // Verify update of field when an item is selected from the dropdown.
@@ -76,16 +74,16 @@ public class BasicFieldDropdownViewTest extends BlocklyTestCase {
         final BasicFieldDropdownView view = makeFieldDropdownView();
 
         view.setSelection(2);
-        assertEquals(view.getSelectedItemPosition(), mFieldDropdown.getSelectedIndex());
-        assertEquals(view.getSelectedItem().toString(), mFieldDropdown.getSelectedDisplayName());
+        assertThat(mFieldDropdown.getSelectedIndex()).isEqualTo(view.getSelectedItemPosition());
+        assertThat(mFieldDropdown.getSelectedDisplayName()).isEqualTo(view.getSelectedItem().toString());
 
         view.setSelection(0);
-        assertEquals(view.getSelectedItemPosition(), mFieldDropdown.getSelectedIndex());
-        assertEquals(view.getSelectedItem().toString(), mFieldDropdown.getSelectedDisplayName());
+        assertThat(mFieldDropdown.getSelectedIndex()).isEqualTo(view.getSelectedItemPosition());
+        assertThat(mFieldDropdown.getSelectedDisplayName()).isEqualTo(view.getSelectedItem().toString());
 
         view.setSelection(1);
-        assertEquals(view.getSelectedItemPosition(), mFieldDropdown.getSelectedIndex());
-        assertEquals(view.getSelectedItem().toString(), mFieldDropdown.getSelectedDisplayName());
+        assertThat(mFieldDropdown.getSelectedIndex()).isEqualTo(view.getSelectedItemPosition());
+        assertThat(mFieldDropdown.getSelectedDisplayName()).isEqualTo(view.getSelectedItem().toString());
     }
 
     // Test update of view if field selection changes.
@@ -94,16 +92,16 @@ public class BasicFieldDropdownViewTest extends BlocklyTestCase {
         final BasicFieldDropdownView view = makeFieldDropdownView();
 
         mFieldDropdown.setSelectedIndex(2);
-        assertEquals(mFieldDropdown.getSelectedIndex(), view.getSelectedItemPosition());
-        assertEquals(mFieldDropdown.getSelectedDisplayName(), view.getSelectedItem().toString());
+        assertThat(view.getSelectedItemPosition()).isEqualTo(mFieldDropdown.getSelectedIndex());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mFieldDropdown.getSelectedDisplayName());
 
         mFieldDropdown.setSelectedIndex(0);
-        assertEquals(mFieldDropdown.getSelectedIndex(), view.getSelectedItemPosition());
-        assertEquals(mFieldDropdown.getSelectedDisplayName(), view.getSelectedItem().toString());
+        assertThat(view.getSelectedItemPosition()).isEqualTo(mFieldDropdown.getSelectedIndex());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mFieldDropdown.getSelectedDisplayName());
 
         mFieldDropdown.setSelectedIndex(1);
-        assertEquals(mFieldDropdown.getSelectedIndex(), view.getSelectedItemPosition());
-        assertEquals(mFieldDropdown.getSelectedDisplayName(), view.getSelectedItem().toString());
+        assertThat(view.getSelectedItemPosition()).isEqualTo(mFieldDropdown.getSelectedIndex());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mFieldDropdown.getSelectedDisplayName());
     }
 
     @NonNull

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldImageViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldImageViewTest.java
@@ -10,8 +10,7 @@ import org.mockito.AdditionalAnswers;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -49,7 +48,7 @@ public class BasicFieldImageViewTest {
     }
 
     private void assertNotEmpty(InputStream in) throws IOException {
-        assertNotNull(in);
-        assertTrue(in.available() > 0);
+        assertThat(in).isNotNull();
+        assertThat(in.available() > 0).isTrue();
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldInputViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldInputViewTest.java
@@ -24,9 +24,7 @@ import com.google.blockly.model.FieldInput;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -46,15 +44,15 @@ public class BasicFieldInputViewTest {
      public void setUp() throws Exception {
         mMockWorkspaceHelper = mock(WorkspaceHelper.class);
         mFieldInput = new FieldInput("FieldInput", INIT_TEXT_VALUE);
-        assertNotNull(mFieldInput);
+        assertThat(mFieldInput).isNotNull();
     }
 
     // Verify object instantiation.
     @Test
     public void testInstantiation() {
         final BasicFieldInputView view = makeFieldInputView();
-        assertSame(mFieldInput, view.getField());
-        assertEquals(INIT_TEXT_VALUE, view.getText().toString());  // Fails without .toString()
+        assertThat(mFieldInput).isSameAs(view.getField());
+        assertThat(view.getText().toString()).isEqualTo(INIT_TEXT_VALUE);  // Fails without .toString()
     }
 
     // Verify setting text in the view propagates to the field.
@@ -62,7 +60,7 @@ public class BasicFieldInputViewTest {
     public void testViewUpdatesField() {
         final BasicFieldInputView view = makeFieldInputView();
         view.setText(SET_TEXT_VALUE);
-        assertEquals(SET_TEXT_VALUE, mFieldInput.getText());
+        assertThat(mFieldInput.getText()).isEqualTo(SET_TEXT_VALUE);
     }
 
     // Verify setting text in the field propagates to the view.
@@ -71,7 +69,7 @@ public class BasicFieldInputViewTest {
         final BasicFieldInputView view = makeFieldInputView();
 
         mFieldInput.setText(SET_TEXT_VALUE);
-        assertEquals(SET_TEXT_VALUE, view.getText().toString());  // Fails without .toString()
+        assertThat(view.getText().toString()).isEqualTo(SET_TEXT_VALUE);  // Fails without .toString()
     }
 
     @NonNull

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelViewTest.java
@@ -21,8 +21,7 @@ import com.google.blockly.model.FieldLabel;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link BasicFieldLabelView}.
@@ -41,7 +40,7 @@ public class BasicFieldLabelViewTest {
 
         final BasicFieldLabelView view = new BasicFieldLabelView(InstrumentationRegistry.getContext());
         view.setField(mFieldLabel);
-        assertSame(mFieldLabel, view.getField());
-        assertEquals(INIT_TEXT_VALUE, view.getText().toString());  // Fails without .toString()
+        assertThat(mFieldLabel).isSameAs(view.getField());
+        assertThat(view.getText().toString()).isEqualTo(INIT_TEXT_VALUE);  // Fails without .toString()
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
@@ -34,9 +34,7 @@ import org.mockito.AdditionalAnswers;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -98,9 +96,9 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
             }
         }, TIMEOUT);
 
-        assertSame(mFieldVariable, view[0].getField());
-        assertEquals(mVariables.length + 2, view[0].getCount());
-        assertEquals(mFieldVariable.getVariable(), (String) (view[0].getSelectedItem()));
+        assertThat(mFieldVariable).isSameAs(view[0].getField());
+        assertThat(view[0].getCount()).isEqualTo(mVariables.length + 2);
+        assertThat((String) (view[0].getSelectedItem())).isEqualTo(mFieldVariable.getVariable());
     }
 
     // Verify update of field when an item is selected from the dropdown.
@@ -116,8 +114,8 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 view.setSelection(2);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[2], mFieldVariable.getVariable());
-        assertEquals(view.getSelectedItem().toString(), mFieldVariable.getVariable());
+        assertThat(mFieldVariable.getVariable()).isEqualTo(mVariables[2]);
+        assertThat(mFieldVariable.getVariable()).isEqualTo(view.getSelectedItem().toString());
 
         runAndSync(new Runnable() {
             @Override
@@ -125,8 +123,8 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 view.setSelection(0);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[0], mFieldVariable.getVariable());
-        assertEquals(view.getSelectedItem().toString(), mFieldVariable.getVariable());
+        assertThat(mFieldVariable.getVariable()).isEqualTo(mVariables[0]);
+        assertThat(mFieldVariable.getVariable()).isEqualTo(view.getSelectedItem().toString());
 
         runAndSync(new Runnable() {
             @Override
@@ -134,8 +132,8 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 view.setSelection(1);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[1], mFieldVariable.getVariable());
-        assertEquals(view.getSelectedItem().toString(), mFieldVariable.getVariable());
+        assertThat(mFieldVariable.getVariable()).isEqualTo(mVariables[1]);
+        assertThat(mFieldVariable.getVariable()).isEqualTo(view.getSelectedItem().toString());
     }
 
     // Test update of view if variable selection changes.
@@ -150,7 +148,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 mFieldVariable.setVariable(mVariables[0]);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[0], view.getSelectedItem().toString());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mVariables[0]);
 
         runAndSync(new Runnable() {
             @Override
@@ -158,7 +156,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 mFieldVariable.setVariable(mVariables[1]);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[1], view.getSelectedItem().toString());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mVariables[1]);
 
         runAndSync(new Runnable() {
             @Override
@@ -166,7 +164,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
                 mFieldVariable.setVariable(mVariables[2]);
             }
         }, TIMEOUT);
-        assertEquals(mVariables[2], view.getSelectedItem().toString());
+        assertThat(view.getSelectedItem().toString()).isEqualTo(mVariables[2]);
     }
 
     @NonNull
@@ -178,7 +176,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
     }
 
     private void runAndSync(final Runnable runnable, long timeoutMilliseconds) {
-        assertNull(mExceptionInThread);
+        assertThat(mExceptionInThread).isNull();
 
         final CountDownLatch latch = new CountDownLatch(1);
         mHandler.post(new Runnable() {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/vertical/VerticalBlockViewFactoryTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/vertical/VerticalBlockViewFactoryTest.java
@@ -29,11 +29,8 @@ import com.google.blockly.model.BlockFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
-
 
 /**
  * Tests for {@link VerticalBlockViewFactory}.
@@ -62,21 +59,20 @@ public class VerticalBlockViewFactoryTest {
         final Block block = mBlockFactory.obtainBlock(
                 "test_block_one_input_each_type", "TestBlock");
         final BlockView blockView = makeBlockView(block);
-        assertNotNull(block);
+        assertThat(block).isNotNull();
 
-        assertSame(block, blockView.getBlock());
+        assertThat(block).isSameAs(blockView.getBlock());
 
         // One InputView per Input?
-        assertEquals(3, blockView.getInputViewCount());
+        assertThat(blockView.getInputViewCount()).isEqualTo(3);
 
         for (int inputIdx = 0; inputIdx < 3; ++inputIdx) {
             // Each InputView points to an Input?
-            assertNotNull(blockView.getInputView(inputIdx).getInput());
+            assertThat(blockView.getInputView(inputIdx).getInput()).isNotNull();
             // Each InputView is a child of the BlockView?
-            assertSame(blockView.getInputView(inputIdx), blockView.getChildAt(inputIdx));
+            assertThat(blockView.getInputView(inputIdx)).isSameAs(blockView.getChildAt(inputIdx));
             // Each input view points to the correct Input?
-            assertSame(block.getInputs().get(inputIdx),
-                    blockView.getInputView(inputIdx).getInput());
+            assertThat(block.getInputs().get(inputIdx)).isSameAs(blockView.getInputView(inputIdx).getInput());
         }
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
@@ -34,13 +34,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.blockly.utils.MoreAsserts.assertStringNotEmpty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Tests for {@link BlockFactory}.
@@ -65,25 +60,24 @@ public class BlockFactoryTest {
         JSONObject blockDefinitionJson = new JSONObject(BlockTestStrings.TEST_JSON_STRING);
         Block block = mBlockFactory.fromJson("test_block", blockDefinitionJson);
 
-        assertNotNull("Block was null after initializing from JSON", block);
-        assertEquals("Type not set correctly", "test_block", block.getType());
+        assertWithMessage("Block was null after initializing from JSON").that(block).isNotNull();
+        assertWithMessage("Type not set correctly").that(block.getType()).isEqualTo("test_block");
         assertStringNotEmpty("Block id cannot be empty.", block.getId());
-        assertEquals("Wrong number of inputs", 2, block.getInputs().size());
-        assertEquals("Wrong number of fields in first input",
-                9, block.getInputs().get(0).getFields().size());
+        assertWithMessage("Wrong number of inputs").that(block.getInputs().size()).isEqualTo(2);
+        assertWithMessage("Wrong number of fields in first input").that(block.getInputs().get(0).getFields().size()).isEqualTo(9);
     }
 
     @Test
     public void testLoadBlocks() {
         List<Block> blocks = mBlockFactory.getAllBlocks();
-        assertEquals("BlockFactory failed to load all blocks.", 21, blocks.size());
+        assertWithMessage("BlockFactory failed to load all blocks.").that(blocks.size()).isEqualTo(21);
     }
 
     @Test
     public void testSuccessfulLoadFromXml() throws IOException, XmlPullParserException {
         Block loaded = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK);
-        assertEquals("frankenblock", loaded.getType());
-        assertEquals(new WorkspacePoint(37, 13), loaded.getPosition());
+        assertThat(loaded.getType()).isEqualTo("frankenblock");
+        assertThat(loaded.getPosition()).isEqualTo(new WorkspacePoint(37, 13));
     }
 
     @Test
@@ -152,7 +146,7 @@ public class BlockFactoryTest {
     public void testBlockWithGoodFields() throws IOException, XmlPullParserException {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "8",
             BlockTestStrings.FIELD_HAS_NAME));
-        assertEquals("item", ((FieldInput) loaded.getFieldByName("text_input")).getText());
+        assertThat(((FieldInput) loaded.getFieldByName("text_input")).getText()).isEqualTo("item");
     }
 
     @Test
@@ -202,37 +196,37 @@ public class BlockFactoryTest {
     @Test
     public void testLoadFromXmlInlineTagAtStart() throws IOException, XmlPullParserException {
         Block inlineAtStart = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK_INLINE_BEGINNING);
-        assertTrue(inlineAtStart.getInputsInline());
-        assertTrue(inlineAtStart.getInputsInlineModified());
+        assertThat(inlineAtStart.getInputsInline()).isTrue();
+        assertThat(inlineAtStart.getInputsInlineModified()).isTrue();
     }
 
     @Test
     public void testLoadFromXmlInlineTagAtEnd() throws IOException, XmlPullParserException {
         Block inlineAtEnd = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK_INLINE_END);
-        assertTrue(inlineAtEnd.getInputsInline());
-        assertTrue(inlineAtEnd.getInputsInlineModified());
+        assertThat(inlineAtEnd.getInputsInline()).isTrue();
+        assertThat(inlineAtEnd.getInputsInlineModified()).isTrue();
     }
 
     @Test
     public void testLoadFromXmlInlineTagFalse() throws IOException, XmlPullParserException {
         Block inlineFalseBlock = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK_INLINE_FALSE);
-        assertFalse(inlineFalseBlock.getInputsInline());
-        assertTrue(inlineFalseBlock.getInputsInlineModified());
+        assertThat(inlineFalseBlock.getInputsInline()).isFalse();
+        assertThat(inlineFalseBlock.getInputsInlineModified()).isTrue();
     }
 
     @Test
     public void testLoadXmlWithNoInlineTag() throws IOException, XmlPullParserException {
         Block blockNoInline = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK);
-        assertFalse(blockNoInline.getInputsInline());
-        assertFalse(blockNoInline.getInputsInlineModified());
+        assertThat(blockNoInline.getInputsInline()).isFalse();
+        assertThat(blockNoInline.getInputsInlineModified()).isFalse();
     }
 
     @Test
     public void testLoadFromXmlSimpleShadow() throws IOException, XmlPullParserException {
         Block loaded = parseShadowFromXml(BlockTestStrings.SIMPLE_SHADOW);
-        assertEquals("math_number", loaded.getType());
-        assertEquals(new WorkspacePoint(37, 13), loaded.getPosition());
-        assertTrue(loaded.isShadow());
+        assertThat(loaded.getType()).isEqualTo("math_number");
+        assertThat(loaded.getPosition()).isEqualTo(new WorkspacePoint(37, 13));
+        assertThat(loaded.isShadow()).isTrue();
     }
 
     @Test
@@ -240,8 +234,8 @@ public class BlockFactoryTest {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "1",
             BlockTestStrings.VALUE_SHADOW));
         Connection conn = loaded.getInputByName("value_input").getConnection();
-        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
-        assertTrue(conn.getShadowBlock().isShadow());
+        assertThat(conn.getShadowBlock()).isEqualTo(conn.getTargetBlock());
+        assertThat(conn.getShadowBlock().isShadow()).isTrue();
     }
 
     @Test
@@ -249,10 +243,10 @@ public class BlockFactoryTest {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "2",
             BlockTestStrings.VALUE_SHADOW_GOOD));
         Connection conn = loaded.getInputByName("value_input").getConnection();
-        assertEquals("VALUE_REAL", conn.getTargetBlock().getId());
-        assertFalse(conn.getTargetBlock().isShadow());
-        assertEquals("VALUE_SHADOW", conn.getShadowBlock().getId());
-        assertTrue(conn.getShadowBlock().isShadow());
+        assertThat(conn.getTargetBlock().getId()).isEqualTo("VALUE_REAL");
+        assertThat(conn.getTargetBlock().isShadow()).isFalse();
+        assertThat(conn.getShadowBlock().getId()).isEqualTo("VALUE_SHADOW");
+        assertThat(conn.getShadowBlock().isShadow()).isTrue();
     }
 
     @Test
@@ -260,8 +254,8 @@ public class BlockFactoryTest {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "3",
             BlockTestStrings.STATEMENT_SHADOW));
         Connection conn = loaded.getInputByName("NAME").getConnection();
-        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
-        assertTrue(conn.getShadowBlock().isShadow());
+        assertThat(conn.getShadowBlock()).isEqualTo(conn.getTargetBlock());
+        assertThat(conn.getShadowBlock().isShadow()).isTrue();
     }
 
     @Test
@@ -269,10 +263,10 @@ public class BlockFactoryTest {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "4",
             BlockTestStrings.STATEMENT_SHADOW_GOOD));
         Connection conn = loaded.getInputByName("NAME").getConnection();
-        assertEquals("STATEMENT_REAL", conn.getTargetBlock().getId());
-        assertFalse(conn.getTargetBlock().isShadow());
-        assertEquals("STATEMENT_SHADOW", conn.getShadowBlock().getId());
-        assertTrue(conn.getShadowBlock().isShadow());
+        assertThat(conn.getTargetBlock().getId()).isEqualTo("STATEMENT_REAL");
+        assertThat(conn.getTargetBlock().isShadow()).isFalse();
+        assertThat(conn.getShadowBlock().getId()).isEqualTo("STATEMENT_SHADOW");
+        assertThat(conn.getShadowBlock().isShadow()).isTrue();
     }
 
     @Test
@@ -280,12 +274,12 @@ public class BlockFactoryTest {
         Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "5",
             BlockTestStrings.VALUE_NESTED_SHADOW));
         Connection conn = loaded.getInputByName("value_input").getConnection();
-        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
+        assertThat(conn.getShadowBlock()).isEqualTo(conn.getTargetBlock());
         Block shadow1 = conn.getShadowBlock();
-        assertEquals("SHADOW1", shadow1.getId());
+        assertThat(shadow1.getId()).isEqualTo("SHADOW1");
         conn = shadow1.getOnlyValueInput().getConnection();
-        assertEquals(conn.getTargetBlock(), conn.getShadowBlock());
-        assertEquals("SHADOW2", conn.getShadowBlock().getId());
+        assertThat(conn.getShadowBlock()).isEqualTo(conn.getTargetBlock());
+        assertThat(conn.getShadowBlock().getId()).isEqualTo("SHADOW2");
     }
 
     @Test
@@ -305,46 +299,39 @@ public class BlockFactoryTest {
     @Test
     public void testObtainBlock() {
         Block emptyBlock = mBlockFactory.obtainBlock("empty_block", null);
-        assertNotNull("Failed to create the empty block.", emptyBlock);
-        assertEquals("Empty block has the wrong type", "empty_block", emptyBlock.getType());
+        assertWithMessage("Failed to create the empty block.").that(emptyBlock).isNotNull();
+        assertWithMessage("Empty block has the wrong type").that(emptyBlock.getType()).isEqualTo("empty_block");
 
         Block frankenblock = mBlockFactory.obtainBlock("frankenblock", null);
-        assertNotNull("Failed to create the frankenblock.", frankenblock);
+        assertWithMessage("Failed to create the frankenblock.").that(frankenblock).isNotNull();
 
         List<Input> inputs = frankenblock.getInputs();
-        assertEquals("Frankenblock has the wrong number of inputs", 3, inputs.size());
-        assertTrue("First input should be a value input.",
-                inputs.get(0) instanceof Input.InputValue);
-        assertTrue("Second input should be a statement input.",
-                inputs.get(1) instanceof Input.InputStatement);
-        assertTrue("Third input should be a dummy input.",
-                inputs.get(2) instanceof Input.InputDummy);
+        assertWithMessage("Frankenblock has the wrong number of inputs").that(inputs.size()).isEqualTo(3);
+        assertWithMessage("First input should be a value input.").that(inputs.get(0) instanceof Input.InputValue).isTrue();
+        assertWithMessage("Second input should be a statement input.").that(inputs.get(1) instanceof Input.InputStatement).isTrue();
+        assertWithMessage("Third input should be a dummy input.").that(inputs.get(2) instanceof Input.InputDummy).isTrue();
 
-        assertNotNull(frankenblock.getFieldByName("angle"));
+        assertThat(frankenblock.getFieldByName("angle")).isNotNull();
     }
 
     @Test
     public void testObtainBlock_repeatedWithoutUuid() {
         Block frankenblock = mBlockFactory.obtainBlock("frankenblock", null);
-        assertNotNull("Failed to create the frankenblock.", frankenblock);
+        assertWithMessage("Failed to create the frankenblock.").that(frankenblock).isNotNull();
 
         Block frankencopy = mBlockFactory.obtainBlock("frankenblock", null);
-        assertNotSame("Obtained blocks should be distinct objects when uuid is null.",
-                frankenblock, frankencopy);
+        assertWithMessage("Obtained blocks should be distinct objects when uuid is null.").that(frankencopy).isNotSameAs(frankenblock);
 
-        assertNotSame("Obtained blocks should not share connections.",
-                frankenblock.getNextConnection(), frankencopy.getNextConnection());
-        assertNotSame("Obtained blocks should not share connections.",
-                frankenblock.getPreviousConnection(), frankencopy.getPreviousConnection());
-        assertNull(frankenblock.getOutputConnection());
-        assertNotSame("Obtained blocks should not share inputs.",
-                frankenblock.getInputs().get(0), frankencopy.getInputs().get(0));
+        assertWithMessage("Obtained blocks should not share connections.").that(frankencopy.getNextConnection()).isNotSameAs(frankenblock.getNextConnection());
+        assertWithMessage("Obtained blocks should not share connections.").that(frankencopy.getPreviousConnection()).isNotSameAs(frankenblock.getPreviousConnection());
+        assertThat(frankenblock.getOutputConnection()).isNull();
+        assertWithMessage("Obtained blocks should not share inputs.").that(frankencopy.getInputs().get(0)).isNotSameAs(frankenblock.getInputs().get(0));
     }
 
     @Test
     public void testObtainBlock_repeatedWithUuid() {
         Block frankenblock = mBlockFactory.obtainBlock("frankenblock", "123");
-        assertNotNull("Failed to create the frankenblock.", frankenblock);
+        assertWithMessage("Failed to create the frankenblock.").that(frankenblock).isNotNull();
 
         thrown.expect(IllegalArgumentException.class);
         thrown.reportMissingExceptionWithMessage("Cannot create two bblocks with the same id");
@@ -354,7 +341,7 @@ public class BlockFactoryTest {
     @Test
     public void testObtainBlock_repeatedWithUuidMismatchingPrototype() {
         Block frankenblock = mBlockFactory.obtainBlock("frankenblock", "123");
-        assertNotNull("Failed to create the frankenblock.", frankenblock);
+        assertWithMessage("Failed to create the frankenblock.").that(frankenblock).isNotNull();
 
         thrown.expect(IllegalArgumentException.class);
         thrown.reportMissingExceptionWithMessage("Expected error when requesting a block with " +
@@ -366,7 +353,7 @@ public class BlockFactoryTest {
             throws IOException, XmlPullParserException {
         XmlPullParser parser = getXmlPullParser(testString, "block");
         Block loaded = mBlockFactory.fromXml(parser);
-        assertNotNull(loaded);
+        assertThat(loaded).isNotNull();
         return loaded;
     }
 
@@ -374,7 +361,7 @@ public class BlockFactoryTest {
             throws IOException, XmlPullParserException {
         XmlPullParser parser = getXmlPullParser(testString, "shadow");
         Block loaded = mBlockFactory.fromXml(parser);
-        assertNotNull(loaded);
+        assertThat(loaded).isNotNull();
         return loaded;
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -40,12 +40,8 @@ import java.util.regex.Pattern;
 
 import static android.test.MoreAsserts.assertNotEqual;
 import static com.google.blockly.utils.MoreAsserts.assertStringNotEmpty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Tests for {@link Block}.
@@ -87,11 +83,9 @@ public class BlockTest {
                 .setShadowConnection(originalShadow.getOutputConnection());
 
         Block copy = original.deepCopy();
-        assertNotSame(original, copy);
-        assertNotSame(original.getOnlyValueInput().getConnection().getTargetBlock(),
-                copy.getOnlyValueInput().getConnection().getTargetBlock());
-        assertNotSame(original.getOnlyValueInput().getConnection().getShadowBlock(),
-                copy.getOnlyValueInput().getConnection().getShadowBlock());
+        assertThat(original).isNotSameAs(copy);
+        assertThat(original.getOnlyValueInput().getConnection().getTargetBlock()).isNotSameAs(copy.getOnlyValueInput().getConnection().getTargetBlock());
+        assertThat(original.getOnlyValueInput().getConnection().getShadowBlock()).isNotSameAs(copy.getOnlyValueInput().getConnection().getShadowBlock());
     }
 
     @Test
@@ -104,21 +98,18 @@ public class BlockTest {
 
         testMessage = "This has no args %%5";
         tokens = Block.tokenizeMessage(testMessage);
-        assertEquals("Should have 1 token: " + tokens.toString(), 1, tokens.size());
-        assertEquals("Only token should be the original string: " + tokens.toString(),
-                testMessage, tokens.get(0));
+        assertWithMessage("Should have 1 token: " + tokens.toString()).that(tokens.size()).isEqualTo(1);
+        assertWithMessage("Only token should be the original string: " + tokens.toString()).that(tokens.get(0)).isEqualTo(testMessage);
 
         testMessage = "%1";
         tokens = Block.tokenizeMessage(testMessage);
-        assertEquals("Should have 1 token: " + tokens.toString(), 1, tokens.size());
-        assertEquals("Only token should be the original string: " + tokens.toString(),
-                testMessage, tokens.get(0));
+        assertWithMessage("Should have 1 token: " + tokens.toString()).that(tokens.size()).isEqualTo(1);
+        assertWithMessage("Only token should be the original string: " + tokens.toString()).that(tokens.get(0)).isEqualTo(testMessage);
 
         testMessage = "%Hello";
         tokens = Block.tokenizeMessage(testMessage);
-        assertEquals("Should have 1 token: " + tokens.toString(), 1, tokens.size());
-        assertEquals("Only token should be the original string: " + tokens.toString(),
-                testMessage, tokens.get(0));
+        assertWithMessage("Should have 1 token: " + tokens.toString()).that(tokens.size()).isEqualTo(1);
+        assertWithMessage("Only token should be the original string: " + tokens.toString()).that(tokens.get(0)).isEqualTo(testMessage);
 
 
         testMessage = "%Hello%1World%";
@@ -137,14 +128,14 @@ public class BlockTest {
 
         block.serialize(serializer, true);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_BLOCK_WITH_POSITION, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_BLOCK_WITH_POSITION);
 
         os = new ByteArrayOutputStream();
         serializer = getXmlSerializer(os);
 
         block.serialize(serializer, false);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_BLOCK_NO_POSITION, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_BLOCK_NO_POSITION);
 
         block = bf.obtainBlock("frankenblock", "frankenblock1");
         os = new ByteArrayOutputStream();
@@ -152,9 +143,10 @@ public class BlockTest {
 
         block.serialize(serializer, false);
         serializer.flush();
-        assertEquals(BlockTestStrings.blockStart("block", "frankenblock", "frankenblock1", null)
+        assertThat(os.toString()).isEqualTo(
+            BlockTestStrings.blockStart("block", "frankenblock", "frankenblock1", null)
                 + BlockTestStrings.FRANKENBLOCK_DEFAULT_VALUES
-                + BlockTestStrings.BLOCK_END, os.toString());
+                + BlockTestStrings.BLOCK_END);
     }
 
     @Test
@@ -167,21 +159,21 @@ public class BlockTest {
 
         block.serialize(serializer, true);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_BLOCK_WITH_POSITION, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_BLOCK_WITH_POSITION);
 
         block.setInputsInline(false);
         os = new ByteArrayOutputStream();
         serializer = getXmlSerializer(os);
         block.serialize(serializer, true);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_BLOCK_INLINE_FALSE, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_BLOCK_INLINE_FALSE);
 
         block.setInputsInline(true);
         os = new ByteArrayOutputStream();
         serializer = getXmlSerializer(os);
         block.serialize(serializer, true);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_BLOCK_INLINE_TRUE, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_BLOCK_INLINE_TRUE);
     }
 
     @Test
@@ -195,7 +187,7 @@ public class BlockTest {
 
         block.serialize(serializer, true);
         serializer.flush();
-        assertEquals(BlockTestStrings.EMPTY_SHADOW_WITH_POSITION, os.toString());
+        assertThat(os.toString()).isEqualTo(BlockTestStrings.EMPTY_SHADOW_WITH_POSITION);
     }
 
     @Test
@@ -217,7 +209,7 @@ public class BlockTest {
                 + BlockTestStrings.VALUE_GOOD
                 + BlockTestStrings.FRANKENBLOCK_DEFAULT_VALUES
                 + BlockTestStrings.BLOCK_END;
-        assertEquals(expected, os.toString());
+        assertThat(os.toString()).isEqualTo(expected);
     }
 
     @Test
@@ -242,7 +234,7 @@ public class BlockTest {
                 + BlockTestStrings.VALUE_SHADOW_GOOD
                 + BlockTestStrings.FRANKENBLOCK_DEFAULT_VALUES
                 + BlockTestStrings.BLOCK_END;
-        assertEquals(expected, os.toString());
+        assertThat(os.toString()).isEqualTo(expected);
 
         block = bf.obtainBlock("frankenblock", "777");
         block.setPosition(37, 13);
@@ -263,7 +255,7 @@ public class BlockTest {
                 + BlockTestStrings.VALUE_NESTED_SHADOW
                 + BlockTestStrings.FRANKENBLOCK_DEFAULT_VALUES
                 + BlockTestStrings.BLOCK_END;
-        assertEquals(expected, os.toString());
+        assertThat(os.toString()).isEqualTo(expected);
     }
 
     @Test
@@ -290,19 +282,19 @@ public class BlockTest {
                 + "</statement>"
                 + BlockTestStrings.FRANKENBLOCK_DEFAULT_VALUES_END
                 + BlockTestStrings.BLOCK_END;
-        assertEquals(expected, os.toString());
+        assertThat(os.toString()).isEqualTo(expected);
     }
 
     @Test
     public void testGetAllConnections() {
         Block block = mBlockFactory.obtainBlock("frankenblock", null);
         List<Connection> allConnections = block.getAllConnections();
-        assertEquals(4, allConnections.size());
+        assertThat(allConnections.size()).isEqualTo(4);
 
         block = mBlockFactory.obtainBlock("frankenblock", null);
         allConnections.clear();
         block.getAllConnections(allConnections);
-        assertEquals(4, allConnections.size());
+        assertThat(allConnections.size()).isEqualTo(4);
 
         allConnections.clear();
 
@@ -314,29 +306,29 @@ public class BlockTest {
         block.getInputs().get(1).getConnection().connect(smb.getPreviousConnection());
 
         block.getAllConnectionsRecursive(allConnections);
-        assertEquals(9, allConnections.size());
+        assertThat(allConnections.size()).isEqualTo(9);
     }
 
     @Test
     public void testGetOnlyValueInput() {
         BlockFactory bf = new BlockFactory(InstrumentationRegistry.getContext(), new int[]{R.raw.test_blocks});
         // No inputs.
-        assertNull(bf.obtainBlock("statement_no_input", null).getOnlyValueInput());
+        assertThat(bf.obtainBlock("statement_no_input", null).getOnlyValueInput()).isNull();
 
         // One value input.
         Block underTest = bf.obtainBlock("statement_value_input", null);
-        assertSame(underTest.getInputByName("value"), underTest.getOnlyValueInput());
+        assertThat(underTest.getInputByName("value")).isSameAs(underTest.getOnlyValueInput());
 
         // Statement input, no value inputs.
-        assertNull(bf.obtainBlock("statement_statement_input", null).getOnlyValueInput());
+        assertThat(bf.obtainBlock("statement_statement_input", null).getOnlyValueInput()).isNull();
 
         // Multiple value inputs.
-        assertNull(bf.obtainBlock("statement_multiple_value_input", null)
+        assertThat(bf.obtainBlock("statement_multiple_value_input", null)
                 .getOnlyValueInput());
 
         // Statement input, dummy input and value input.
         underTest = bf.obtainBlock("controls_repeat_ext", null);
-        assertSame(underTest.getInputByName("TIMES"), underTest.getOnlyValueInput());
+        assertThat(underTest.getInputByName("TIMES")).isSameAs(underTest.getOnlyValueInput());
     }
 
     private XmlSerializer getXmlSerializer(ByteArrayOutputStream os) throws BlocklySerializerException {
@@ -352,9 +344,9 @@ public class BlockTest {
     }
 
     private void assertListsMatch(List<String> expected, List<String> actual) {
-        assertEquals("Wrong number of items in the list.", expected.size(), actual.size());
+        assertWithMessage("Wrong number of items in the list.").that(actual.size()).isEqualTo(expected.size());
         for (int i = 0; i < expected.size(); i++) {
-            assertEquals("Item " + i + " does not match.", expected.get(i), actual.get(i));
+            assertWithMessage("Item " + i + " does not match.").that(actual.get(i)).isEqualTo(expected.get(i));
         }
     }
 
@@ -367,10 +359,8 @@ public class BlockTest {
         first.getOnlyValueInput().getConnection().connect(second.getOutputConnection());
         blocks.add(first);
 
-        assertSame(second.getLastUnconnectedInputConnection(),
-                second.getOnlyValueInput().getConnection());
-        assertSame(first.getLastUnconnectedInputConnection(),
-                second.getOnlyValueInput().getConnection());
+        assertThat(second.getLastUnconnectedInputConnection()).isSameAs(second.getOnlyValueInput().getConnection());
+        assertThat(first.getLastUnconnectedInputConnection()).isSameAs(second.getOnlyValueInput().getConnection());
     }
 
     @Test
@@ -383,9 +373,9 @@ public class BlockTest {
         second.getOnlyValueInput().getConnection().connect(third.getOutputConnection());
         blocks.add(first);
 
-        assertNull(third.getLastUnconnectedInputConnection());
-        assertNull(second.getLastUnconnectedInputConnection());
-        assertNull(first.getLastUnconnectedInputConnection());
+        assertThat(third.getLastUnconnectedInputConnection()).isNull();
+        assertThat(second.getLastUnconnectedInputConnection()).isNull();
+        assertThat(first.getLastUnconnectedInputConnection()).isNull();
     }
 
     @Test
@@ -398,9 +388,9 @@ public class BlockTest {
         second.getOnlyValueInput().getConnection().connect(third.getOutputConnection());
         blocks.add(first);
 
-        assertNull(third.getLastUnconnectedInputConnection());
-        assertNull(second.getLastUnconnectedInputConnection());
-        assertNull(first.getLastUnconnectedInputConnection());
+        assertThat(third.getLastUnconnectedInputConnection()).isNull();
+        assertThat(second.getLastUnconnectedInputConnection()).isNull();
+        assertThat(first.getLastUnconnectedInputConnection()).isNull();
     }
 
     @Test
@@ -416,10 +406,8 @@ public class BlockTest {
         secondConn.connect(shadow.getOutputConnection());
         blocks.add(first);
 
-        assertSame(second.getLastUnconnectedInputConnection(),
-                second.getOnlyValueInput().getConnection());
-        assertSame(first.getLastUnconnectedInputConnection(),
-                second.getOnlyValueInput().getConnection());
+        assertThat(second.getLastUnconnectedInputConnection()).isSameAs(second.getOnlyValueInput().getConnection());
+        assertThat(first.getLastUnconnectedInputConnection()).isSameAs(second.getOnlyValueInput().getConnection());
     }
 
     @Test
@@ -430,7 +418,7 @@ public class BlockTest {
         Block value = mBlockFactory.obtainBlock("output_no_input", "value");
         block.getInputByName("value").getConnection().connect(value.getOutputConnection());
 
-        assertSame(block, block.getLastBlockInSequence());
+        assertThat(block).isSameAs(block.getLastBlockInSequence());
     }
 
     @Test
@@ -441,7 +429,7 @@ public class BlockTest {
         Block value = mBlockFactory.obtainBlock("output_no_input", "value");
         block.getInputByName("value").getConnection().connect(value.getOutputConnection());
 
-        assertSame(block, block.getLastBlockInSequence());
+        assertThat(block).isSameAs(block.getLastBlockInSequence());
     }
 
     @Test
@@ -457,7 +445,7 @@ public class BlockTest {
         second.getNextConnection().connect(third.getPreviousConnection());
         third.getInputByName("value").getConnection().connect(value.getOutputConnection());
 
-        assertSame(third, first.getLastBlockInSequence());
+        assertThat(third).isSameAs(first.getLastBlockInSequence());
     }
 
     @Test
@@ -473,7 +461,7 @@ public class BlockTest {
         second.getNextConnection().connect(third.getPreviousConnection());
         third.getInputByName("value").getConnection().connect(value.getOutputConnection());
 
-        assertSame(third, first.getLastBlockInSequence());
+        assertThat(third).isSameAs(first.getLastBlockInSequence());
     }
 
     @Test
@@ -486,7 +474,7 @@ public class BlockTest {
         second.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
         second.getNextConnection().connect(shadow.getPreviousConnection());
 
-        assertSame(second, first.getLastBlockInSequence());
+        assertThat(second).isSameAs(first.getLastBlockInSequence());
     }
 
     @Test
@@ -497,108 +485,106 @@ public class BlockTest {
     @Test
     public void testCollapsed() {
         Block block = new Block.Builder("statement_no_input").build();
-        assertFalse("By default, blocks are not collapsed.", block.isCollapsed());
+        assertWithMessage("By default, blocks are not collapsed.").that(block.isCollapsed()).isFalse();
 
         String blockXml = toXml(block);
-        assertFalse("Default state is not stored in XML", blockXml.contains("collapsed"));
+        assertWithMessage("Default state is not stored in XML").that(blockXml.contains("collapsed")).isFalse();
 
         Block blockFromXml = fromXmlWithoutId(blockXml);
-        assertFalse("By default, blocks loaded from XML are not collapsed.",
-                blockFromXml.isCollapsed());
+        assertWithMessage("By default, blocks loaded from XML are not collapsed.").that(blockFromXml.isCollapsed()).isFalse();
 
         block.setCollapsed(true);
-        assertTrue("Collapsed state can change.", block.isCollapsed());
+        assertWithMessage("Collapsed state can change.").that(block.isCollapsed()).isTrue();
 
         blockXml = toXml(block);
-        assertTrue("Collapsed state is stored in XML.", blockXml.contains("collapsed=\"true\""));
+        assertWithMessage("Collapsed state is stored in XML.").that(blockXml.contains("collapsed=\"true\"")).isTrue();
 
         blockFromXml = fromXmlWithoutId(blockXml);
-        assertTrue("Collapsed state set from XML.", blockFromXml.isCollapsed());
+        assertWithMessage("Collapsed state set from XML.").that(blockFromXml.isCollapsed()).isTrue();
     }
 
     @Test
     public void testDeletable() {
         Block block = new Block.Builder("statement_no_input").build();
-        assertTrue("By default, blocks are deletable.", block.isDeletable());
+        assertWithMessage("By default, blocks are deletable.").that(block.isDeletable()).isTrue();
 
         String blockXml = toXml(block);
-        assertFalse("Default state is not stored in XML", blockXml.contains("deletable"));
+        assertWithMessage("Default state is not stored in XML").that(blockXml.contains("deletable")).isFalse();
 
         Block blockFromXml = fromXmlWithoutId(blockXml);
-        assertTrue("By default, blocks loaded from XML are deletable.", blockFromXml.isDeletable());
+        assertWithMessage("By default, blocks loaded from XML are deletable.").that(blockFromXml.isDeletable()).isTrue();
 
         block.setDeletable(false);
-        assertFalse("Deletable state can change.", block.isDeletable());
+        assertWithMessage("Deletable state can change.").that(block.isDeletable()).isFalse();
 
         blockXml = toXml(block);
-        assertTrue("Deletable state is stored in XML", blockXml.contains("deletable=\"false\""));
+        assertWithMessage("Deletable state is stored in XML").that(blockXml.contains("deletable=\"false\"")).isTrue();
 
         blockFromXml = fromXmlWithoutId(blockXml);
-        assertFalse("Deletable state set from XML.", blockFromXml.isDeletable());
+        assertWithMessage("Deletable state set from XML.").that(blockFromXml.isDeletable()).isFalse();
     }
 
     @Test
     public void testDisabled() {
         Block block = new Block.Builder("statement_no_input").build();
-        assertFalse("By default, blocks are not disabled.", block.isDisabled());
+        assertWithMessage("By default, blocks are not disabled.").that(block.isDisabled()).isFalse();
 
         String blockXml = toXml(block);
-        assertFalse("Default state is not stored in XML", blockXml.contains("disabled"));
+        assertWithMessage("Default state is not stored in XML").that(blockXml.contains("disabled")).isFalse();
 
         Block blockFromXml = fromXmlWithoutId(blockXml);
-        assertFalse("By default, blocks loaded from XML are not disabled.",
-                blockFromXml.isDisabled());
+        assertWithMessage("By default, blocks loaded from XML are not disabled.").that(blockFromXml.isDisabled()).isFalse();
 
         block.setDisabled(true);
-        assertTrue("Disabled state can change.", block.isDisabled());
+        assertWithMessage("Disabled state can change.").that(block.isDisabled()).isTrue();
 
         blockXml = toXml(block);
-        assertTrue("Disabled state is stored in XML.", blockXml.contains("disabled=\"true\""));
+        assertWithMessage("Disabled state is stored in XML.").that(blockXml.contains("disabled=\"true\"")).isTrue();
 
         blockFromXml = fromXmlWithoutId(blockXml);
-        assertTrue("Disabled state set from XML.", blockFromXml.isDisabled());
+        assertWithMessage("Disabled state set from XML.").that(blockFromXml.isDisabled()).isTrue();
     }
 
     @Test
     public void testEditable() {
         Block block = new Block.Builder("statement_no_input").build();
-        assertTrue("By default, blocks are editable.", block.isEditable());
+        assertWithMessage("By default, blocks are editable.").that(block.isEditable()).isTrue();
 
         String blockXml = toXml(block);
-        assertFalse("Default state is not stored in XML", blockXml.contains("editable"));
+        assertWithMessage("Default state is not stored in XML").that(blockXml.contains("editable")).isFalse();
 
         Block blockFromXml = fromXmlWithoutId(blockXml);
-        assertTrue("By default, blocks loaded from XML are editable.", blockFromXml.isEditable());
+        assertWithMessage("By default, blocks loaded from XML are editable.").that(blockFromXml.isEditable()).isTrue();
 
         block.setEditable(false);
-        assertFalse("Editable state can change.", block.isEditable());
+        assertWithMessage("Editable state can change.").that(block.isEditable()).isFalse();
 
         blockXml = toXml(block);
-        assertTrue("Editable state is stored in XML", blockXml.contains("editable=\"false\""));
+        assertWithMessage("Editable state is stored in XML").that(blockXml.contains("editable=\"false\"")).isTrue();
 
         blockFromXml = fromXmlWithoutId(blockXml);
-        assertFalse("Editable state set from XML.", blockFromXml.isEditable());
+        assertWithMessage("Editable state set from XML.").that(blockFromXml.isEditable()).isFalse();
     }
 
     @Test
     public void testMovable() {
         Block block = new Block.Builder("statement_no_input").build();
-        assertTrue("By default, blocks are editable.", block.isMovable());
+        assertWithMessage("By default, blocks are editable.").that(block.isMovable()).isTrue();
 
         String blockXml = toXml(block);
-        assertFalse("Default state is not stored in XML", blockXml.contains("movable"));
+        assertWithMessage("Default state is not stored in XML").that(blockXml.contains("movable")).isFalse();
 
         Block blockFromXml = fromXmlWithoutId(blockXml);
-        assertTrue("By default, blocks loaded from XML are movable.", blockFromXml.isMovable());
+        assertWithMessage("By default, blocks loaded from XML are movable.").that(blockFromXml.isMovable()).isTrue();
 
         block.setMovable(false);
-        assertFalse("Movable state can change.", block.isMovable());
+        assertWithMessage("Movable state can change.").that(block.isMovable()).isFalse();
 
         blockXml = toXml(block);
-        assertTrue("Movable state is stored in XML", blockXml.contains("movable=\"false\""));
+        assertWithMessage("Movable state is stored in XML").that(blockXml.contains("movable=\"false\"")).isTrue();
 
         blockFromXml = fromXmlWithoutId(blockXml);
-        assertFalse("Movable state set from XML.", blockFromXml.isMovable());
+        assertWithMessage("Movable state set from XML.").that(blockFromXml.isMovable()).isFalse();
     }
 
     /**
@@ -613,9 +599,8 @@ public class BlockTest {
 
         String xml = toXml(block);
         Matcher matcher = Pattern.compile("less.*end").matcher(xml);
-        assertTrue(matcher.find());
-        assertEquals("less than &lt; greater than &gt; ampersand &amp; quote \" apostrophe ' end",
-                matcher.group());
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.group()).isEqualTo("less than &lt; greater than &gt; ampersand &amp; quote \" apostrophe ' end");
     }
 
     private String toXml(Block block) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
@@ -12,8 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -113,15 +112,15 @@ public class BlocklyEventTest {
                                  BlocklyEvent.ChangeEvent event,
                                  String oldValue, String newValue)
             throws JSONException {
-        assertSame(event.getTypeId(), BlocklyEvent.TYPE_CHANGE);
-        assertSame(event.getTypeName(), BlocklyEvent.TYPENAME_CHANGE);
-        assertEquals(WORKSPACE_ID, event.getWorkspaceId());
+        assertThat(event.getTypeId()).isSameAs(BlocklyEvent.TYPE_CHANGE);
+        assertThat(event.getTypeName()).isSameAs(BlocklyEvent.TYPENAME_CHANGE);
+        assertThat(event.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
         // Group id is assigned by the BlocklyController, not tested here.
-        assertEquals(element, event.getElement());
-        assertEquals(oldValue, event.getOldValue());
-        assertEquals(newValue, event.getNewValue());
+        assertThat(event.getElement()).isEqualTo(element);
+        assertThat(event.getOldValue()).isEqualTo(oldValue);
+        assertThat(event.getNewValue()).isEqualTo(newValue);
         if (element == BlocklyEvent.ELEMENT_FIELD) {
-            assertEquals(FIELD_NAME, event.getFieldName());
+            assertThat(event.getFieldName()).isEqualTo(FIELD_NAME);
         }
 
         String serialized = event.toJsonString();
@@ -129,14 +128,14 @@ public class BlocklyEventTest {
 
         BlocklyEvent.ChangeEvent deserializedEvent =
                 (BlocklyEvent.ChangeEvent) BlocklyEvent.fromJson(json);
-        assertEquals(event.getTypeName(), deserializedEvent.getTypeName());
+        assertThat(deserializedEvent.getTypeName()).isEqualTo(event.getTypeName());
         // Workspace ids are not serialized.
         // Group id is assigned by the BlocklyController, not tested here.
-        assertEquals(element, deserializedEvent.getElement());
-        assertEquals(BLOCK_ID, deserializedEvent.getBlockId());
-        assertEquals(newValue, deserializedEvent.getNewValue());
+        assertThat(deserializedEvent.getElement()).isEqualTo(element);
+        assertThat(deserializedEvent.getBlockId()).isEqualTo(BLOCK_ID);
+        assertThat(deserializedEvent.getNewValue()).isEqualTo(newValue);
         if (element == BlocklyEvent.ELEMENT_FIELD) {
-            assertEquals(FIELD_NAME, deserializedEvent.getFieldName());
+            assertThat(deserializedEvent.getFieldName()).isEqualTo(FIELD_NAME);
         }
     }
 
@@ -144,30 +143,30 @@ public class BlocklyEventTest {
     public void testCreateEvent() throws JSONException {
         BlocklyEvent.CreateEvent event = new BlocklyEvent.CreateEvent(mMockWorkspace, mBlock);
 
-        assertSame(event.getTypeId(), BlocklyEvent.TYPE_CREATE);
-        assertSame(event.getTypeName(), BlocklyEvent.TYPENAME_CREATE);
-        assertEquals(WORKSPACE_ID, event.getWorkspaceId());
+        assertThat(event.getTypeId()).isSameAs(BlocklyEvent.TYPE_CREATE);
+        assertThat(event.getTypeName()).isSameAs(BlocklyEvent.TYPENAME_CREATE);
+        assertThat(event.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
         // Group id is assigned by the BlocklyController, not tested here.
-        assertEquals(1, event.getIds().size());
-        assertEquals(BLOCK_ID, event.getIds().get(0));
+        assertThat(event.getIds().size()).isEqualTo(1);
+        assertThat(event.getIds().get(0)).isEqualTo(BLOCK_ID);
 
         String serialized = event.toJsonString();
         JSONObject json = new JSONObject(serialized);
 
         BlocklyEvent.CreateEvent deserializedEvent =
                 (BlocklyEvent.CreateEvent) BlocklyEvent.fromJson(json);
-        assertEquals(event.getTypeName(), deserializedEvent.getTypeName());
+        assertThat(deserializedEvent.getTypeName()).isEqualTo(event.getTypeName());
         // Workspace ids are not serialized.
         // Group id is assigned by the BlocklyController, not tested here.
-        assertEquals(BLOCK_ID, deserializedEvent.getBlockId());
-        assertEquals(1, deserializedEvent.getIds().size());
-        assertEquals(BLOCK_ID, deserializedEvent.getIds().get(0));
+        assertThat(deserializedEvent.getBlockId()).isEqualTo(BLOCK_ID);
+        assertThat(deserializedEvent.getIds().size()).isEqualTo(1);
+        assertThat(deserializedEvent.getIds().get(0)).isEqualTo(BLOCK_ID);
 
         mBlockFactory.clearPriorBlockReferences(); // Prevent duplicate block id errors.
         Block deserializedBlock =
                 BlocklyXmlHelper.loadOneBlockFromXml(deserializedEvent.getXml(), mBlockFactory);
-        assertEquals(BLOCK_ID, deserializedBlock.getId());
-        assertEquals(BLOCK_TYPE, mBlock.getType());
-        assertEquals(NEW_POSITION, mBlock.getPosition());
+        assertThat(deserializedBlock.getId()).isEqualTo(BLOCK_ID);
+        assertThat(mBlock.getType()).isEqualTo(BLOCK_TYPE);
+        assertThat(mBlock.getPosition()).isEqualTo(NEW_POSITION);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/ConnectionTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/ConnectionTest.java
@@ -19,7 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link Connection}.
@@ -72,74 +72,74 @@ public class ConnectionTest {
 
     @Test
     public void testCanConnectWithReason() {
-        assertEquals(Connection.REASON_TARGET_NULL, input.canConnectWithReason(null));
-        assertEquals(Connection.REASON_TARGET_NULL, input.canConnectWithReason(
-                new Connection(Connection.CONNECTION_TYPE_OUTPUT, null)));
+        assertThat(input.canConnectWithReason(null)).isEqualTo(Connection.REASON_TARGET_NULL);
+        assertThat(input.canConnectWithReason(new Connection(Connection.CONNECTION_TYPE_OUTPUT, null)))
+            .isEqualTo(Connection.REASON_TARGET_NULL);
 
-        assertEquals(Connection.REASON_SELF_CONNECTION, input.canConnectWithReason(input));
-        assertEquals(Connection.REASON_SELF_CONNECTION, input.canConnectWithReason(input));
+        assertThat(input.canConnectWithReason(input)).isEqualTo(Connection.REASON_SELF_CONNECTION);
+        assertThat(input.canConnectWithReason(input)).isEqualTo(Connection.REASON_SELF_CONNECTION);
     }
 
     @Test
     public void testCanConnectWithReasonDisconnect() {
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.CAN_CONNECT);
         Connection conn = new Connection(Connection.CONNECTION_TYPE_OUTPUT, null);
         conn.setBlock(blockBuilder.build());
         input.connect(conn);
-        assertEquals(Connection.REASON_MUST_DISCONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.REASON_MUST_DISCONNECT);
     }
 
     @Test
     public void testCanConnectWithReasonType() {
-        assertEquals(Connection.REASON_WRONG_TYPE, input.canConnectWithReason(previous));
-        assertEquals(Connection.REASON_WRONG_TYPE, input.canConnectWithReason(next));
+        assertThat(input.canConnectWithReason(previous)).isEqualTo(Connection.REASON_WRONG_TYPE);
+        assertThat(input.canConnectWithReason(next)).isEqualTo(Connection.REASON_WRONG_TYPE);
 
-        assertEquals(Connection.REASON_WRONG_TYPE, output.canConnectWithReason(previous));
-        assertEquals(Connection.REASON_WRONG_TYPE, output.canConnectWithReason(next));
+        assertThat(output.canConnectWithReason(previous)).isEqualTo(Connection.REASON_WRONG_TYPE);
+        assertThat(output.canConnectWithReason(next)).isEqualTo(Connection.REASON_WRONG_TYPE);
 
-        assertEquals(Connection.REASON_WRONG_TYPE, previous.canConnectWithReason(input));
-        assertEquals(Connection.REASON_WRONG_TYPE, previous.canConnectWithReason(output));
+        assertThat(previous.canConnectWithReason(input)).isEqualTo(Connection.REASON_WRONG_TYPE);
+        assertThat(previous.canConnectWithReason(output)).isEqualTo(Connection.REASON_WRONG_TYPE);
 
-        assertEquals(Connection.REASON_WRONG_TYPE, next.canConnectWithReason(input));
-        assertEquals(Connection.REASON_WRONG_TYPE, next.canConnectWithReason(output));
+        assertThat(next.canConnectWithReason(input)).isEqualTo(Connection.REASON_WRONG_TYPE);
+        assertThat(next.canConnectWithReason(output)).isEqualTo(Connection.REASON_WRONG_TYPE);
     }
 
     @Test
     public void testCanConnectWithReasonChecks() {
         input = new Connection(Connection.CONNECTION_TYPE_INPUT, new String[]{"String", "int"});
         input.setBlock(blockBuilder.build());
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.CAN_CONNECT);
 
         output = new Connection(Connection.CONNECTION_TYPE_OUTPUT, new String[]{"int"});
         output.setBlock(blockBuilder.build());
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.CAN_CONNECT);
 
         output = new Connection(Connection.CONNECTION_TYPE_OUTPUT, new String[]{"String"});
         output.setBlock(blockBuilder.build());
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.CAN_CONNECT);
 
         output = new Connection(Connection.CONNECTION_TYPE_OUTPUT, new String[]{"String", "int"});
         output.setBlock(blockBuilder.build());
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.CAN_CONNECT);
 
         output = new Connection(Connection.CONNECTION_TYPE_OUTPUT, new String[]{"Some other type"});
         output.setBlock(blockBuilder.build());
-        assertEquals(Connection.REASON_CHECKS_FAILED, input.canConnectWithReason(output));
+        assertThat(input.canConnectWithReason(output)).isEqualTo(Connection.REASON_CHECKS_FAILED);
     }
 
     @Test
     public void testCanConnectWithReason_shadows() {
         // Verify a shadow can connect
-        assertEquals(Connection.CAN_CONNECT, input.canConnectWithReason(shadowOutput));
+        assertThat(input.canConnectWithReason(shadowOutput)).isEqualTo(Connection.CAN_CONNECT);
         input.connect(output);
         // Verify a shadow and non shadow can't be connected at the same time
-        assertEquals(Connection.REASON_MUST_DISCONNECT, input.canConnectWithReason(shadowOutput));
+        assertThat(input.canConnectWithReason(shadowOutput)).isEqualTo(Connection.REASON_MUST_DISCONNECT);
         input.disconnect();
         input.connect(shadowOutput);
 
         // Veryify a normal connection can't be made after a shadow connection
         next.connect(shadowPrevious);
-        assertEquals(Connection.REASON_MUST_DISCONNECT, next.canConnectWithReason(previous));
+        assertThat(next.canConnectWithReason(previous)).isEqualTo(Connection.REASON_MUST_DISCONNECT);
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldAngleTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldAngleTest.java
@@ -16,10 +16,7 @@ package com.google.blockly.model;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldAngle}.
@@ -28,33 +25,33 @@ public class FieldAngleTest {
     @Test
     public void testConstructor() {
         FieldAngle field = new FieldAngle("name", 0);
-        assertEquals(Field.TYPE_ANGLE, field.getType());
-        assertEquals("name", field.getName());
-        assertEquals(0f, field.getAngle(), 0d);
+        assertThat(field.getType()).isEqualTo(Field.TYPE_ANGLE);
+        assertThat(field.getName()).isEqualTo("name");
+        assertThat(field.getAngle()).isEqualTo(0f);
     }
 
     @Test
     public void testWrapAround() {
         FieldAngle field = new FieldAngle("name", 360);
-        assertEquals(0f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(0f);
 
         field.setAngle(720f);
-        assertEquals(0f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(0f);
 
         field.setAngle(-180f);
-        assertEquals(180f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(180f);
 
         field.setAngle(10000f);
-        assertEquals(280f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(280f);
 
         field.setAngle(-10000f);
-        assertEquals(80f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(80f);
 
         field.setAngle(27f);
-        assertEquals(27f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(27f);
 
         field.setAngle(-10001f);
-        assertEquals(79f, field.getAngle(), 0d);
+        assertThat(field.getAngle()).isEqualTo(79f);
     }
 
     @Test
@@ -62,11 +59,11 @@ public class FieldAngleTest {
         FieldAngle field = new FieldAngle("name", 0);
 
         // xml parsing
-        assertTrue(field.setFromString("-180"));
-        assertEquals(180f, field.getAngle(), 0d);
-        assertTrue(field.setFromString("27"));
-        assertEquals(27f, field.getAngle(), 0d);
-        assertFalse(field.setFromString("this is not a number"));
+        assertThat(field.setFromString("-180")).isTrue();
+        assertThat(field.getAngle()).isEqualTo(180f);
+        assertThat(field.setFromString("27")).isTrue();
+        assertThat(field.getAngle()).isEqualTo(27f);
+        assertThat(field.setFromString("this is not a number")).isFalse();
     }
 
     @Test
@@ -74,9 +71,9 @@ public class FieldAngleTest {
         FieldAngle field = new FieldAngle("name", 5);
         FieldAngle clone = field.clone();
 
-        assertNotSame(field, field.clone());
-        assertEquals(field.getName(), clone.getName());
-        assertEquals(field.getAngle(), clone.getAngle(), 0d);
+        assertThat(field).isNotSameAs(field.clone());
+        assertThat(clone.getName()).isEqualTo(field.getName());
+        assertThat(clone.getAngle()).isEqualTo(field.getAngle());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldCheckboxTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldCheckboxTest.java
@@ -16,10 +16,7 @@ package com.google.blockly.model;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldCheckbox}.
@@ -28,33 +25,33 @@ public class FieldCheckboxTest {
     @Test
     public void testFieldCheckbox() {
         FieldCheckbox field = new FieldCheckbox("checkbox", true);
-        assertEquals(Field.TYPE_CHECKBOX, field.getType());
-        assertEquals("checkbox", field.getName());
-        assertEquals(true, field.isChecked());
+        assertThat(field.getType()).isEqualTo(Field.TYPE_CHECKBOX);
+        assertThat(field.getName()).isEqualTo("checkbox");
+        assertThat(field.isChecked()).isEqualTo(true);
         field.setChecked(false);
-        assertEquals(false, field.isChecked());
+        assertThat(field.isChecked()).isEqualTo(false);
 
         field = new FieldCheckbox("fname", false);
-        assertEquals(false, field.isChecked());
+        assertThat(field.isChecked()).isEqualTo(false);
         field.setChecked(true);
-        assertEquals(true, field.isChecked());
+        assertThat(field.isChecked()).isEqualTo(true);
 
-        assertTrue(field.setFromString("false"));
-        assertFalse(field.isChecked());
+        assertThat(field.setFromString("false")).isTrue();
+        assertThat(field.isChecked()).isFalse();
 
-        assertTrue(field.setFromString("true"));
-        assertTrue(field.setFromString("TRUE"));
-        assertTrue(field.setFromString("True"));
-        assertTrue(field.isChecked());
+        assertThat(field.setFromString("true")).isTrue();
+        assertThat(field.setFromString("TRUE")).isTrue();
+        assertThat(field.setFromString("True")).isTrue();
+        assertThat(field.isChecked()).isTrue();
 
         // xml parsing
         // Boolean.parseBoolean checks the lowercased value against "true" and returns false
         // otherwise.
-        assertTrue(field.setFromString("This is not a boolean"));
-        assertFalse(field.isChecked());
+        assertThat(field.setFromString("This is not a boolean")).isTrue();
+        assertThat(field.isChecked()).isFalse();
         field.setChecked(true);
-        assertTrue(field.setFromString("t"));
-        assertFalse(field.isChecked());
+        assertThat(field.setFromString("t")).isTrue();
+        assertThat(field.isChecked()).isFalse();
     }
 
     @Test
@@ -62,14 +59,14 @@ public class FieldCheckboxTest {
         FieldCheckbox field = new FieldCheckbox("checkbox", true);
         FieldCheckbox clone = field.clone();
 
-        assertNotSame(field, clone);
-        assertEquals(field.getName(), field.getName());
-        assertEquals(field.isChecked(), clone.isChecked());
+        assertThat(field).isNotSameAs(clone);
+        assertThat(field.getName()).isEqualTo(field.getName());
+        assertThat(clone.isChecked()).isEqualTo(field.isChecked());
 
         // Test with false
         field = new FieldCheckbox("checkbox", false);
         clone = field.clone();
-        assertEquals(field.isChecked(), clone.isChecked());
+        assertThat(clone.isChecked()).isEqualTo(field.isChecked());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldColorTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldColorTest.java
@@ -17,10 +17,7 @@ package com.google.blockly.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldColor}.
@@ -38,45 +35,45 @@ public class FieldColorTest {
 
     @Test
     public void testConstructors() {
-        assertEquals(Field.TYPE_COLOR, mField.getType());
-        assertEquals("fname", mField.getName());
-        assertEquals(INITIAL_COLOR, mField.getColor());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_COLOR);
+        assertThat(mField.getName()).isEqualTo("fname");
+        assertThat(mField.getColor()).isEqualTo(INITIAL_COLOR);
 
         mField = new FieldColor("fname");
-        assertEquals("fname", mField.getName());
-        assertEquals(FieldColor.DEFAULT_COLOR, mField.getColor());
+        assertThat(mField.getName()).isEqualTo("fname");
+        assertThat(mField.getColor()).isEqualTo(FieldColor.DEFAULT_COLOR);
     }
 
     @Test
     public void testSetColor() {
         mField.setColor(0xb0bb1e);
-        assertEquals(0xb0bb1e, mField.getColor());
+        assertThat(mField.getColor()).isEqualTo(0xb0bb1e);
     }
 
     @Test
     public void testSetFromString() {
-        assertTrue(mField.setFromString("#ffcc66"));
-        assertEquals(0xffcc66, mField.getColor());
-        assertTrue(mField.setFromString("#00cc66"));
-        assertEquals(0x00cc66, mField.getColor());
+        assertThat(mField.setFromString("#ffcc66")).isTrue();
+        assertThat(mField.getColor()).isEqualTo(0xffcc66);
+        assertThat(mField.setFromString("#00cc66")).isTrue();
+        assertThat(mField.getColor()).isEqualTo(0x00cc66);
 
         // Ignore alpha channel
-        assertTrue(mField.setFromString("#1000cc66"));
-        assertEquals(0x00cc66, mField.getColor());
+        assertThat(mField.setFromString("#1000cc66")).isTrue();
+        assertThat(mField.getColor()).isEqualTo(0x00cc66);
 
         // Invalid color strings. Value should not change.
-        assertFalse(mField.setFromString("This is not a color"));
-        assertEquals(0x00cc66, mField.getColor());
-        assertFalse(mField.setFromString("#fc6"));
-        assertEquals(0x00cc66, mField.getColor());
+        assertThat(mField.setFromString("This is not a color")).isFalse();
+        assertThat(mField.getColor()).isEqualTo(0x00cc66);
+        assertThat(mField.setFromString("#fc6")).isFalse();
+        assertThat(mField.getColor()).isEqualTo(0x00cc66);
     }
 
     @Test
     public void testClone() {
         FieldColor clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertEquals(mField.getColor(), clone.getColor());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(clone.getColor()).isEqualTo(mField.getColor());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDateTest.java
@@ -19,10 +19,7 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldDate}.
@@ -39,38 +36,38 @@ public class FieldDateTest {
 
     @Test
     public void testConstructor() {
-        assertEquals(Field.TYPE_DATE, mField.getType());
-        assertEquals("alphabet", mField.getName());
-        assertEquals(INITIAL_VALUE, mField.getSerializedValue());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_DATE);
+        assertThat(mField.getName()).isEqualTo("alphabet");
+        assertThat(mField.getSerializedValue()).isEqualTo(INITIAL_VALUE);
     }
 
     @Test
     public void testSetDate() {
         Date date = new Date();
         mField.setDate(date);
-        assertEquals(date, mField.getDate());
+        assertThat(mField.getDate()).isEqualTo(date);
         date.setTime(date.getTime() + 86400000);
         mField.setTime(date.getTime());
-        assertEquals(date, mField.getDate());
+        assertThat(mField.getDate()).isEqualTo(date);
 
-        assertTrue(mField.setFromString("2017-03-23"));
-        assertEquals("2017-03-23", mField.getLocalizedDateString());
+        assertThat(mField.setFromString("2017-03-23")).isTrue();
+        assertThat(mField.getLocalizedDateString()).isEqualTo("2017-03-23");
     }
 
     @Test
     public void testSetFromString() {
-        assertFalse(mField.setFromString("today"));
-        assertFalse(mField.setFromString("2017/03/03"));
-        assertFalse(mField.setFromString(""));
+        assertThat(mField.setFromString("today")).isFalse();
+        assertThat(mField.setFromString("2017/03/03")).isFalse();
+        assertThat(mField.setFromString("")).isFalse();
     }
 
     @Test
     public void testClone() {
         FieldDate clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertNotSame(mField.getDate(), clone.getDate());
-        assertEquals(mField.getDate(), clone.getDate());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(mField.getDate()).isNotSameAs(clone.getDate());
+        assertThat(clone.getDate()).isEqualTo(mField.getDate());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldDropdownTest.java
@@ -24,9 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldDropdown}.
@@ -58,33 +56,33 @@ public class FieldDropdownTest {
     @Test
     public void testOptionsConstructorFromStrings() {
         // Created above.
-        assertEquals(VALUES.size(), mOptions.size());
+        assertThat(mOptions.size()).isEqualTo(VALUES.size());
         for (int i = 0; i < mOptions.size(); ++i) {
             FieldDropdown.Option option = mOptions.get(i);
-            assertEquals(VALUES.get(i), option.value);
-            assertEquals(LABELS.get(i), option.displayName);
+            assertThat(option.value).isEqualTo(VALUES.get(i));
+            assertThat(option.displayName).isEqualTo(LABELS.get(i));
         }
     }
 
     @Test
     public void testDropdownConstructor() {
-        assertEquals(Field.TYPE_DROPDOWN, mDropDown.getType());
-        assertEquals(FIELD_NAME, mDropDown.getName());
-        assertEquals(0, mDropDown.getSelectedIndex());
-        assertEquals(VALUES.size(), mDropDown.getOptions().size());
+        assertThat(mDropDown.getType()).isEqualTo(Field.TYPE_DROPDOWN);
+        assertThat(mDropDown.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(0);
+        assertThat(mDropDown.getOptions().size()).isEqualTo(VALUES.size());
 
         // The options may be shared, so identity
-        assertSame(mOptions, mDropDown.getOptions());
+        assertThat(mOptions).isSameAs(mDropDown.getOptions());
     }
 
     @Test
     public void testSelectedByIndex() {
         for (int i = 0; i < VALUES.size(); i++) {
             mDropDown.setSelectedIndex(i);
-            assertEquals(i, mDropDown.getSelectedIndex());
-            assertEquals(VALUES.get(i), mDropDown.getSelectedValue());
-            assertEquals(VALUES.get(i), mDropDown.getSerializedValue());
-            assertEquals(LABELS.get(i), mDropDown.getSelectedDisplayName());
+            assertThat(mDropDown.getSelectedIndex()).isEqualTo(i);
+            assertThat(mDropDown.getSelectedValue()).isEqualTo(VALUES.get(i));
+            assertThat(mDropDown.getSerializedValue()).isEqualTo(VALUES.get(i));
+            assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(LABELS.get(i));
         }
 
         thrown.expect(IllegalArgumentException.class);
@@ -98,31 +96,31 @@ public class FieldDropdownTest {
 
         for (int i = 0; i < VALUES.size(); ++i) {
             mDropDown.setSelectedValue(VALUES.get(i));
-            assertEquals(i, mDropDown.getSelectedIndex());
-            assertEquals(VALUES.get(i), mDropDown.getSelectedValue());
-            assertEquals(VALUES.get(i), mDropDown.getSerializedValue());
-            assertEquals(LABELS.get(i), mDropDown.getSelectedDisplayName());
+            assertThat(mDropDown.getSelectedIndex()).isEqualTo(i);
+            assertThat(mDropDown.getSelectedValue()).isEqualTo(VALUES.get(i));
+            assertThat(mDropDown.getSerializedValue()).isEqualTo(VALUES.get(i));
+            assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(LABELS.get(i));
         }
 
         // setting a non-existent value defaults to 0
         mDropDown.setSelectedValue("bad value");
-        assertEquals(0, mDropDown.getSelectedIndex());
-        assertEquals(LABELS.get(0), mDropDown.getSelectedDisplayName());
-        assertEquals(VALUES.get(0), mDropDown.getSerializedValue());
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(0);
+        assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(LABELS.get(0));
+        assertThat(mDropDown.getSerializedValue()).isEqualTo(VALUES.get(0));
     }
 
     @Test
     public void testSetFromString() {
-        assertTrue(mDropDown.setFromString(VALUES.get(1)));
-        assertEquals(1, mDropDown.getSelectedIndex());
-        assertEquals(LABELS.get(1), mDropDown.getSelectedDisplayName());
-        assertEquals(VALUES.get(1), mDropDown.getSerializedValue());
+        assertThat(mDropDown.setFromString(VALUES.get(1))).isTrue();
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(1);
+        assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(LABELS.get(1));
+        assertThat(mDropDown.getSerializedValue()).isEqualTo(VALUES.get(1));
 
         // Setting a non-existent value defaults to 0
         mDropDown.setSelectedValue("bad value");
-        assertEquals(0, mDropDown.getSelectedIndex());
-        assertEquals(LABELS.get(0), mDropDown.getSelectedDisplayName());
-        assertEquals(VALUES.get(0), mDropDown.getSerializedValue());
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(0);
+        assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(LABELS.get(0));
+        assertThat(mDropDown.getSerializedValue()).isEqualTo(VALUES.get(0));
     }
 
     @Test
@@ -142,8 +140,8 @@ public class FieldDropdownTest {
         );
         mDropDown.getOptions().updateOptions(newOptions);
 
-        assertEquals(oldSelectedIndex + 1, mDropDown.getSelectedIndex());
-        assertEquals(oldSelectedValue, mDropDown.getSelectedValue());
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(oldSelectedIndex + 1);
+        assertThat(mDropDown.getSelectedValue()).isEqualTo(oldSelectedValue);
     }
 
     @Test
@@ -160,12 +158,12 @@ public class FieldDropdownTest {
         mDropDown.getOptions().updateOptions(newOptions);
 
         // No matching value, so index should be 0;
-        assertEquals(0, mDropDown.getSelectedIndex());
+        assertThat(mDropDown.getSelectedIndex()).isEqualTo(0);
 
         for (int i = 1; i < VALUES.size(); i++) {
             mDropDown.setSelectedIndex(i);
-            assertEquals(LABELS.get(i), mDropDown.getSerializedValue());
-            assertEquals(VALUES.get(i), mDropDown.getSelectedDisplayName());
+            assertThat(mDropDown.getSerializedValue()).isEqualTo(LABELS.get(i));
+            assertThat(mDropDown.getSelectedDisplayName()).isEqualTo(VALUES.get(i));
         }
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldImageTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldImageTest.java
@@ -17,9 +17,7 @@ package com.google.blockly.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldImage}.
@@ -40,23 +38,23 @@ public class FieldImageTest {
 
     @Test
     public void testFieldImage() {
-        assertEquals(Field.TYPE_IMAGE, mField.getType());
-        assertEquals(FIELD_NAME, mField.getName());
-        assertEquals(SOURCE, mField.getSource());
-        assertEquals(WIDTH, mField.getWidth());
-        assertEquals(HEIGHT, mField.getHeight());
-        assertEquals(ALT_TEXT, mField.getAltText());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_IMAGE);
+        assertThat(mField.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mField.getSource()).isEqualTo(SOURCE);
+        assertThat(mField.getWidth()).isEqualTo(WIDTH);
+        assertThat(mField.getHeight()).isEqualTo(HEIGHT);
+        assertThat(mField.getAltText()).isEqualTo(ALT_TEXT);
     }
 
     @Test
     public void testClone() {
         FieldImage clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertEquals(mField.getSource(), clone.getSource());
-        assertEquals(mField.getWidth(), clone.getWidth());
-        assertEquals(mField.getHeight(), clone.getHeight());
-        assertEquals(mField.getAltText(), clone.getAltText());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(clone.getSource()).isEqualTo(mField.getSource());
+        assertThat(clone.getWidth()).isEqualTo(mField.getWidth());
+        assertThat(clone.getHeight()).isEqualTo(mField.getHeight());
+        assertThat(clone.getAltText()).isEqualTo(mField.getAltText());
     }
 
     @Test
@@ -65,17 +63,17 @@ public class FieldImageTest {
         mField.registerObserver(new Field.Observer() {
             @Override
             public void onValueChanged(Field field, String oldValue, String newValue) {
-                assertSame(mField, field);
+                assertThat(mField).isSameAs(field);
                 eventCount[0] += 1;
             }
         });
 
         // Same source, new metadata
         mField.setImage(SOURCE, 101, 202);
-        assertEquals(1, eventCount[0]);
+        assertThat(eventCount[0]).isEqualTo(1);
 
         // New source
         mField.setImage(SOURCE + "2", 101, 202);
-        assertEquals(2, eventCount[0]);
+        assertThat(eventCount[0]).isEqualTo(2);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldInputTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldInputTest.java
@@ -17,9 +17,7 @@ package com.google.blockly.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldInput}.
@@ -37,29 +35,29 @@ public class FieldInputTest {
 
     @Test
     public void testConstructor() {
-        assertEquals(Field.TYPE_INPUT, mField.getType());
-        assertEquals(FIELD_NAME, mField.getName());
-        assertEquals(INITIAL_VALUE, mField.getText());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_INPUT);
+        assertThat(mField.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mField.getText()).isEqualTo(INITIAL_VALUE);
     }
 
     @Test
     public void testSetText() {
         mField.setText("new text");
-        assertEquals("new text", mField.getText());
+        assertThat(mField.getText()).isEqualTo("new text");
     }
 
     @Test
     public void testSetFromString() {
-        assertTrue(mField.setFromString("newest text"));
-        assertEquals("newest text", mField.getText());
+        assertThat(mField.setFromString("newest text")).isTrue();
+        assertThat(mField.getText()).isEqualTo("newest text");
     }
 
     @Test
     public void testClone() {
         FieldInput clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertEquals(mField.getText(), clone.getText());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(clone.getText()).isEqualTo(mField.getText());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldLabelTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldLabelTest.java
@@ -17,8 +17,7 @@ package com.google.blockly.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldLabel}.
@@ -35,16 +34,16 @@ public class FieldLabelTest {
 
     @Test
     public void testConstructor() {
-        assertEquals(Field.TYPE_LABEL, mField.getType());
-        assertEquals(FIELD_NAME, mField.getName());
-        assertEquals(INITIAL_VALUE, mField.getText());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_LABEL);
+        assertThat(mField.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mField.getText()).isEqualTo(INITIAL_VALUE);
     }
 
     @Test
     public void testClone() {
         FieldLabel clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertEquals(mField.getText(), clone.getText());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(clone.getText()).isEqualTo(mField.getText());
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
@@ -20,9 +20,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Tests for {@link FieldNumber}.
@@ -42,20 +41,20 @@ public class FieldNumberTest {
 
     @Test
     public void testConstructor() {
-        assertEquals(FIELD_NAME, mField.getName());
-        assertEquals(Field.TYPE_NUMBER, mField.getType(), 0d);
+        assertThat(mField.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_NUMBER);
     }
 
     @Test
     public void testConstraintDefaults() {
         // Before assignment
-        assertTrue(Double.isNaN(mField.getMinimumValue()));
-        assertTrue(Double.isNaN(mField.getMaximumValue()));
-        assertTrue(Double.isNaN(mField.getPrecision()));
+        assertThat(Double.isNaN(mField.getMinimumValue())).isTrue();
+        assertThat(Double.isNaN(mField.getMaximumValue())).isTrue();
+        assertThat(Double.isNaN(mField.getPrecision())).isTrue();
 
-        assertFalse(mField.hasMaximum());
-        assertFalse(mField.hasMinimum());
-        assertFalse(mField.hasPrecision());
+        assertThat(mField.hasMaximum()).isFalse();
+        assertThat(mField.hasMinimum()).isFalse();
+        assertThat(mField.hasPrecision()).isFalse();
     }
 
     @Test
@@ -65,75 +64,75 @@ public class FieldNumberTest {
         final double PRECISION = 0.1;
 
         mField.setConstraints(MIN, MAX, PRECISION);
-        assertEquals(MIN, mField.getMinimumValue(), 0d);
-        assertEquals(MAX, mField.getMaximumValue(), 0d);
-        assertEquals(PRECISION, mField.getPrecision(), 0d);
-        assertTrue(mField.hasPrecision());
+        assertThat(mField.getMinimumValue()).isEqualTo(MIN);
+        assertThat(mField.getMaximumValue()).isEqualTo(MAX);
+        assertThat(mField.getPrecision()).isEqualTo(PRECISION);
+        assertThat(mField.hasPrecision()).isTrue();
 
         // Normal assignments
         mField.setValue(3.0);
-        assertEquals(3.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(3.0);
         mField.setValue(0.2);
-        assertEquals(0.2, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.2);
         mField.setValue(0.09);
-        assertEquals("Rounded 0.09 to precision.", 0.1, mField.getValue(), 0d);
+        assertWithMessage("Rounded 0.09 to precision.").that(mField.getValue()).isEqualTo(0.1);
         mField.setValue(0.0);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
         mField.setValue(-0.1);
-        assertEquals(-0.1, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-0.1);
         mField.setValue(-0.1);
-        assertEquals(-0.1, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-0.1);
         mField.setValue(-0.29);
-        assertEquals(-0.3, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-0.3);
 
         mField.setValue(MIN + PRECISION);
-        assertTrue(MIN < mField.getValue());
+        assertThat(MIN < mField.getValue()).isTrue();
         mField.setValue(MAX - PRECISION);
-        assertTrue(mField.getValue() < MAX);
+        assertThat(mField.getValue() < MAX).isTrue();
 
         mField.setValue(MIN);
-        assertEquals(MIN, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MIN);
         mField.setValue(MAX);
-        assertEquals(MAX, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MAX);
 
         mField.setValue(MIN - PRECISION);
-        assertEquals(MIN, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MIN);
         mField.setValue(MAX + PRECISION);
-        assertEquals(MAX, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MAX);
 
         mField.setValue(MIN - 1e100);
-        assertEquals(MIN, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MIN);
         mField.setValue(MAX + 1e100);
-        assertEquals(MAX, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(MAX);
     }
 
     @Test
     public void testSetConstraints_SpecialValues() {
         mField.setConstraints(Double.NaN, 1.0, 0.1);
-        assertTrue(Double.isNaN(mField.getMinimumValue()));
-        assertFalse(mField.hasMinimum());
-        assertTrue(mField.hasMaximum());
+        assertThat(Double.isNaN(mField.getMinimumValue())).isTrue();
+        assertThat(mField.hasMinimum()).isFalse();
+        assertThat(mField.hasMaximum()).isTrue();
 
         mField.setConstraints(Double.NEGATIVE_INFINITY, 1.0, 0.1);
-        assertTrue(Double.isNaN(mField.getMinimumValue()));
-        assertFalse(mField.hasMinimum());
-        assertTrue(mField.hasMaximum());
+        assertThat(Double.isNaN(mField.getMinimumValue())).isTrue();
+        assertThat(mField.hasMinimum()).isFalse();
+        assertThat(mField.hasMaximum()).isTrue();
 
         mField.setConstraints(-1.0, Double.NaN, 0.1);
-        assertTrue(Double.isNaN(mField.getMaximumValue()));
-        assertTrue(mField.hasMinimum());
-        assertFalse(mField.hasMaximum());
+        assertThat(Double.isNaN(mField.getMaximumValue())).isTrue();
+        assertThat(mField.hasMinimum()).isTrue();
+        assertThat(mField.hasMaximum()).isFalse();
 
         mField.setConstraints(-1.0, Double.POSITIVE_INFINITY, 0.1);
-        assertTrue(Double.isNaN(mField.getMaximumValue()));
-        assertTrue(mField.hasMinimum());
-        assertFalse(mField.hasMaximum());
+        assertThat(Double.isNaN(mField.getMaximumValue())).isTrue();
+        assertThat(mField.hasMinimum()).isTrue();
+        assertThat(mField.hasMaximum()).isFalse();
 
         mField.setConstraints(-1.0, 1.0, Double.NaN);
-        assertTrue(Double.isNaN(mField.getPrecision()));
-        assertTrue(mField.hasMinimum());
-        assertTrue(mField.hasMaximum());
-        assertFalse(mField.hasPrecision());
+        assertThat(Double.isNaN(mField.getPrecision())).isTrue();
+        assertThat(mField.hasMinimum()).isTrue();
+        assertThat(mField.hasMaximum()).isTrue();
+        assertThat(mField.hasPrecision()).isFalse();
     }
 
     @Test
@@ -179,68 +178,68 @@ public class FieldNumberTest {
         final double PRECISION = 0.25;  // Two significant digits
         mField.setConstraints(MIN, MAX, PRECISION);
 
-        assertFalse(mField.isInteger());
+        assertThat(mField.isInteger()).isFalse();
 
         // Exact values
         mField.setValue(0.0);
-        assertEquals(0.0, mField.getValue(), 0d);
-        assertEquals("0", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(0.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("0");
 
         mField.setValue(0.25);
-        assertEquals(0.25, mField.getValue(), 0d);
-        assertEquals("0.25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(0.25);
+        assertThat(mField.getFormattedValue()).isEqualTo("0.25");
 
         mField.setValue(1.0);
-        assertEquals(1.0, mField.getValue(), 0d);
-        assertEquals("1", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(1.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("1");
 
         mField.setValue(1.25);
-        assertEquals(1.25, mField.getValue(), 0d);
-        assertEquals("1.25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(1.25);
+        assertThat(mField.getFormattedValue()).isEqualTo("1.25");
 
         mField.setValue(2.50);
-        assertEquals(2.5, mField.getValue(), 0d);
-        assertEquals("2.5", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(2.5);
+        assertThat(mField.getFormattedValue()).isEqualTo("2.5");
 
         mField.setValue(25);
-        assertEquals(25.0, mField.getValue(), 0d);
-        assertEquals("25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(25.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("25");
 
         mField.setValue(-0.25);
-        assertEquals(-0.25, mField.getValue(), 0d);
-        assertEquals("-0.25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-0.25);
+        assertThat(mField.getFormattedValue()).isEqualTo("-0.25");
 
         mField.setValue(-1.0);
-        assertEquals(-1.0, mField.getValue(), 0d);
-        assertEquals("-1", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-1.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-1");
 
         mField.setValue(-1.25);
-        assertEquals(-1.25, mField.getValue(), 0d);
-        assertEquals("-1.25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-1.25);
+        assertThat(mField.getFormattedValue()).isEqualTo("-1.25");
 
         mField.setValue(-2.50);
-        assertEquals(-2.5, mField.getValue(), 0d);
-        assertEquals("-2.5", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-2.5);
+        assertThat(mField.getFormattedValue()).isEqualTo("-2.5");
 
         mField.setValue(-25);
-        assertEquals(-25.0, mField.getValue(), 0d);
-        assertEquals("-25", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-25.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-25");
 
         // Rounded Values
         mField.setValue(0.2);
-        assertEquals(0.25, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.25);
 
         mField.setValue(0.9);
-        assertEquals(1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.0);
 
         mField.setValue(1.1);
-        assertEquals(1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.0);
 
         mField.setValue(1.2);
-        assertEquals(1.25, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.25);
 
         mField.setValue(1.3);
-        assertEquals(1.25, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.25);
     }
 
     @Test
@@ -250,95 +249,95 @@ public class FieldNumberTest {
         final double PRECISION = 1;
         mField.setConstraints(MIN, MAX, PRECISION);
 
-        assertTrue(mField.isInteger());
+        assertThat(mField.isInteger()).isTrue();
 
         // Exact values
         mField.setValue(0.0);
 
         // Exact values
         mField.setValue(0.0);
-        assertEquals(0.0, mField.getValue(), 0d);
-        assertEquals("0", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(0.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("0");
 
         mField.setValue(1.0);
-        assertEquals(1.0, mField.getValue(), 0d);
-        assertEquals("1", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(1.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("1");
 
         mField.setValue(2.0);
-        assertEquals(2.0, mField.getValue(), 0d);
-        assertEquals("2", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(2.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("2");
 
         mField.setValue(7.0);
-        assertEquals(7.0, mField.getValue(), 0d);
-        assertEquals("7", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(7.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("7");
 
         mField.setValue(10.0);
-        assertEquals(10.0, mField.getValue(), 0d);
-        assertEquals("10", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(10.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("10");
 
         mField.setValue(100.0);
-        assertEquals(100.0, mField.getValue(), 0d);
-        assertEquals("100", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(100.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("100");
 
         mField.setValue(1000000.0);
-        assertEquals(1000000.0, mField.getValue(), 0d);
-        assertEquals("1000000", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(1000000.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("1000000");
 
         mField.setValue(-1.0);
-        assertEquals(-1.0, mField.getValue(), 0d);
-        assertEquals("-1", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-1.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-1");
 
         mField.setValue(-2.0);
-        assertEquals(-2.0, mField.getValue(), 0d);
-        assertEquals("-2", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-2.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-2");
 
         mField.setValue(-7.0);
-        assertEquals(-7.0, mField.getValue(), 0d);
-        assertEquals("-7", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-7.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-7");
 
         mField.setValue(-10.0);
-        assertEquals(-10.0, mField.getValue(), 0d);
-        assertEquals("-10", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-10.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-10");
 
         mField.setValue(-100.0);
-        assertEquals(-100.0, mField.getValue(), 0d);
-        assertEquals("-100", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-100.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-100");
 
         mField.setValue(-1000000.0);
-        assertEquals(-1000000.0, mField.getValue(), 0d);
-        assertEquals("-1000000", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-1000000.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-1000000");
 
 
         // Rounded Values
         mField.setValue(0.2);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(0.499999);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(0.5);
-        assertEquals(1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.0);
 
         mField.setValue(1.1);
-        assertEquals(1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1.0);
 
         mField.setValue(99.9999);
-        assertEquals(100.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(100.0);
 
         mField.setValue(-0.2);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(-0.5);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(-0.501);
-        assertEquals(-1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-1.0);
 
         mField.setValue(-1.1);
-        assertEquals(-1.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-1.0);
 
         mField.setValue(-99.9999);
-        assertEquals(-100.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-100.0);
     }
 
     @Test
@@ -348,60 +347,60 @@ public class FieldNumberTest {
         final double PRECISION = 2;
         mField.setConstraints(MIN, MAX, PRECISION);
 
-        assertTrue(mField.isInteger());
+        assertThat(mField.isInteger()).isTrue();
 
         // Exact values
         mField.setValue(0.0);
-        assertEquals(0.0, mField.getValue(), 0d);
-        assertEquals("0", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(0.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("0");
 
         mField.setValue(2.0);
-        assertEquals(2.0, mField.getValue(), 0d);
-        assertEquals("2", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(2.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("2");
 
         mField.setValue(8.0);
-        assertEquals(8.0, mField.getValue(), 0d);
-        assertEquals("8", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(8.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("8");
 
         mField.setValue(10.0);
-        assertEquals(10.0, mField.getValue(), 0d);
-        assertEquals("10", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(10.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("10");
 
         mField.setValue(-2.0);
-        assertEquals(-2.0, mField.getValue(), 0d);
-        assertEquals("-2", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-2.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-2");
 
         mField.setValue(-8.0);
-        assertEquals(-8.0, mField.getValue(), 0d);
-        assertEquals("-8", mField.getFormattedValue());
+        assertThat(mField.getValue()).isEqualTo(-8.0);
+        assertThat(mField.getFormattedValue()).isEqualTo("-8");
 
         // Rounded Values
         mField.setValue(0.2);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(1.9);
-        assertEquals(2.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(2.0);
 
         mField.setValue(0.999);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(1.0);
-        assertEquals(2.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(2.0);
 
         mField.setValue(3.0);
-        assertEquals(4.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(4.0);
 
         mField.setValue(-0.2);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(-1.9);
-        assertEquals(-2.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-2.0);
 
         mField.setValue(-1.0);
-        assertEquals(0.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0);
 
         mField.setValue(-1.001);
-        assertEquals(-2.0, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-2.0);
     }
 
     @Test
@@ -412,19 +411,19 @@ public class FieldNumberTest {
         mField.setConstraints(MIN, MAX, PRECISION);
 
         mField.setFromString("123e4");
-        assertEquals(1230000d, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(1230000d);
 
         mField.setFromString("1.23e4");
-        assertEquals(12300d, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(12300d);
 
         mField.setFromString("-1.23e4");
-        assertEquals(-12300d, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(-12300d);
 
         mField.setFromString("123e-4");
-        assertEquals(0.0123, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.0123);
 
         mField.setFromString("1.23e-4");
-        assertEquals(0.000123, mField.getValue(), 0d);
+        assertThat(mField.getValue()).isEqualTo(0.000123);
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTestHelper.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTestHelper.java
@@ -2,6 +2,9 @@ package com.google.blockly.model;
 
 import org.junit.Assert;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
 /**
  * Helper methods for testing fields.
  */
@@ -26,9 +29,9 @@ public class FieldTestHelper {
             @Override
             public void onValueChanged(Field eventField, String oldValue, String newValue) {
                 observerOneCount[0]++;
-                Assert.assertSame(field, eventField);
-                Assert.assertEquals(expectedOldValue, oldValue);
-                Assert.assertEquals(expectedNewValue, newValue);
+                assertThat(field).isSameAs(eventField);
+                assertThat(oldValue).isEqualTo(expectedOldValue);
+                assertThat(newValue).isEqualTo(expectedNewValue);
 
             }
         });
@@ -40,8 +43,8 @@ public class FieldTestHelper {
         });
 
         field.setFromString(newValue);
-        Assert.assertEquals("Exactly one observation per Observer", 1, observerOneCount[0]);
-        Assert.assertEquals("Exactly one observation per Observer", 1, observerTwoCount[0]);
+        assertWithMessage("Exactly one observation per Observer").that(observerOneCount[0]).isEqualTo(1);
+        assertWithMessage("Exactly one observation per Observer").that(observerTwoCount[0]).isEqualTo(1);
     }
 
     /**

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldVariableTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldVariableTest.java
@@ -17,10 +17,7 @@ package com.google.blockly.model;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests for {@link FieldVariable}.
@@ -38,31 +35,31 @@ public class FieldVariableTest {
 
     @Test
     public void testConstructor() {
-        assertEquals(Field.TYPE_VARIABLE, mField.getType());
-        assertEquals(FIELD_NAME, mField.getName());
-        assertEquals(VARIABLE_NAME, mField.getVariable());
+        assertThat(mField.getType()).isEqualTo(Field.TYPE_VARIABLE);
+        assertThat(mField.getName()).isEqualTo(FIELD_NAME);
+        assertThat(mField.getVariable()).isEqualTo(VARIABLE_NAME);
     }
 
     @Test
     public void testSetVariable() {
         mField.setVariable("newVar");
-        assertEquals("newVar", mField.getVariable());
+        assertThat( mField.getVariable()).isEqualTo("newVar");
     }
 
     @Test
     public void testSetFromString() {
-        assertTrue(mField.setFromString("newestVar"));
-        assertEquals("newestVar", mField.getVariable());
-        assertFalse(mField.setFromString(""));
-        assertEquals("newestVar", mField.getVariable());
+        assertThat(mField.setFromString("newestVar")).isTrue();
+        assertThat(mField.getVariable()).isEqualTo("newestVar");
+        assertThat(mField.setFromString("")).isFalse();
+        assertThat(mField.getVariable()).isEqualTo("newestVar");
     }
 
     @Test
     public void testClone() {
         FieldVariable clone = mField.clone();
-        assertNotSame(mField, clone);
-        assertEquals(mField.getName(), clone.getName());
-        assertEquals(mField.getVariable(), clone.getVariable());
+        assertThat(mField).isNotSameAs(clone);
+        assertThat(clone.getName()).isEqualTo(mField.getName());
+        assertThat(clone.getVariable()).isEqualTo(mField.getVariable());
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/WorkspaceTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/WorkspaceTest.java
@@ -29,7 +29,8 @@ import org.junit.rules.ExpectedException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import static org.junit.Assert.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Tests for {@link Workspace}.
@@ -63,18 +64,18 @@ public class WorkspaceTest extends BlocklyTestCase {
     @Test
     public void testSimpleXmlParsing() {
         mWorkspace.loadWorkspaceContents(assembleWorkspace(BlockTestStrings.SIMPLE_BLOCK));
-        assertEquals("Workspace should have one block", 1, mWorkspace.getRootBlocks().size());
+        assertWithMessage("Workspace should have one block").that(mWorkspace.getRootBlocks()).hasSize(1);
     }
 
     @Test
     public void testEmptyXmlParsing() {
         // Normal end tag.
         mWorkspace.loadWorkspaceContents(assembleWorkspace(""));
-        assertEquals("Workspace should be empty", 0, mWorkspace.getRootBlocks().size());
+        assertWithMessage("Workspace should be empty").that(mWorkspace.getRootBlocks()).hasSize(0);
 
         // Abbreviated end tag.
         mWorkspace.loadWorkspaceContents(new ByteArrayInputStream(EMPTY_WORKSPACE.getBytes()));
-        assertEquals("Workspace should be empty", 0, mWorkspace.getRootBlocks().size());
+        assertWithMessage("Workspace should be empty").that(mWorkspace.getRootBlocks()).hasSize(0);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class WorkspaceTest extends BlocklyTestCase {
     public void testSerialization() throws BlocklySerializerException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         mWorkspace.serializeToXml(os);
-        assertEquals(EMPTY_WORKSPACE, os.toString());
+        assertThat(os.toString()).isEqualTo(EMPTY_WORKSPACE);
     }
 
     private static ByteArrayInputStream assembleWorkspace(String interior) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/utils/MoreAsserts.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/utils/MoreAsserts.java
@@ -1,14 +1,13 @@
 package com.google.blockly.utils;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /**
  * Aseerts used by Blockly's test code.
  */
 public class MoreAsserts {
     public static void assertStringNotEmpty(String mesg, String str) {
-        assertNotNull(mesg + " Found null string.", str);
-        assertNotEquals(mesg + " Found empty string.", str.length(), 0);
+        assertWithMessage(mesg + " Found null string").that(str).isNotNull();
+        assertWithMessage(mesg + " Found empty string").that(str).isNotEmpty();
     }
 }

--- a/blocklytest/src/main/AndroidManifest.xml
+++ b/blocklytest/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/BlocklyVerticalTheme">
+        android:theme="@style/BlocklyVerticalTheme"
+        android:name="android.support.multidex.MultiDexApplication">
 
         <activity
             android:name="com.google.blockly.android.BlocklyTestActivity"


### PR DESCRIPTION
Although this touches all the test files, it's pretty uncontroversial. I did about 90% of asserts via regex, and manually fixed the ones that were split over lines.

I haven't made use of any of the more interesting assertions (e.g. assertions on lists/etc), it's all one to one mappings at this stage.

The main thing to point out, is I had to enable multidex, as the truth library caused the instrumented tests to go over the method limit. There might be a way to enable this only on the test project, but I think it's a blanket application as this review stands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/473)
<!-- Reviewable:end -->
