### PR TITLE
Fix #540 test failures on API 16.

### DIFF
--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
@@ -79,7 +79,11 @@ public class BlockFactoryTest {
     public void testSuccessfulLoadFromXml() throws IOException, XmlPullParserException {
         Block loaded = parseBlockFromXml(BlockTestStrings.SIMPLE_BLOCK);
         assertThat(loaded.getType()).isEqualTo("frankenblock");
-        assertThat(loaded.getPosition()).isEqualTo(new WorkspacePoint(37, 13));
+
+        // PointF.equals(other) did not exist before API 17. Compare components for 16.
+        WorkspacePoint position = loaded.getPosition();
+        assertThat(position.x).isEqualTo(37f);
+        assertThat(position.y).isEqualTo(13f);
     }
 
     @Test
@@ -235,8 +239,12 @@ public class BlockFactoryTest {
     public void testLoadFromXmlSimpleShadow() throws IOException, XmlPullParserException {
         Block loaded = parseShadowFromXml(BlockTestStrings.SIMPLE_SHADOW);
         assertThat(loaded.getType()).isEqualTo("math_number");
-        assertThat(loaded.getPosition()).isEqualTo(new WorkspacePoint(37, 13));
         assertThat(loaded.isShadow()).isTrue();
+
+        // PointF.equals(other) did not exist before API 17. Compare components for API 16.
+        WorkspacePoint position = loaded.getPosition();
+        assertThat(position.x).isEqualTo(37f);
+        assertThat(position.y).isEqualTo(13f);
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlocklyEventTest.java
@@ -166,6 +166,10 @@ public class BlocklyEventTest {
                 BlocklyXmlHelper.loadOneBlockFromXml(deserializedEvent.getXml(), mBlockFactory);
         assertThat(deserializedBlock.getId()).isEqualTo(BLOCK_ID);
         assertThat(mBlock.getType()).isEqualTo(BLOCK_TYPE);
-        assertThat(mBlock.getPosition()).isEqualTo(NEW_POSITION);
+
+        // PointF.equals(other) did not exist before API 17. Compare components for 16.
+        WorkspacePoint position = mBlock.getPosition();
+        assertThat(position.x).isEqualTo(NEW_POSITION.x);
+        assertThat(position.y).isEqualTo(NEW_POSITION.y);
     }
 }


### PR DESCRIPTION
Sidesteps use of PointF.equals(..) in tests. Fixes #540.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/541)
<!-- Reviewable:end -->
