### PR TITLE
Improve FieldNumber and FieldNumberView for other languages.

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
@@ -18,13 +18,19 @@ package com.google.blockly.android.demo;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.blockly.android.AbstractBlocklyActivity;
 import com.google.blockly.android.codegen.CodeGenerationRequest;
+import com.google.blockly.model.BlocklySerializerException;
+import com.google.blockly.utils.BlocklyXmlHelper;
+import com.google.blockly.utils.StringOutputStream;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,6 +60,27 @@ public class SplitActivity extends AbstractBlocklyActivity {
                     });
                 }
             };
+
+    @Override
+    protected void onRunCode() {
+        final StringOutputStream serialized = new StringOutputStream();
+        try {
+            getController().getWorkspace().serializeToXml(serialized);
+            mGeneratedTextView.setText(serialized.toString());
+        } catch (BlocklySerializerException e) {
+            // Not using a string resource because no non-developer should see this.
+            String msg = "Failed to serialize workspace during code generation.";
+            Log.wtf(TAG, msg, e);
+            Toast.makeText(this, msg, Toast.LENGTH_LONG).show();
+            throw new IllegalStateException(msg, e);
+        } finally {
+            try {
+                serialized.close();
+            } catch (IOException e) {
+                // Ignore error on close().
+            }
+        }
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
@@ -245,6 +245,11 @@ public class BlocklyActivityHelper {
                         codeGenerationCallback,
                         blockDefinitionsJsonPaths,
                         generatorsJsPaths));
+        try {
+            serialized.close();
+        } catch (IOException e) {
+            // Ignore error on close().
+        }
     }
 
 

--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldNumber.java
@@ -25,7 +25,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * A 'field_number' type of field, for an editable number.
@@ -35,6 +37,8 @@ public final class FieldNumber extends Field {
 
     public static final double NO_CONSTRAINT = Double.NaN;
 
+    private static final DecimalFormatSymbols PERIOD_AS_DECIMAL =
+            new DecimalFormatSymbols(new Locale("en", "us"));
     /**
      * This formatter is used by fields without precision, and to count precision's significant
      * digits past the decimal point.  Unlike {@link Double#toString}, it displays as many
@@ -42,10 +46,13 @@ public final class FieldNumber extends Field {
      */
     private static final DecimalFormat NAIVE_DECIMAL_FORMAT;
     static {
+        // Force as many significant digits as possible in a naive decimal format, using the period
+        // as the decimal.
         char[] sigDigts = new char[100];
         Arrays.fill(sigDigts, '#');
         NAIVE_DECIMAL_FORMAT
-                = new DecimalFormat(new StringBuffer("0.").append(sigDigts).toString());
+                = new DecimalFormat(new StringBuffer("0.").append(sigDigts).toString(),
+                        PERIOD_AS_DECIMAL);
     }
 
     /**
@@ -182,7 +189,7 @@ public final class FieldNumber extends Field {
                 char[] sigDigitsFormat = new char[significantDigits];
                 Arrays.fill(sigDigitsFormat, '#');
                 sb.append(sigDigitsFormat);
-                mFormatter = new DecimalFormat(sb.toString());
+                mFormatter = new DecimalFormat(sb.toString(), PERIOD_AS_DECIMAL);
             }
         }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldNumberTest.java
@@ -20,6 +20,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -177,53 +180,66 @@ public class FieldNumberTest {
         final double MAX = FieldNumber.NO_CONSTRAINT;
         final double PRECISION = 0.25;  // Two significant digits
         mField.setConstraints(MIN, MAX, PRECISION);
+        NumberFormat periodDecimal = mField.getNumberFormatForLocale(new Locale("en", "us"));
+        NumberFormat commaDecimal = mField.getNumberFormatForLocale(new Locale("es", "es"));
 
         assertThat(mField.isInteger()).isFalse();
 
         // Exact values
         mField.setValue(0.0);
         assertThat(mField.getValue()).isEqualTo(0.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("0");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("0");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("0");
 
         mField.setValue(0.25);
         assertThat(mField.getValue()).isEqualTo(0.25);
-        assertThat(mField.getFormattedValue()).isEqualTo("0.25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("0.25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("0,25");
 
         mField.setValue(1.0);
         assertThat(mField.getValue()).isEqualTo(1.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("1");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("1");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("1");
 
         mField.setValue(1.25);
         assertThat(mField.getValue()).isEqualTo(1.25);
-        assertThat(mField.getFormattedValue()).isEqualTo("1.25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("1.25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("1,25");
 
         mField.setValue(2.50);
         assertThat(mField.getValue()).isEqualTo(2.5);
-        assertThat(mField.getFormattedValue()).isEqualTo("2.5");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("2.5");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("2,5");
 
         mField.setValue(25);
         assertThat(mField.getValue()).isEqualTo(25.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("25");
 
         mField.setValue(-0.25);
         assertThat(mField.getValue()).isEqualTo(-0.25);
-        assertThat(mField.getFormattedValue()).isEqualTo("-0.25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("-0.25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("-0,25");
 
         mField.setValue(-1.0);
         assertThat(mField.getValue()).isEqualTo(-1.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-1");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("-1");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("-1");
 
         mField.setValue(-1.25);
         assertThat(mField.getValue()).isEqualTo(-1.25);
-        assertThat(mField.getFormattedValue()).isEqualTo("-1.25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("-1.25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("-1,25");
 
         mField.setValue(-2.50);
         assertThat(mField.getValue()).isEqualTo(-2.5);
-        assertThat(mField.getFormattedValue()).isEqualTo("-2.5");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("-2.5");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("-2,5");
 
         mField.setValue(-25);
         assertThat(mField.getValue()).isEqualTo(-25.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-25");
+        assertThat(periodDecimal.format(mField.getValue())).isEqualTo("-25");
+        assertThat(commaDecimal.format(mField.getValue())).isEqualTo("-25");
 
         // Rounded Values
         mField.setValue(0.2);
@@ -248,6 +264,8 @@ public class FieldNumberTest {
         final double MAX = FieldNumber.NO_CONSTRAINT;
         final double PRECISION = 1;
         mField.setConstraints(MIN, MAX, PRECISION);
+        NumberFormat commaMarker = mField.getNumberFormatForLocale(new Locale("en", "us"));
+        NumberFormat periodMarker = mField.getNumberFormatForLocale(new Locale("es", "es"));
 
         assertThat(mField.isInteger()).isTrue();
 
@@ -257,55 +275,69 @@ public class FieldNumberTest {
         // Exact values
         mField.setValue(0.0);
         assertThat(mField.getValue()).isEqualTo(0.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("0");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("0");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("0");
 
         mField.setValue(1.0);
         assertThat(mField.getValue()).isEqualTo(1.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("1");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("1");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("1");
 
         mField.setValue(2.0);
         assertThat(mField.getValue()).isEqualTo(2.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("2");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("2");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("2");
 
         mField.setValue(7.0);
         assertThat(mField.getValue()).isEqualTo(7.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("7");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("7");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("7");
 
         mField.setValue(10.0);
         assertThat(mField.getValue()).isEqualTo(10.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("10");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("10");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("10");
 
         mField.setValue(100.0);
         assertThat(mField.getValue()).isEqualTo(100.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("100");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("100");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("100");
 
+        // Large numbers render with grouping markers
         mField.setValue(1000000.0);
         assertThat(mField.getValue()).isEqualTo(1000000.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("1000000");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("1,000,000");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("1.000.000");
 
         mField.setValue(-1.0);
         assertThat(mField.getValue()).isEqualTo(-1.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-1");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-1");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-1");
 
         mField.setValue(-2.0);
         assertThat(mField.getValue()).isEqualTo(-2.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-2");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-2");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-2");
 
         mField.setValue(-7.0);
         assertThat(mField.getValue()).isEqualTo(-7.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-7");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-7");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-7");
 
         mField.setValue(-10.0);
         assertThat(mField.getValue()).isEqualTo(-10.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-10");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-10");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-10");
 
         mField.setValue(-100.0);
         assertThat(mField.getValue()).isEqualTo(-100.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-100");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-100");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-100");
 
         mField.setValue(-1000000.0);
         assertThat(mField.getValue()).isEqualTo(-1000000.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-1000000");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-1,000,000");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-1.000.000");
 
 
         // Rounded Values
@@ -346,33 +378,41 @@ public class FieldNumberTest {
         final double MAX = FieldNumber.NO_CONSTRAINT;
         final double PRECISION = 2;
         mField.setConstraints(MIN, MAX, PRECISION);
+        NumberFormat commaMarker = mField.getNumberFormatForLocale(new Locale("en", "us"));
+        NumberFormat periodMarker = mField.getNumberFormatForLocale(new Locale("es", "es"));
 
         assertThat(mField.isInteger()).isTrue();
 
         // Exact values
         mField.setValue(0.0);
         assertThat(mField.getValue()).isEqualTo(0.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("0");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("0");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("0");
 
         mField.setValue(2.0);
         assertThat(mField.getValue()).isEqualTo(2.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("2");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("2");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("2");
 
         mField.setValue(8.0);
         assertThat(mField.getValue()).isEqualTo(8.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("8");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("8");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("8");
 
         mField.setValue(10.0);
         assertThat(mField.getValue()).isEqualTo(10.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("10");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("10");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("10");
 
         mField.setValue(-2.0);
         assertThat(mField.getValue()).isEqualTo(-2.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-2");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-2");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-2");
 
         mField.setValue(-8.0);
         assertThat(mField.getValue()).isEqualTo(-8.0);
-        assertThat(mField.getFormattedValue()).isEqualTo("-8");
+        assertThat(commaMarker.format(mField.getValue())).isEqualTo("-8");
+        assertThat(periodMarker.format(mField.getValue())).isEqualTo("-8");
 
         // Rounded Values
         mField.setValue(0.2);


### PR DESCRIPTION
Solves #231 serialization under locales that use commas (or anything else) as a decimal point.
Also improves input in these Locales, allowing the comma to be rendered and typed in the corresponding views.

Number rendering now includes grouping separators (the comma after thousands in English), although those are stripped during parsing for permissive inputs (and also due to incorrect parsing when included in the NumberFormat).

KNOWN ISSUES:
 * Fractional numbers are rendered truncated at three significant digits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/546)
<!-- Reviewable:end -->
