### PR TITLE
Adding Block.reshape(). Making Inputs immutable.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -55,7 +55,7 @@ public class Block extends Observable<Block.Observer> {
     public static final int UPDATE_IS_COLLAPSED = 0x20;
     public static final int UPDATE_IS_EDITABLE = 0x40;
     public static final int UPDATE_IS_DELETABLE = 0x80;
-    // TODO(Anm): Tooltip, Context menu, Color
+    // TODO(Anm): Tooltip, Context menu, Block color
 
     public interface Observer {
         /**
@@ -90,11 +90,11 @@ public class Block extends Observable<Block.Observer> {
 
     // These values can be changed after creating the block
     private int mColor = ColorUtils.DEFAULT_BLOCK_COLOR;
-    private List<Input> mInputList = Collections.EMPTY_LIST;
+    private List<Input> mInputList = Collections.<Input>emptyList();
     private Connection mOutputConnection;
     private Connection mNextConnection;
     private Connection mPreviousConnection;
-    private List<Connection> mConnectionList = Collections.EMPTY_LIST;
+    private List<Connection> mConnectionList = Collections.<Connection>emptyList();
     private String mTooltip = null;
     private String mComment = null;
     private boolean mHasContextMenu = true;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -839,7 +839,7 @@ public class Block extends Observable<Block.Observer> {
         }
 
         if (newInputList == null) {
-            newInputList = Collections.EMPTY_LIST;
+            newInputList = Collections.<Input>emptyList();
         }
 
         List<Connection> connectionList = new ArrayList<>();

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
@@ -222,8 +222,7 @@ public final class BlockDefinition {
                             fields.add(factory.loadFieldFromJson(mTypeName, element));
                             break;
                         } else if (Input.isInputType(elementType)) {
-                            Input input = Input.fromJson(element);
-                            input.addAll(fields);
+                            Input input = Input.fromJson(element, fields);
                             fields.clear();
                             inputs.add(input);
                             break;
@@ -250,8 +249,7 @@ public final class BlockDefinition {
             // If there were leftover fields we need to add a dummy input to hold them.
             if (fields.size() != 0) {
                 String align = mJson.optString(lastDummyAlignKey, Input.ALIGN_LEFT_STRING);
-                Input input = new Input.InputDummy(null, align);
-                input.addAll(fields);
+                Input input = new Input.InputDummy(null, fields, align);
                 inputs.add(input);
                 fields.clear();
             }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
@@ -349,7 +349,7 @@ public final class BlockDefinition {
     private List<String> parseExtensions(JSONObject json)
             throws JSONException, BlockLoadingException {
         if (!json.has("extensions")) {
-            return Collections.EMPTY_LIST;
+            return Collections.<String>emptyList();
         }
 
         // While we expect an array, permissively grab an Object in case it is just a string.

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockExtension.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockExtension.java
@@ -43,7 +43,8 @@ import java.util.Map;
  * extensions and mutators</a>.
  */
 public interface BlockExtension {
-    Map<String, BlockExtension> STANDARD_EXTENSIONS = Collections.EMPTY_MAP;  // TODO
+    Map<String, BlockExtension> STANDARD_EXTENSIONS =
+            Collections.<String, BlockExtension>emptyMap();  // TODO
 
     /**
      * Applies the extension to the provided block.

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -152,6 +152,12 @@ public abstract class Field extends Observable<Field.Observer> implements Clonea
      * @param block The parent block for this field.
      */
     protected void setBlock(Block block) {
+        if (block == mBlock) {
+            return;
+        }
+        if (block != null && mBlock != null) {
+            throw new IllegalStateException("Field is already a member of another block.");
+        }
         mBlock = block;
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
@@ -305,6 +305,12 @@ public abstract class Input implements Cloneable {
      * @param block The block that owns this input.
      */
     public void setBlock(Block block) {
+        if (block == mBlock) {
+            return;
+        }
+        if (block != null && mBlock != null) {
+            throw new IllegalStateException("Input is already a member of another block.");
+        }
         mBlock = block;
         if (mConnection != null) {
             mConnection.setBlock(block);

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -50,9 +50,9 @@ public class BlockView extends AbstractBlockView<InputView> {
     private static final float SHADOW_SATURATION_MULTIPLIER = 0.4f;
     private static final float SHADOW_VALUE_MULTIPLIER = 1.2f;
 
-    private static final int UPDATES_THAT_CAUSE_REINIT =
-            Block.UPDATE_INPUTS_FIELDS | Block.UPDATE_IS_COLLAPSED | Block.UPDATE_IS_DISABLED
-            | Block.UPDATE_IS_SHADOW;
+    private static final int UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS =
+            Block.UPDATE_INPUTS_FIELDS_CONNECTIONS | Block.UPDATE_IS_COLLAPSED
+            | Block.UPDATE_IS_DISABLED | Block.UPDATE_IS_SHADOW;
 
     // TODO(#86): Determine from 9-patch measurements.
     private final int mMinBlockWidth;
@@ -125,7 +125,7 @@ public class BlockView extends AbstractBlockView<InputView> {
         block.registerObserver(new Block.Observer() {
             @Override
             public void onBlockUpdated(Block block, @Block.UpdateState int updateMask) {
-                if ((updateMask & UPDATES_THAT_CAUSE_REINIT) != 0) {
+                if ((updateMask & UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS) != 0) {
                     onBlockStructureUpdated();
                 }
             }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/ConnectionManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/ConnectionManagerTest.java
@@ -149,11 +149,13 @@ public class ConnectionManagerTest {
     public void testIsConnectionAllowedNext() {
         Connection one = createConnection(0, 0,
                 Connection.CONNECTION_TYPE_NEXT, /* shadow */ false);
-        one.setInput(new Input.InputValue("test input", "" /* align */, null /* checks */));
+        one.setInput(new Input.InputValue("test input",
+                null /* fields */, "" /* align */, null /* checks */));
 
         Connection two = createConnection(0, 0,
                 Connection.CONNECTION_TYPE_NEXT, /* shadow */ false);
-        two.setInput(new Input.InputValue("test input", "" /* align */, null /* checks */));
+        two.setInput(new Input.InputValue("test input",
+                null /* fields */, "" /* align */, null /* checks */));
 
         // Don't offer to connect the bottom of a statement block to one that's already connected.
         Connection three = createConnection(0, 0,

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -313,15 +313,14 @@ public class BlockTest extends BlocklyTestCase {
     @Test
     public void testGetAllConnections() throws BlockLoadingException {
         Block block = mBlockFactory.obtainBlockFrom(new BlockTemplate().ofType("frankenblock"));
-        List<Connection> allConnections = block.getAllConnections();
+        List<Connection> allConnections = new ArrayList<>();
+        block.getAllConnections(allConnections);
         assertThat(allConnections.size()).isEqualTo(4);
 
         block = mBlockFactory.obtainBlockFrom(new BlockTemplate().ofType("frankenblock"));
         allConnections.clear();
         block.getAllConnections(allConnections);
         assertThat(allConnections.size()).isEqualTo(4);
-
-        allConnections.clear();
 
         Block ivb = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output"));
@@ -331,6 +330,7 @@ public class BlockTest extends BlocklyTestCase {
         Block smb = mBlockFactory.obtainBlockFrom(new BlockTemplate().ofType("statement_no_input"));
         block.getInputs().get(1).getConnection().connect(smb.getPreviousConnection());
 
+        allConnections.clear();
         block.getAllConnectionsRecursive(allConnections);
         assertThat(allConnections.size()).isEqualTo(9);
     }


### PR DESCRIPTION
reshape() updates the inputs and all connections with potentially new values, potentially changing the shape of the block. This method is designed be called by either the constructor or mutators.

This version has not been fully tested, but works well enough to replace the previous block construction implementation.  All old tests pass, and there is no noticeable different in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/563)
<!-- Reviewable:end -->
