### PR TITLE
Adding Observer / Observable to Block class.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -70,9 +70,9 @@ public class Block extends Observable<Block.Observer> {
          *     <li>Deletable state</li>
          * </ul>
          * @param block The block updated.
-         * @param whatChanged The bit flags identifying the changed state.
+         * @param updateStateMask A bit mask of {@link UpdateState} bits for the updated parts.
          */
-        void onUpdated(Block block, @UpdateState int whatChanged);
+        void onBlockUpdated(Block block, @UpdateState int updateStateMask);
     }
 
     // These values are immutable once a block is created
@@ -262,7 +262,7 @@ public class Block extends Observable<Block.Observer> {
      * @param deletable
      */
     public void setDeletable(boolean deletable) {
-        if (mDeletable != deletable) {
+        if (mDeletable == deletable) {
             return;
         }
         mDeletable = deletable;
@@ -410,7 +410,7 @@ public class Block extends Observable<Block.Observer> {
      *
      * @param comment The text of the comment.
      */
-    public void setComment(String comment) {
+    public void setComment(@Nullable String comment) {
         if (comment == mComment || (comment != null && comment.equals(mComment))) {
             return;
         }
@@ -996,10 +996,11 @@ public class Block extends Observable<Block.Observer> {
 
     /**
      * Notifies Observers of a structure change.
+     * @param updateStateMask A bit mask of {@link UpdateState} bits for the updated parts.
      */
-    protected void fireUpdate(@UpdateState int whatChanged) {
+    protected void fireUpdate(@UpdateState int updateStateMask) {
         for (Observer observer: mObservers) {
-            observer.onUpdated(this, whatChanged);
+            observer.onBlockUpdated(this, updateStateMask);
         }
     }
 

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -50,6 +50,10 @@ public class BlockView extends AbstractBlockView<InputView> {
     private static final float SHADOW_SATURATION_MULTIPLIER = 0.4f;
     private static final float SHADOW_VALUE_MULTIPLIER = 1.2f;
 
+    private static final int UPDATES_THAT_CAUSE_REINIT =
+            Block.UPDATE_INPUTS_FIELDS | Block.UPDATE_IS_COLLAPSED | Block.UPDATE_IS_DISABLED
+            | Block.UPDATE_IS_SHADOW;
+
     // TODO(#86): Determine from 9-patch measurements.
     private final int mMinBlockWidth;
 
@@ -120,8 +124,10 @@ public class BlockView extends AbstractBlockView<InputView> {
 
         block.registerObserver(new Block.Observer() {
             @Override
-            public void onStructureUpdated(Block block) {
-                onBlockStructureUpdated();
+            public void onBlockUpdated(Block block, @Block.UpdateState int updateMask) {
+                if ((updateMask & UPDATES_THAT_CAUSE_REINIT) != 0) {
+                    onBlockStructureUpdated();
+                }
             }
         });
     }

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -117,6 +117,13 @@ public class BlockView extends AbstractBlockView<InputView> {
         setWillNotDraw(false);
 
         initDrawingObjects();
+
+        block.registerObserver(new Block.Observer() {
+            @Override
+            public void onStructureUpdated(Block block) {
+                onBlockStructureUpdated();
+            }
+        });
     }
 
     @Override
@@ -226,6 +233,15 @@ public class BlockView extends AbstractBlockView<InputView> {
      */
     public ColorFilter getColorFilter() {
         return mBlockColorFilter;
+    }
+
+    /**
+     * Called when a block's inputs, fields, comment, or mutator is/are updated, and thus the
+     * shape may have changed.
+     */
+    protected void onBlockStructureUpdated() {
+        // TODO(AnmAtAnm): Mark view for full recalc?
+        requestLayout();
     }
 
     /**


### PR DESCRIPTION
Blocks can now be observed by their view instances. Observations are categorized by `Block.UPDATE_*` bit flags. This will allows changes caused by mutators (or mutation events) to be noticed by the views, so the views will update themselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/561)
<!-- Reviewable:end -->
