### PR TITLE
Fixes Number field rendering.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/clipboard/SingleMimeTypeClipDataHelper.java
@@ -99,6 +99,9 @@ public class SingleMimeTypeClipDataHelper implements BlockClipDataHelper {
      */
     @Override
     public PendingDrag getPendingDrag(DragEvent event) {
+        if (!isBlockData(event.getClipDescription())) {
+            return null;
+        }
         // In the future, this will support drags across application boundaries, constructing a new
         // PendingDrag as necessary. For now, it just extracts the PendingData from the local state.
         return (PendingDrag) event.getLocalState();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
@@ -15,7 +15,9 @@
 
 package com.google.blockly.android.ui;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.res.Resources;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -26,10 +28,14 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.view.DragEvent;
 import android.view.View;
 import android.view.ViewParent;
 
+import com.google.blockly.android.AbstractBlocklyActivity;
 import com.google.blockly.android.ZoomBehavior;
+import com.google.blockly.android.clipboard.BlockClipDataHelper;
+import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.model.Block;
 import com.google.blockly.model.WorkspacePoint;
 
@@ -81,6 +87,24 @@ public class WorkspaceHelper {
     private BlockViewFactory mViewFactory;
     private float mDensity;
     private boolean mRtl;
+
+    /**
+     * Determine if {@code dragEvent} is a block drag.
+     * @param viewContext The context of the view receiving the drag event.
+     * @param dragEvent The drag event in question.
+     * @return True if the drag represents a block drag. Otherwise false.
+     */
+    public static boolean isBlockDrag(Context viewContext, DragEvent dragEvent) {
+        // Unwrap ContextWrappers until the Activity is found.
+        while (viewContext instanceof ContextWrapper && !(viewContext instanceof Activity)) {
+            viewContext = ((ContextWrapper) viewContext).getBaseContext();
+        }
+        BlocklyController controller = (viewContext instanceof AbstractBlocklyActivity) ?
+                ((AbstractBlocklyActivity) viewContext).getController() : null;
+        BlockClipDataHelper clipHelper =
+                (controller == null) ? null : controller.getClipDataHelper();
+        return (clipHelper != null && clipHelper.isBlockData(dragEvent.getClipDescription()));
+    }
 
     /**
      * Create a helper for creating and doing calculations for views in the workspace.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -24,9 +24,7 @@ import android.util.Log;
 import android.view.DragEvent;
 import android.widget.EditText;
 
-import com.google.blockly.android.AbstractBlocklyActivity;
-import com.google.blockly.android.clipboard.BlockClipDataHelper;
-import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldInput;
 
@@ -121,15 +119,9 @@ public class BasicFieldInputView extends EditText implements FieldView {
     @Override
     public boolean onDragEvent(DragEvent event) {
         // Don't let block groups be dropped into text fields.
-        Context context = getContext();
-        BlocklyController controller = (context instanceof AbstractBlocklyActivity) ?
-                ((AbstractBlocklyActivity) context).getController() : null;
-        BlockClipDataHelper clipHelper =
-                (controller == null) ? null : controller.getClipDataHelper();
-        if (clipHelper != null && clipHelper.isBlockData(event.getClipDescription())) {
+        if (WorkspaceHelper.isBlockDrag(getContext(), event)) {
             return false;
         }
-
         return super.onDragEvent(event);
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -29,9 +29,7 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.DragEvent;
 
-import com.google.blockly.android.AbstractBlocklyActivity;
-import com.google.blockly.android.clipboard.BlockClipDataHelper;
-import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldNumber;
 
@@ -215,16 +213,9 @@ public class BasicFieldNumberView extends AppCompatEditText implements FieldView
      */
     @Override
     public boolean onDragEvent(DragEvent event) {
-        // Don't let block groups be dropped into text fields.
-        Context context = getContext();
-        BlocklyController controller = (context instanceof AbstractBlocklyActivity) ?
-                ((AbstractBlocklyActivity) context).getController() : null;
-        BlockClipDataHelper clipHelper =
-                (controller == null) ? null : controller.getClipDataHelper();
-        if (clipHelper != null && clipHelper.isBlockData(event.getClipDescription())) {
+        if (WorkspaceHelper.isBlockDrag(getContext(), event)) {
             return false;
         }
-
         return super.onDragEvent(event);
     }
 


### PR DESCRIPTION
 * Fix number field view, correcting filter for block drags.
 * Unify block drag checks from `BasicFiedNumberView` and `BasicFieldInputView` as `WorkspaceHelper.isBlockDrag(..)`.
 * `SimpleMimeTypeClipDataHelper`: Filter out non-block drags before casting `getPendingDrag()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/555)
<!-- Reviewable:end -->
