### PR TITLE
Added getWorkspaceSavePath() to AbstractBlocklyActivity.

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -255,4 +255,10 @@ public class DevTestsActivity extends BlocklySectionsActivity {
         controller.addVariable("gir");
         controller.addVariable("tak");
     }
+
+    @NonNull
+    @Override
+    protected String getWorkspaceSavePath() {
+        return "devtests_workspace.xml";
+    }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
@@ -36,8 +36,6 @@ import java.util.List;
 public class SplitActivity extends AbstractBlocklyActivity {
     private static final String TAG = "SplitActivity";
 
-    // SplitActivity shares a save file with TurtleActivity to show generated code and running code.
-    public static final String SAVED_WORKSPACE_FILENAME = TurtleActivity.SAVED_WORKSPACE_FILENAME;
     private TextView mGeneratedTextView;
     private Handler mHandler;
 
@@ -56,16 +54,6 @@ public class SplitActivity extends AbstractBlocklyActivity {
                     });
                 }
             };
-
-    @Override
-    public void onLoadWorkspace() {
-        mBlockly.loadWorkspaceFromAppDir(SAVED_WORKSPACE_FILENAME);
-    }
-
-    @Override
-    public void onSaveWorkspace() {
-        mBlockly.saveWorkspaceToAppDir(SAVED_WORKSPACE_FILENAME);
-    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -155,5 +143,13 @@ public class SplitActivity extends AbstractBlocklyActivity {
 
         float density = getResources().getDisplayMetrics().density;
         mGeneratedTextView.setMinWidth((int) (maxline * 13 * density));
+    }
+
+    @NonNull
+    @Override
+    protected String getWorkspaceSavePath() {
+        // SplitActivity uses the turtle block definitions, and thus shares the same file as
+        // TurtleActivity.
+        return TurtleActivity.SAVED_WORKSPACE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
@@ -222,4 +222,10 @@ public class TurtleActivity extends BlocklySectionsActivity {
         controller.addVariable("kitkat");
         controller.addVariable("android");
     }
+
+    @NonNull
+    @Override
+    protected String getWorkspaceSavePath() {
+        return SAVED_WORKSPACE_FILENAME;
+    }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -80,8 +80,6 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
 
     private static final String TAG = "AbstractBlocklyActivity";
 
-    public static final String DEFAULT_WORKSPACE_FILENAME = "workspace.xml";
-
     protected BlocklyActivityHelper mBlockly;
 
     protected ActionBar mActionBar;
@@ -162,10 +160,10 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     /**
      * Called when the user clicks the save action.  Default implementation delegates handling to
      * {@link BlocklyActivityHelper#saveWorkspaceToAppDir(String)} using
-     * {@link #DEFAULT_WORKSPACE_FILENAME}.
+     * {@link #getWorkspaceSavePath()}.
      */
     public void onSaveWorkspace() {
-        mBlockly.saveWorkspaceToAppDir(DEFAULT_WORKSPACE_FILENAME);
+        mBlockly.saveWorkspaceToAppDir(getWorkspaceSavePath());
     }
 
     /**
@@ -181,7 +179,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      * {@link BlocklyActivityHelper#loadWorkspaceFromAppDir(String)}.
      */
     public void onLoadWorkspace() {
-        mBlockly.loadWorkspaceFromAppDir(DEFAULT_WORKSPACE_FILENAME);
+        mBlockly.loadWorkspaceFromAppDir(getWorkspaceSavePath());
     }
 
     /**
@@ -405,6 +403,15 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
      */
     @NonNull
     abstract protected CodeGenerationRequest.CodeGeneratorCallback getCodeGenerationCallback();
+
+    /**
+     * @return The path to the saved workspace file on the local device. By default,
+     *         "workspace.xml".
+     */
+    @NonNull
+    protected String getWorkspaceSavePath() {
+        return "workspace.xml";
+    }
 
     /**
      * Creates or loads the root content view (by default, {@link R.layout#drawers_and_action_bar})


### PR DESCRIPTION
Replaces DEFAULT_WORKSPACE_FILENAME, which as a static constant, wasn't overridable.

Using different workspace files for the demos (grouped by their shared block definitions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/512)
<!-- Reviewable:end -->
