### PR TITLE
Create trashAllBlocks public method

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -948,6 +948,16 @@ public class BlocklyController {
     }
 
     /**
+     * Removes all blocks from the {@link WorkspaceView} and puts them in the trash.
+     */
+    public void trashAllBlocks() {
+        List<Block> rootBlocks = new ArrayList<>(mWorkspace.getRootBlocks());
+        for (Block block: rootBlocks) {
+            trashRootBlockImpl(block, true);
+        }
+    }
+
+    /**
      * Adds the provided block as a root block.  If a {@link WorkspaceView} is attached, it will
      * also update the view, creating a new {@link BlockGroup} if not provided.
      * <p/>

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -1295,7 +1295,7 @@ public class BlocklyControllerTest extends BlocklyTestCase {
     @Test
     public void testLoadWorkspaceContents_andReset() {
         mController.initWorkspaceView(mWorkspaceView);
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(0);
+        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
         assertThat(mWorkspaceView.getChildCount()).isEqualTo(0);
 
         mController.loadWorkspaceContents(
@@ -1303,12 +1303,33 @@ public class BlocklyControllerTest extends BlocklyTestCase {
                 BlockTestStrings.EMPTY_BLOCK_WITH_POSITION.replace(
                         BlockTestStrings.EMPTY_BLOCK_ID,
                         BlockTestStrings.EMPTY_BLOCK_ID + '2'));
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+        assertThat(mWorkspace.getRootBlocks()).hasSize(2);
         assertThat(mWorkspaceView.getChildCount()).isEqualTo(2);
 
         mController.resetWorkspace();
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(0);
+        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
         assertThat(mWorkspaceView.getChildCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testLoadWorkspaceContents_andTrashAllBlocks() {
+        mController.initWorkspaceView(mWorkspaceView);
+        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
+        assertThat(mWorkspace.getTrashContents()).hasSize(0);
+
+        mController.loadWorkspaceContents(
+            BlockTestStrings.EMPTY_BLOCK_WITH_POSITION +
+                BlockTestStrings.EMPTY_BLOCK_WITH_POSITION.replace(
+                    BlockTestStrings.EMPTY_BLOCK_ID,
+                    BlockTestStrings.EMPTY_BLOCK_ID + '2'));
+        assertThat(mWorkspace.getRootBlocks()).hasSize(2);
+        assertThat(mWorkspace.getTrashContents()).hasSize(0);
+
+        mController.trashAllBlocks();
+        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
+        assertThat(mWorkspace.getTrashContents()).hasSize(2);
+
+
     }
 
     /**

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -1328,8 +1328,6 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         mController.trashAllBlocks();
         assertThat(mWorkspace.getRootBlocks()).hasSize(0);
         assertThat(mWorkspace.getTrashContents()).hasSize(2);
-
-
     }
 
     /**


### PR DESCRIPTION
A new public method on `BlocklyController` which allows consumers to move all blocks to the trash (similar to `resetWorkspace` except `resetWorkspace` also clears the trash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/476)
<!-- Reviewable:end -->
