### PR TITLE
Use drag shadows to dragged blocks. Also add ClipDataDescription.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -392,8 +392,9 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      * <p/>
      * By default, it constructs a {@link SingleMimeTypeClipDataHelper} with a MIME type derived
      * from the application's package name. This assumes all Blockly workspaces in an app work with
-     * the same shared set of blocks, and blocks can be dragged/copied/pasted them, even if they are
-     * in different Activities. It also ensures blocks from other applications will be rejected.
+     * the same shared set of blocks, and blocks can be dragged/copied/pasted between them, even if
+     * they are in different Activities. It also ensures blocks from other applications will be
+     * rejected.
      * <p/>
      * If your app uses different block sets for different workspaces, or you intend to interoperate
      * with other applications, you will need to override this method with your own implementation.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -402,9 +402,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      * @return A new {@link BlockClipDataHelper}.
      */
     protected BlockClipDataHelper onCreateClipDataHelper() {
-        String packageName = getApplication().getPackageName();
-        String mimeType = "application/x-blockly-" + packageName + "+xml";
-        return new SingleMimeTypeClipDataHelper(mimeType, R.string.blockly_clipdata_label_default);
+        return SingleMimeTypeClipDataHelper.getDefault(this);
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.blockly.android.clipboard;
+
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.view.DragEvent;
+
+import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.ui.BlockViewFactory;
+import com.google.blockly.android.ui.BlockGroup;
+import com.google.blockly.android.ui.PendingDrag;
+import com.google.blockly.android.ui.WorkspaceHelper;
+import com.google.blockly.model.Block;
+import com.google.blockly.model.BlockFactory;
+
+import java.io.IOException;
+
+
+/**
+ * {@code ClipDataTransformer} is an interface to help transform {@link Block} data and view objects
+ * into ClipData, and back. This is used for drag-and-drop operations and copy/paste actions.
+ * <p/>
+ * Every application needs one implementation. Most applications will be content with
+ * {@link SingleMimeTypeClipDataHelper}.
+ */
+public interface BlockClipDataHelper {
+    /**
+     * Sets the {@link BlocklyController} for this instance. Called during the controller's
+     * initialization.  The controller provides access to critical classes, such as the
+     * {@link WorkspaceHelper}, {@link BlockFactory}, and {@link BlockViewFactory}
+     */
+    void setController(BlocklyController controller);
+
+    /**
+     * Constructs a new populated {@link ClipData} using the information from a {@link PendingDrag}.
+     * It also sets the PendingDrag as the backing local state.
+     *
+     * @param pendingDrag The source of clip
+     * @return A new {@link ClipData} representing the drag and dragged {@link BlockGroup}.
+     */
+    ClipData buildDragClipData(PendingDrag pendingDrag) throws IOException;
+
+    /**
+     * This determines whether an incoming {@link ClipData} is a representation of Blockly
+     * {@link Block}s that can be handled by this {@link BlockClipDataHelper}.
+     *
+     * @param clipDescrip A description of the incoming clipboard data.
+     * @return True if the MIME type is found.
+     */
+    boolean isBlockData(ClipDescription clipDescrip);
+
+    /**
+     * Extracts a PendingDrag from a {@link DragEvent}. Assumes the {@link #isBlockData} has been
+     * called and returned {@link true}.
+     *
+     * @param event A block drag event.
+     * @return The PendingDrag for {@code event}
+     */
+    PendingDrag getPendingDrag(DragEvent event);
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
@@ -49,7 +49,7 @@ public interface BlockClipDataHelper {
      * Constructs a new populated {@link ClipData} using the information from a {@link PendingDrag}.
      *
      * @param pendingDrag The source of clip
-     * @return A new {@link ClipData} representing the drag and dragged {@link BlockGroup}.
+     * @return A new {@link ClipData} representing the dragged or copied {@link BlockGroup}.
      */
     ClipData buildDragClipData(PendingDrag pendingDrag) throws IOException;
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
@@ -47,7 +47,6 @@ public interface BlockClipDataHelper {
 
     /**
      * Constructs a new populated {@link ClipData} using the information from a {@link PendingDrag}.
-     * It also sets the PendingDrag as the backing local state.
      *
      * @param pendingDrag The source of clip
      * @return A new {@link ClipData} representing the drag and dragged {@link BlockGroup}.
@@ -64,7 +63,7 @@ public interface BlockClipDataHelper {
     boolean isBlockData(ClipDescription clipDescrip);
 
     /**
-     * Extracts a PendingDrag from a {@link DragEvent}. Assumes the {@link #isBlockData} has been
+     * Extracts a PendingDrag from a {@link DragEvent}. Assumes that {@link #isBlockData} has been
      * called and returned {@link true}.
      *
      * @param event A block drag event.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/BlockClipDataHelper.java
@@ -39,13 +39,6 @@ import java.io.IOException;
  */
 public interface BlockClipDataHelper {
     /**
-     * Sets the {@link BlocklyController} for this instance. Called during the controller's
-     * initialization.  The controller provides access to critical classes, such as the
-     * {@link WorkspaceHelper}, {@link BlockFactory}, and {@link BlockViewFactory}
-     */
-    void setController(BlocklyController controller);
-
-    /**
      * Constructs a new populated {@link ClipData} using the information from a {@link PendingDrag}.
      *
      * @param pendingDrag The source of clip

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
@@ -88,7 +88,8 @@ public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
 
         Intent intent = new Intent();
         intent.putExtra(EXTRA_BLOCKLY_XML, xml);
-        // TODO(#): Encode shadow size/offset/zoom info for remote drop targets.
+
+        // TODO(#489): Encode shadow size/offset/zoom info for remote drop targets.
         ClipData.Item item = new ClipData.Item(intent);
 
         return new ClipData(mClipLabel, new String[] {mMimeType}, item);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.blockly.android.clipboard;
+
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.Context;
+import android.content.Intent;
+import android.view.DragEvent;
+
+import com.google.blockly.android.R;
+import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.ui.PendingDrag;
+import com.google.blockly.android.ui.WorkspaceHelper;
+import com.google.blockly.model.Block;
+import com.google.blockly.utils.BlocklyXmlHelper;
+
+import java.io.IOException;
+
+/**
+ * Implements ClipDataTransformer with a single support MIME type.  Uses intent extras as the
+ * in-transit storage format.
+ */
+public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
+    public static final String EXTRA_BLOCKLY_XML = "BLOCKLY_XML";
+
+    /**
+     * This constructs a {@link SingleMimeTypeClipDataHelper} with a MIME type derived
+     * from the application's package name. This assumes all Blockly workspaces in an app use with
+     * a shared set of blocks, and blocks can be dragged/copied/pasted them, even if they are
+     * in different Activities. It also ensures blocks from other applications will be rejected.
+     *
+     * @param context
+     * @return
+     */
+    public static BlockClipDataHelper getDefault(Context context) {
+        String mimeType = "application/x-blockly-" + context.getPackageName() + "+xml";
+        return new SingleMimeTypeClipDataHelper(mimeType, R.string.blockly_clipdata_label_default);
+
+    }
+
+    protected final String mMimeType;
+    protected final int mClipLabelRes;  // TODO(#): Singular vs plural ("block" vs "blocks")
+
+    protected BlocklyController mController;
+    protected WorkspaceHelper mViewHelper;
+    protected Context mContext;
+    protected String mClipLabel;
+
+    /**
+     * Constructs a new {@link SingleMimeTypeClipDataHelper} with the provided MIME string and
+     * user visible (accessibility, etc.) clip label string.
+     *
+     * @param mimeType The MIME type the new instance use for encoding and decoding.
+     * @param clipLabelRes The resource id of the label to apply to {@link ClipData}s.
+     */
+    public SingleMimeTypeClipDataHelper(String mimeType, int clipLabelRes) {
+        mMimeType = mimeType;
+        mClipLabelRes = clipLabelRes;
+    }
+
+    @Override
+    public void setController(BlocklyController controller) {
+        mController = controller;
+        mViewHelper = controller.getWorkspaceHelper();
+
+        mContext = mController.getContext();
+        mClipLabel = mContext.getResources().getString(mClipLabelRes);
+    }
+
+    @Override
+    public ClipData buildDragClipData(PendingDrag drag) throws IOException {
+        Block root = drag.getRootDraggedBlock();
+        String xml = BlocklyXmlHelper.writeBlockToXml(root);
+
+        Intent intent = new Intent();
+        intent.putExtra(EXTRA_BLOCKLY_XML, xml);
+        // TODO(#): Encode shadow size/offset/zoom info for remote drop targets.
+        ClipData.Item item = new ClipData.Item(intent);
+
+        return new ClipData(mClipLabel, new String[] {mMimeType}, item);
+    }
+
+    /**
+     * @param descript A description of the incoming clipboard data.
+     * @return True if the MIME type is found.
+     */
+    @Override
+    public boolean isBlockData(ClipDescription descript) {
+        return descript != null && descript.filterMimeTypes(mMimeType).length > 0;
+    }
+
+    /**
+     * @param event The DragEvent containing the PendingDrag.
+     * @return The PendingDrag containing the dragged blocks.
+     */
+    @Override
+    public PendingDrag getPendingDrag(DragEvent event) {
+        // In the future, this will support drags across application boundaries, constructing a new
+        // PendingDrag as necessary. For now, it just extracts the PendingData from the local state.
+        return (PendingDrag) event.getLocalState();
+    }
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
@@ -24,14 +24,13 @@ import android.view.DragEvent;
 import com.google.blockly.android.R;
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.PendingDrag;
-import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Block;
 import com.google.blockly.utils.BlocklyXmlHelper;
 
 import java.io.IOException;
 
 /**
- * Implements ClipDataTransformer with a single support MIME type.  Uses intent extras as the
+ * Implements ClipDataTransformer with a single supported MIME type.  Uses intent extras as the
  * in-transit storage format.
  */
 public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
@@ -48,37 +47,31 @@ public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
      */
     public static BlockClipDataHelper getDefault(Context context) {
         String mimeType = "application/x-blockly-" + context.getPackageName() + "+xml";
-        return new SingleMimeTypeClipDataHelper(mimeType, R.string.blockly_clipdata_label_default);
 
+        // TODO(#): Singular vs plural ("block" vs "blocks")
+        String label = context.getResources().getString(R.string.blockly_clipdata_label_default);
+
+        return new SingleMimeTypeClipDataHelper(mimeType, label);
     }
 
     protected final String mMimeType;
-    protected final int mClipLabelRes;  // TODO(#): Singular vs plural ("block" vs "blocks")
-
-    protected BlocklyController mController;
-    protected WorkspaceHelper mViewHelper;
-    protected Context mContext;
-    protected String mClipLabel;
+    protected final String mClipLabel;
 
     /**
      * Constructs a new {@link SingleMimeTypeClipDataHelper} with the provided MIME string and
      * user visible (accessibility, etc.) clip label string.
      *
      * @param mimeType The MIME type the new instance use for encoding and decoding.
-     * @param clipLabelRes The resource id of the label to apply to {@link ClipData}s.
+     * @param clipLabel The human readable label to apply to {@link ClipData}s.
      */
-    public SingleMimeTypeClipDataHelper(String mimeType, int clipLabelRes) {
+    public SingleMimeTypeClipDataHelper(String mimeType, String clipLabel) {
         mMimeType = mimeType;
-        mClipLabelRes = clipLabelRes;
+        mClipLabel = clipLabel;
     }
 
     @Override
     public void setController(BlocklyController controller) {
-        mController = controller;
-        mViewHelper = controller.getWorkspaceHelper();
-
-        mContext = mController.getContext();
-        mClipLabel = mContext.getResources().getString(mClipLabelRes);
+        // Unused, but may be used in the future to access the WorkspaceHelper and drag shadow size.
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
@@ -70,11 +70,6 @@ public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
     }
 
     @Override
-    public void setController(BlocklyController controller) {
-        // Unused, but may be used in the future to access the WorkspaceHelper and drag shadow size.
-    }
-
-    @Override
     public ClipData buildDragClipData(PendingDrag drag) throws IOException {
         Block root = drag.getRootDraggedBlock();
         String xml = BlocklyXmlHelper.writeBlockToXml(root);
@@ -94,7 +89,8 @@ public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
      */
     @Override
     public boolean isBlockData(ClipDescription descript) {
-        return descript != null && descript.filterMimeTypes(mMimeType).length > 0;
+        String[] mimeTypes =(descript == null) ? null : descript.filterMimeTypes(mMimeType);
+        return mimeTypes != null && mimeTypes.length > 0;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -37,6 +37,7 @@ import com.google.blockly.android.ui.BlockView;
 import com.google.blockly.android.ui.BlockViewFactory;
 import com.google.blockly.android.ui.InputView;
 import com.google.blockly.android.ui.PendingDrag;
+import com.google.blockly.android.ui.ViewPoint;
 import com.google.blockly.android.ui.VirtualWorkspaceView;
 import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.android.ui.WorkspaceView;
@@ -145,7 +146,7 @@ public class BlocklyController {
             return new Runnable() {
                 @Override
                 public void run() {
-                    // extractBlockAsRoot() fires move event immediately.
+                    // extractBlockAsRoot() fires MoveEvent immediately.
                     extractBlockAsRoot(activeTouchedView.getBlock());
 
                     // Since this block was already on the workspace, the block's position should
@@ -153,7 +154,16 @@ public class BlocklyController {
                     BlockGroup bg = mHelper.getRootBlockGroup(activeTouchedView);
                     bg.bringToFront();
 
-                    pendingDrag.setDragGroup(bg);
+                    // Measure and layout the block group to get the correct touch offset.
+                    bg.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+                    bg.layout(0, 0, bg.getMeasuredWidth(), bg.getMeasuredHeight());
+
+                    ViewPoint touchOffset = new ViewPoint(
+                            (int) (activeTouchedView.getX()
+                                    + pendingDrag.getTouchDownViewOffsetX()),
+                            (int) (activeTouchedView.getY()
+                                    + pendingDrag.getTouchDownViewOffsetY()));
+                    pendingDrag.startDrag(bg, touchOffset);
                 }
             };
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -212,7 +212,6 @@ public class BlocklyController {
 
         // mHelper, mModelFactory, and mViewFactory must be initialized before mClipHelper.
         mClipHelper = clipHelper;
-        mClipHelper.setController(this);
 
         mWorkspace = new Workspace(mContext, this, mModelFactory);
         mConnectionManager = mWorkspace.getConnectionManager();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
@@ -41,7 +41,7 @@ import java.util.List;
  * {@link InputView}s are direct children, and handles most UI events and view hierarchy
  * coordination. The measurement, placement and drawing are left to the subclass to implement.
  */
-@SuppressLint("ViewConstructor")
+@SuppressLint("ViewConstructor")  // BlockViews should not be instantiated by layout XML.
 public abstract class AbstractBlockView<InputView extends com.google.blockly.android.ui.InputView>
         extends NonPropagatingViewGroup implements BlockView {
     protected final WorkspaceHelper mHelper;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListView.java
@@ -166,7 +166,8 @@ public class BlockListView extends RecyclerView {
      * pan, and scale.
      *
      * @param pendingDrag The {@link PendingDrag} for the gesture.
-     * @return The {@link BlockGroup} return by {@link OnDragListBlock#getDraggableBlockGroup}.
+     * @return The pair of {@link BlockGroup} and the view relative touch point returned by
+     *         {@link OnDragListBlock#getDraggableBlockGroup}.
      */
     @NonNull
     protected Pair<BlockGroup, ViewPoint> getWorkspaceBlockGroupForTouch(PendingDrag pendingDrag) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
@@ -44,14 +44,14 @@ public interface BlockView {
     /** @see View#getParent() */
     ViewParent getParent();
 
+    /** @see View#getX() */
+    float getX();
+
+    /** @see View#getY() */
+    float getY();
+
     /** @see View#getWidth() */
     int getWidth();
-
-    /**
-     * @see View#getLocationOnScreen(int[])
-     * @param location an array of two integers in which to hold the coordinates
-     */
-    void getLocationOnScreen(@Size(2) int[] location);
 
     /**
      * @return The closest view tree ancestor that is a BlockGroup.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -17,6 +17,7 @@ package com.google.blockly.android.ui;
 
 import android.content.Context;
 import android.support.annotation.Nullable;
+import android.support.v13.view.ViewCompat;
 import android.view.View;
 import android.widget.SpinnerAdapter;
 
@@ -356,5 +357,17 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
     protected final void unregisterView(BlockView blockView) {
         Block block = blockView.getBlock();
         mBlockIdToView.remove(block.getId());
+    }
+
+    /**
+     * Constructs the drag and drop flags used by {@link ViewCompat#startDragAndDrop}.
+     */
+    public int getDragAndDropFlags() {
+        int flags = 0;
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            flags |= 0x00000100;  // View.DRAG_FLAG_GLOBAL
+            flags |= 0x00000200;  // View.DRAG_FLAG_OPAQUE
+        }
+        return flags;
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -16,7 +16,6 @@
 package com.google.blockly.android.ui;
 
 import android.content.ClipData;
-import android.content.ClipDescription;
 import android.graphics.Canvas;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -611,7 +610,7 @@ public class Dragger {
                                     pendingDrag,
                                     flags);
                         } catch (IOException e) {
-                            // Serialization failed in ClipDataHelper.
+                            Log.w(TAG, "Serialization failed in ClipDataHelper.");
                             mPendingDrag = null;
                         }
                     } else {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -731,6 +731,7 @@ public class Dragger {
             mSizeY = dragGroup.getHeight();
         }
 
+        @Override
         public void onProvideShadowMetrics(Point shadowSize, Point shadowTouchPoint) {
             shadowSize.set(
                     (int) Math.ceil(mSizeX * mZoomScale),

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -41,7 +41,6 @@ import com.google.blockly.model.WorkspacePoint;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 /**
  * Controller for dragging blocks and groups of blocks within a workspace.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -16,6 +16,8 @@
 package com.google.blockly.android.ui;
 
 import android.content.ClipData;
+import android.graphics.Canvas;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Handler;
 import android.support.annotation.IntDef;
@@ -39,6 +41,7 @@ import com.google.blockly.model.WorkspacePoint;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Controller for dragging blocks and groups of blocks within a workspace.
@@ -75,7 +78,7 @@ public class Dragger {
          * {@link Dragger} is designed to catch these calls and forcibly crash.  Just don't do it.
          * <p/>
          * When the {@link Runnable} is called, it should proceed with the {@code Block} and
-         * {@code BlockView} manipulations, and call {@link PendingDrag#setDragGroup(BlockGroup)} to
+         * {@code BlockView} manipulations, and call {@link PendingDrag#startDrag} to
          * assign the draggable {@link BlockGroup}, which must contain a root block on the
          * {@link Workspace} and be added to the {@link WorkspaceView}.
          * <p/>
@@ -567,8 +570,9 @@ public class Dragger {
                         removeDraggedConnectionsFromConnectionManager(rootBlock);
                         ClipData clipData = ClipData.newPlainText(
                                 WorkspaceView.BLOCK_GROUP_CLIP_DATA_LABEL, "");
-                        dragGroup.startDrag(clipData,
-                                new View.DragShadowBuilder(), null, 0);
+
+                        dragGroup.startDrag(
+                                clipData, new DragShadowBuilder(pendingDrag, mHelper), null, 0);
                     } else {
                         mPendingDrag = null;
                     }
@@ -664,5 +668,42 @@ public class Dragger {
 
     private Pair<Connection, Connection> findBestConnection(Block block) {
         return mConnectionManager.findBestConnection(block, mHelper.getMaxSnapDistance());
+    }
+
+    private static class DragShadowBuilder extends View.DragShadowBuilder {
+        private PendingDrag mPendingDrag;
+        private int mSizeX, mSizeY;
+        private float mZoomScale;
+
+        DragShadowBuilder(PendingDrag pendingDrag, WorkspaceHelper helper) {
+            super(pendingDrag.getDragGroup());
+            mPendingDrag = pendingDrag;
+            mZoomScale = helper.getWorkspaceZoomScale();
+
+            BlockGroup dragGroup = pendingDrag.getDragGroup();
+            mSizeX = dragGroup.getWidth();
+            if (mSizeX == 0) {
+                dragGroup.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+                dragGroup.layout(0, 0, dragGroup.getMeasuredWidth(), dragGroup.getMeasuredHeight());
+                mSizeX = dragGroup.getWidth();
+            }
+            mSizeY = dragGroup.getHeight();
+        }
+
+        public void onProvideShadowMetrics(Point shadowSize, Point shadowTouchPoint) {
+            shadowSize.set(
+                    (int) Math.ceil(mSizeX * mZoomScale),
+                    (int) Math.ceil(mSizeY * mZoomScale));
+            ViewPoint dragTouchOffset = mPendingDrag.getDragTouchOffset();
+            shadowTouchPoint.set(
+                    (int) Math.ceil(dragTouchOffset.x * mZoomScale),
+                    (int) Math.ceil(dragTouchOffset.y * mZoomScale));
+        }
+
+        @Override
+        public void onDrawShadow(Canvas canvas) {
+            canvas.scale(mZoomScale, mZoomScale);
+            super.onDrawShadow(canvas);
+        }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
@@ -14,8 +14,8 @@ import com.google.blockly.model.WorkspacePoint;
 /**
  * {@code PendingDrag} collects all the information related to an in-progress drag of a
  * {@link BlockView}.  It is initialized by {@link Dragger}, passed to a {@link Dragger.DragHandler}
- * which calls {@link #setDragGroup(BlockGroup)} to inform the dragger how to complete the rest of
- * the drag behavior.
+ * which calls {@link #startDrag} to inform the Dragger how to complete the rest of the drag
+ * behavior.
  */
 // TODO(#233): Rename to PendingGesture or similar
 public final class PendingDrag {
@@ -51,6 +51,7 @@ public final class PendingDrag {
     // (possibly scaled by zoom, if within a WorkspaceView).
     private final int mTouchDownBlockX;
     private final int mTouchDownBlockY;
+    private ViewPoint mDragTouchOffset = null;
 
     private BlockGroup mDragGroup;
     private BlockView mRootBlockView;
@@ -128,7 +129,7 @@ public final class PendingDrag {
 
     /**
      * @return The X offset of the initial {@link MotionEvent#ACTION_DOWN} event, from the left side
-     *         of the view in local view pixels.
+     *         of the first touched view in local view pixels.
      */
     public float getTouchDownViewOffsetX() {
         return mTouchDownBlockX;
@@ -136,13 +137,13 @@ public final class PendingDrag {
 
     /**
      * @return The Y offset of the initial {@link MotionEvent#ACTION_DOWN} event, from the top of
-     *         the view in local view pixels.
+     *         the first touched view in local view pixels.
      */
     public float getTouchDownViewOffsetY() {
         return mTouchDownBlockY;
     }
 
-    /**
+    /*
      * @return The workspace coordinates of the initial {@link MotionEvent#ACTION_DOWN} event.
      */
     public WorkspacePoint getTouchDownWorkspaceCoordinates() {
@@ -152,13 +153,13 @@ public final class PendingDrag {
     /**
      * This sets the draggable {@link BlockGroup}, containing all the dragged blocks.
      * {@code dragGroup} must be a root block added to the {@link WorkspaceView}, with it's first
-     * {@link Block} added as a root block in the {@link Workspace}.  The touch offset will be
-     * inferred from the delta between block's workspace location and the initial touch down
-     * workspace location.
+     * {@link Block} added as a root block in the {@link Workspace}.
      *
      * @param dragGroup The draggable {@link BlockGroup}.
+     * @param touchOffset The touch offset from the top left corner of {@code dragGroup}, in view
+     *                    pixels.
      */
-    public void setDragGroup(@NonNull BlockGroup dragGroup) {
+    public void startDrag(@NonNull BlockGroup dragGroup, ViewPoint touchOffset) {
         if (dragGroup == null) {
             throw new IllegalArgumentException("DragGroup cannot be null");
         }
@@ -178,6 +179,7 @@ public final class PendingDrag {
         }
 
         mOriginalBlockPosition.setFrom(dragGroup.getFirstBlock().getPosition());
+        mDragTouchOffset = touchOffset;
     }
 
     /**
@@ -192,6 +194,13 @@ public final class PendingDrag {
      */
     public BlockGroup getDragGroup() {
         return mDragGroup;
+    }
+
+    /**
+     * @return The touch offset from the top left corner of the dragged BlockGroup, in view pixels.
+     */
+    public ViewPoint getDragTouchOffset() {
+        return mDragTouchOffset;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/PendingDrag.java
@@ -207,7 +207,7 @@ public final class PendingDrag {
      * @return The root {@link Block} of the drag group.
      */
     public Block getRootDraggedBlock() {
-        return mRootBlockView.getBlock();
+        return mRootBlockView == null ? null : mRootBlockView.getBlock();
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -25,6 +25,9 @@ import android.util.Log;
 import android.view.DragEvent;
 import android.widget.EditText;
 
+import com.google.blockly.android.AbstractBlocklyActivity;
+import com.google.blockly.android.clipboard.BlockClipDataHelper;
+import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.WorkspaceView;
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldInput;
@@ -120,10 +123,12 @@ public class BasicFieldInputView extends EditText implements FieldView {
     @Override
     public boolean onDragEvent(DragEvent event) {
         // Don't let block groups be dropped into text fields.
-        if (event.getClipDescription() != null
-            && event.getClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)
-            && event.getClipDescription().getLabel().equals(
-                WorkspaceView.BLOCK_GROUP_CLIP_DATA_LABEL)) {
+        Context context = getContext();
+        BlocklyController controller = (context instanceof AbstractBlocklyActivity) ?
+                ((AbstractBlocklyActivity) context).getController() : null;
+        BlockClipDataHelper clipHelper =
+                (controller == null) ? null : controller.getClipDataHelper();
+        if (clipHelper != null && clipHelper.isBlockData(event.getClipDescription())) {
             return false;
         }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -28,6 +28,9 @@ import android.util.Log;
 import android.view.DragEvent;
 import android.widget.EditText;
 
+import com.google.blockly.android.AbstractBlocklyActivity;
+import com.google.blockly.android.clipboard.BlockClipDataHelper;
+import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.WorkspaceView;
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldNumber;
@@ -176,10 +179,12 @@ public class BasicFieldNumberView extends EditText implements FieldView {
     @Override
     public boolean onDragEvent(DragEvent event) {
         // Don't let block groups be dropped into text fields.
-        if (event.getClipDescription() != null
-            && event.getClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)
-            && event.getClipDescription().getLabel().equals(
-                WorkspaceView.BLOCK_GROUP_CLIP_DATA_LABEL)) {
+        Context context = getContext();
+        BlocklyController controller = (context instanceof AbstractBlocklyActivity) ?
+                ((AbstractBlocklyActivity) context).getController() : null;
+        BlockClipDataHelper clipHelper =
+                (controller == null) ? null : controller.getClipDataHelper();
+        if (clipHelper != null && clipHelper.isBlockData(event.getClipDescription())) {
             return false;
         }
 

--- a/blocklylib-core/src/main/res/values/strings.xml
+++ b/blocklylib-core/src/main/res/values/strings.xml
@@ -38,4 +38,5 @@
     <string name="name_variable_positive">OK</string>
     <string name="name_variable_negative">Cancel</string>
 
+    <string name="blockly_clipdata_label_default">Blockly blocks</string>
 </resources>

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -16,7 +16,6 @@
 package com.google.blockly.android.control;
 
 import com.google.blockly.android.BlocklyTestCase;
-import com.google.blockly.android.clipboard.SingleMimeTypeClipDataHelper;
 import com.google.blockly.android.test.R;
 import com.google.blockly.android.testui.TestableBlockGroup;
 import com.google.blockly.android.testui.TestableBlockViewFactory;

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -16,6 +16,7 @@
 package com.google.blockly.android.control;
 
 import com.google.blockly.android.BlocklyTestCase;
+import com.google.blockly.android.clipboard.SingleMimeTypeClipDataHelper;
 import com.google.blockly.android.test.R;
 import com.google.blockly.android.testui.TestableBlockGroup;
 import com.google.blockly.android.testui.TestableBlockViewFactory;

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
@@ -114,7 +114,7 @@ public class DraggerTest extends BlocklyTestCase {
         @Override
         public void run() {
             ++mDragGroupCreatorCallCount;
-            mPendingDrag.setDragGroup(mDragGroup);
+            mPendingDrag.startDrag(mDragGroup, new ViewPoint());
             mDragGroupCreatorLatch.countDown();
         }
     };


### PR DESCRIPTION
New DragShadowBuilder renders the dragged block group to an image during dragging.  This improves drag responsiveness and begins the drag view above all over views, even outside of the workspace.

Also, annotate every block drag attempt with ClipDataDescription. A BlockClipDataHelper allows any view to participate in the drag behavior. In a pending CL, the TrashCan will utilize this, but it offers extension to other views outside the Blockly framework (e.g., a sprite, as in Scratch, for copying a block group between workspaces).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/486)
<!-- Reviewable:end -->
