### PR TITLE
Make unbinding from CodeGeneratorService cleaner

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/codegen/CodeGeneratorManager.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/codegen/CodeGeneratorManager.java
@@ -51,7 +51,7 @@ public class CodeGeneratorManager {
             public void onServiceConnected(ComponentName className, IBinder binder) {
                 try {
                     if (!mResumed) {
-                        mContext.unbindService(mCodeGenerationConnection);
+                        unbind();
                     } else {
                         mGeneratorService = ((CodeGeneratorService.CodeGeneratorBinder) binder).getService();
 
@@ -76,9 +76,7 @@ public class CodeGeneratorManager {
      */
     public void onPause() {
         mResumed = false;
-        if (isBound()) {
-            mContext.unbindService(mCodeGenerationConnection);
-        }
+        unbind();
     }
 
     /**
@@ -88,6 +86,16 @@ public class CodeGeneratorManager {
     public void onResume() {
         mResumed = true;
         mStoredRequests.clear();
+    }
+
+    /**
+     * Checks if the service is currently bound and unbinds it if it is.
+     */
+    protected void unbind() {
+        if (isBound()) {
+            mContext.unbindService(mCodeGenerationConnection);
+            mGeneratorService = null;
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #535 by creating an unbind call that unbinds from the service
and clears state so we don't end up in a situation that can try to
unbind twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/538)
<!-- Reviewable:end -->
