### PR TITLE
Adding support-v4 library to fix build problem with AppCompatActivity

### DIFF
--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -29,6 +29,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile 'com.android.support:support-v4:25.2.0'
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:recyclerview-v7:25.1.0'
     compile 'com.android.support:support-v13:25.1.0'


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/553)
<!-- Reviewable:end -->
