### PR TITLE
Always use the default translucent dragshadow.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -366,7 +366,6 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
         int flags = 0;
         if (android.os.Build.VERSION.SDK_INT >= 24) {
             flags |= 0x00000100;  // View.DRAG_FLAG_GLOBAL
-            flags |= 0x00000200;  // View.DRAG_FLAG_OPAQUE
         }
         return flags;
     }


### PR DESCRIPTION
Fixes #115.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/497)
<!-- Reviewable:end -->
