### PR TITLE
Rename BlocklyXmlHelper.writeOneBlockToXml() to .writeBlockToXml()

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyEvent.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyEvent.java
@@ -433,7 +433,7 @@ public abstract class BlocklyEvent {
         public CreateEvent(@NonNull Workspace workspace, @NonNull Block block) {
             super(TYPE_CREATE, workspace.getId(), null, block.getId());
             try {
-                mXml = BlocklyXmlHelper.writeOneBlockToXml(block);
+                mXml = BlocklyXmlHelper.writeBlockToXml(block);
             } catch (BlocklySerializerException e) {
                 throw new IllegalArgumentException("Invalid block for event serialization");
             }
@@ -508,7 +508,7 @@ public abstract class BlocklyEvent {
         DeleteEvent(@NonNull Workspace workspace, @NonNull Block block) {
             super(TYPE_DELETE, workspace.getId(), null, block.getId());
             try {
-                mOldXml = BlocklyXmlHelper.writeOneBlockToXml(block);
+                mOldXml = BlocklyXmlHelper.writeBlockToXml(block);
             } catch (BlocklySerializerException e) {
                 throw new IllegalArgumentException("Invalid block for event serialization");
             }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlocklySerializerException.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlocklySerializerException.java
@@ -15,10 +15,12 @@
 
 package com.google.blockly.model;
 
+import java.io.IOException;
+
 /**
- * An exception that is thrown when there is an error serializing a blockly Workspace to XML.
+ * An exception that is thrown when there is an error serializing a Blockly Workspace to XML.
  */
-public class BlocklySerializerException extends Throwable {
+public class BlocklySerializerException extends IOException {
     public BlocklySerializerException(String message) {
         super(message);
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
@@ -196,32 +196,32 @@ public final class BlocklyXmlHelper {
     }
 
     /**
-     * Convenience function to serialize only one Block.
+     * Convenience function to serialize one stack of Blocks (a BlockGroup, effectively).
      *
-     * @param toSerialize A Block to serialize.
+     * @param rootBlock The root block of the stack to serialize.
      * @param os An OutputStream to which to write them.
      *
      * @throws BlocklySerializerException
      */
-    public static void writeOneBlockToXml(Block toSerialize, OutputStream os)
+    public static void writeBlockToXml(Block rootBlock, OutputStream os)
             throws BlocklySerializerException {
         List<Block> temp = new ArrayList<>();
-        temp.add(toSerialize);
+        temp.add(rootBlock);
         writeToXml(temp, os);
     }
 
     /**
-     * Convenience function to serialize only one Block.
+     * Convenience function to serialize one stack of Blocks (a BlockGroup, effectively).
      *
-     * @param toSerialize A Block to serialize.
+     * @param rootBlock The root block of the stack to serialize.
      * @return XML string for block and all descendant blocks.
      * @throws BlocklySerializerException
      */
-    public static String writeOneBlockToXml(Block toSerialize)
+    public static String writeBlockToXml(Block rootBlock)
             throws BlocklySerializerException {
         StringWriter sw = new StringWriter();
         List<Block> temp = new ArrayList<>();
-        temp.add(toSerialize);
+        temp.add(rootBlock);
         writeToXml(temp, sw);
         String xmlString = sw.toString();
         try {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
@@ -81,7 +81,7 @@ public class CodeGeneratorServiceTest {
     private String toXml(Block block) {
         StringOutputStream out = new StringOutputStream();
         try {
-            BlocklyXmlHelper.writeOneBlockToXml(block, out);
+            BlocklyXmlHelper.writeBlockToXml(block, out);
         } catch (BlocklySerializerException e) {
             throw new IllegalArgumentException("Failed to serialize block.", e);
         }

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -653,7 +653,7 @@ public class BlockTest extends BlocklyTestCase {
     private String toXml(Block block) {
         StringOutputStream out = new StringOutputStream();
         try {
-            BlocklyXmlHelper.writeOneBlockToXml(block, out);
+            BlocklyXmlHelper.writeBlockToXml(block, out);
         } catch (BlocklySerializerException e) {
             throw new IllegalArgumentException("Failed to serialize block.", e);
         }


### PR DESCRIPTION
Rename BlocklyXmlHelper.writeOneBlockToXml() to .writeBlockToXml() (both versions), since it may write multiple blocks grouped together under the same root. Clarified the method comments, too.

BlocklySerializerException now extends IOException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/484)
<!-- Reviewable:end -->
