### PR TITLE
Renaming resource ids. Moving interfaces into .ui

### DIFF
--- a/blocklydemo/src/main/res/layout/always_open_toolbox.xml
+++ b/blocklydemo/src/main/res/layout/always_open_toolbox.xml
@@ -11,7 +11,7 @@
     >
 
     <fragment android:name="com.google.blockly.android.FlyoutFragment"
-        android:id="@+id/blockly_toolbox_flyout"
+        android:id="@+id/blockly_toolbox_ui"
         android:layout_width="match_parent"
         android:layout_height="140dp"
         android:layout_alignParentTop="true"
@@ -22,7 +22,7 @@
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_below="@id/blockly_toolbox_flyout">
+        android:layout_below="@id/blockly_toolbox_ui">
 
         <fragment android:name="com.google.blockly.android.WorkspaceFragment"
             android:id="@+id/blockly_workspace"
@@ -31,7 +31,7 @@
             />
 
         <fragment android:name="com.google.blockly.android.FlyoutFragment"
-            android:id="@+id/blockly_trash_flyout"
+            android:id="@+id/blockly_trash_ui"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"

--- a/blocklydemo/src/main/res/layout/styled_content.xml
+++ b/blocklydemo/src/main/res/layout/styled_content.xml
@@ -28,7 +28,7 @@
                   blockly:scrollOrientation="horizontal"
                   tools:ignore="MissingPrefix" />
         <fragment android:name="com.google.blockly.android.FlyoutFragment"
-                  android:id="@+id/blockly_toolbox_flyout"
+                  android:id="@+id/blockly_toolbox_ui"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"
                   blockly:scrollOrientation="horizontal"

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -53,7 +53,7 @@ import java.util.List;
  * is constructed to help initialize the Blockly fragments, controller, and supporting UI. If
  * overriding {@link #onCreateContentView} without {@code unified_blockly_workspace.xml} or
  * otherwise using standard blockly fragment and view ids ({@link R.id#blockly_workspace},
- * {@link R.id#blockly_toolbox_flyout}, {@link R.id#blockly_trash_flyout}, etc.), override
+ * {@link R.id#blockly_toolbox_ui}, {@link R.id#blockly_trash_ui}, etc.), override
  * {@link #onCreateActivityHelper()} and {@link BlocklyActivityHelper#onCreateFragments()}
  * appropriately.
  * <p/>

--- a/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
@@ -28,6 +28,7 @@ import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.android.codegen.CodeGeneratorManager;
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.BlockViewFactory;
+import com.google.blockly.android.ui.DefaultVariableCallback;
 import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.BlocklySerializerException;
 import com.google.blockly.model.Workspace;
@@ -44,7 +45,7 @@ import java.util.List;
  * {@link BlocklyActivityHelper#onCreateFragments()} looks for
  * the {@link WorkspaceFragment}, the toolbox's {@link FlyoutFragment}, and the trash's
  * {@link FlyoutFragment} via fragment ids {@link R.id#blockly_workspace},
- * {@link R.id#blockly_toolbox_flyout}, and {@link R.id#blockly_trash_flyout}, respectively.
+ * {@link R.id#blockly_toolbox_ui}, and {@link R.id#blockly_trash_ui}, respectively.
  * <p/>
  * The activity can also contain a few buttons to control the workspace.
  * {@link R.id#blockly_zoom_in_button} and {@link R.id#blockly_zoom_out_button} control the
@@ -247,9 +248,9 @@ public class BlocklyActivityHelper {
      *   {@link #mWorkspaceFragment}.</li>
      *   <li>the toolbox {@link CategorySelectorFragment} with id {@link R.id#blockly_categories},
      *   assigned to {@link #mCategoryFragment}.</li>
-     *   <li>the toolbox {@link FlyoutFragment} with id {@link R.id#blockly_toolbox_flyout},
+     *   <li>the toolbox {@link FlyoutFragment} with id {@link R.id#blockly_toolbox_ui},
      *   assigned to {@link #mToolboxFlyoutFragment}.</li>
-     *   <li>the trash {@link FlyoutFragment} with id {@link R.id#blockly_trash_flyout}, assigned to
+     *   <li>the trash {@link FlyoutFragment} with id {@link R.id#blockly_trash_ui}, assigned to
      *   {@link #mTrashFlyoutFragment}.</li>
      * </ul>
      * Only the workspace fragment is required. The activity layout can choose not to include the
@@ -264,11 +265,11 @@ public class BlocklyActivityHelper {
         mWorkspaceFragment = (WorkspaceFragment)
                 fragmentManager.findFragmentById(R.id.blockly_workspace);
         mToolboxFlyoutFragment = (FlyoutFragment) fragmentManager
-                .findFragmentById(R.id.blockly_toolbox_flyout);
+                .findFragmentById(R.id.blockly_toolbox_ui);
         mCategoryFragment = (CategorySelectorFragment) fragmentManager
                 .findFragmentById(R.id.blockly_categories);
         mTrashFlyoutFragment = (FlyoutFragment) fragmentManager
-                .findFragmentById(R.id.blockly_trash_flyout);
+                .findFragmentById(R.id.blockly_trash_ui);
 
         if (mTrashFlyoutFragment != null) {
             // TODO(#14): Make trash list a drop location.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/CategorySelectorFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/CategorySelectorFragment.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.ui.CategorySelectorUI;
 import com.google.blockly.android.ui.CategoryTabs;
 import com.google.blockly.android.ui.CategoryView;
 import com.google.blockly.android.ui.Rotation;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/FlyoutFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/FlyoutFragment.java
@@ -33,7 +33,9 @@ import android.widget.Button;
 
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.control.FlyoutController;
+import com.google.blockly.android.ui.BlockListUI;
 import com.google.blockly.android.ui.BlockRecyclerViewHelper;
+import com.google.blockly.android.ui.CategorySelectorUI;
 import com.google.blockly.android.ui.FlyoutCallback;
 import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Block;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -26,8 +26,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
-import com.google.blockly.android.BlockListUI;
-import com.google.blockly.android.CategorySelectorUI;
+import com.google.blockly.android.ui.BlockListUI;
+import com.google.blockly.android.ui.CategorySelectorUI;
 import com.google.blockly.android.WorkspaceFragment;
 import com.google.blockly.android.clipboard.BlockClipDataHelper;
 import com.google.blockly.android.clipboard.SingleMimeTypeClipDataHelper;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/FlyoutController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/FlyoutController.java
@@ -18,8 +18,8 @@ package com.google.blockly.android.control;
 import android.support.annotation.Nullable;
 import android.view.View;
 
-import com.google.blockly.android.BlockListUI;
-import com.google.blockly.android.CategorySelectorUI;
+import com.google.blockly.android.ui.BlockListUI;
+import com.google.blockly.android.ui.CategorySelectorUI;
 import com.google.blockly.android.ui.BlockGroup;
 import com.google.blockly.android.ui.FlyoutCallback;
 import com.google.blockly.android.ui.OnDragToTrashListener;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListUI.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockListUI.java
@@ -13,12 +13,11 @@
  *  limitations under the License.
  */
 
-package com.google.blockly.android;
+package com.google.blockly.android.ui;
 
 import android.support.annotation.Nullable;
 
 import com.google.blockly.android.control.BlocklyController;
-import com.google.blockly.android.ui.FlyoutCallback;
 import com.google.blockly.model.FlyoutCategory;
 
 /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategorySelectorUI.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategorySelectorUI.java
@@ -13,7 +13,7 @@
  *  limitations under the License.
  */
 
-package com.google.blockly.android;
+package com.google.blockly.android.ui;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
@@ -28,7 +28,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.google.blockly.android.CategorySelectorUI;
 import com.google.blockly.android.R;
 import com.google.blockly.model.FlyoutCategory;
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryView.java
@@ -24,7 +24,6 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.RelativeLayout;
 
-import com.google.blockly.android.CategorySelectorUI;
 import com.google.blockly.android.R;
 import com.google.blockly.model.FlyoutCategory;
 import com.google.blockly.utils.ColorUtils;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/DefaultVariableCallback.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/DefaultVariableCallback.java
@@ -12,7 +12,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.google.blockly.android;
+package com.google.blockly.android.ui;
 
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;

--- a/blocklylib-core/src/main/res/layout/blockly_unified_workspace.xml
+++ b/blocklylib-core/src/main/res/layout/blockly_unified_workspace.xml
@@ -14,7 +14,7 @@
               android:layout_toRightOf="@id/blockly_categories"/>
 
     <fragment android:name="com.google.blockly.android.FlyoutFragment"
-              android:id="@+id/blockly_trash_flyout"
+              android:id="@+id/blockly_trash_ui"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_alignParentBottom="true"
@@ -35,7 +35,7 @@
               blockly:scrollOrientation="vertical"
               tools:ignore="MissingPrefix"/>
     <fragment android:name="com.google.blockly.android.FlyoutFragment"
-              android:id="@+id/blockly_toolbox_flyout"
+              android:id="@+id/blockly_toolbox_ui"
               android:layout_width="wrap_content"
               android:layout_height="match_parent"
               android:layout_toEndOf="@id/blockly_categories"


### PR DESCRIPTION
 * Renaming `blockly_toolbox_flyout` and `blockly_trash_flyout` as `blockly_toolbox_ui` and `blockly_trash_ui`, respectively.
 * Moving `BlockListUI`, `CategorySelectorUI`, and `DefaultVariableCallback` to the `.android.ui` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/518)
<!-- Reviewable:end -->
