### PR TITLE
Adding BlocklyController.groupAndFireEvents(..)

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -66,19 +66,12 @@ import java.util.List;
 /**
  * Controller to coordinate the state among all the major Blockly components: Workspace, Toolbox,
  * Trash, models, and views.
- *
- * Note: Only public methods should call {@link #firePendingEvents()} and only Impl methods should
- * call {@link #addPendingEvent(BlocklyEvent)}. This is to make it easier to maintain events.
  */
 public class BlocklyController {
     private static final String TAG = "BlocklyController";
 
     private static final String SNAPSHOT_BUNDLE_KEY = "com.google.blockly.snapshot";
     private static final String SERIALIZED_WORKSPACE_KEY = "SERIALIZED_WORKSPACE";
-
-    // Debugging flag to enable the check whether mPendingEvents is empty at the beginning of public
-    // method calls..
-    private static final boolean DEBUG_CHECK_EVENT_GROUP = true;
 
     /**
      * Callback interface for {@link BlocklyEvent}s.
@@ -572,7 +565,7 @@ public class BlocklyController {
             throw new IllegalArgumentException("New root block must not be connected.");
         }
 
-        final BlockGroup newRootGroup[] = new BlockGroup[1];
+        final BlockGroup newRootGroup[] = new BlockGroup[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -668,7 +661,7 @@ public class BlocklyController {
      * @return The actual variable name that was created.
      */
     public String addVariable(final String variable) {
-        final String[] resultVarName = new String[1];
+        final String[] resultVarName = new String[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -688,7 +681,7 @@ public class BlocklyController {
      * @return The variable name that was created or null if creation was not allowed.
      */
     public String requestAddVariable(final String variable) {
-        final String resultVarName[] = new String[1];
+        final String resultVarName[] = new String[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -706,7 +699,7 @@ public class BlocklyController {
      * @return True if the variable existed and was deleted, false otherwise.
      */
     public boolean deleteVariable(final String variable) {
-        final boolean resultSuccess[] = new boolean[1];
+        final boolean resultSuccess[] = new boolean[] { false };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -725,7 +718,7 @@ public class BlocklyController {
      * @return True if the variable existed and was deleted, false otherwise.
      */
     public boolean requestDeleteVariable(final String variable) {
-        final boolean[] resultSuccess = new boolean[1];
+        final boolean[] resultSuccess = new boolean[] { false };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -746,7 +739,7 @@ public class BlocklyController {
      * @return The new variable name that was saved.
      */
     public String renameVariable(final String variable, final String newVariable) {
-        final String resultVarName[] = new String[1];
+        final String resultVarName[] = new String[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -768,7 +761,7 @@ public class BlocklyController {
      * @return The new variable name that was saved.
      */
     public String requestRenameVariable(final String variable, final String newVariable) {
-        final String resultVarName[] = new String[1];
+        final String resultVarName[] = new String[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -865,7 +858,7 @@ public class BlocklyController {
      */
     // TODO(#493): Sound Effect.
     public boolean trashRootBlock(final Block block) {
-        final boolean rootFoundAndRemoved[] = new boolean[1];
+        final boolean rootFoundAndRemoved[] = new boolean[] { false };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -884,7 +877,7 @@ public class BlocklyController {
      * @return True if the block was removed, false otherwise.
      */
     public boolean trashRootBlockIgnoringDeletable(final Block block) {
-        final boolean rootFoundAndRemoved[] = new boolean[1];
+        final boolean rootFoundAndRemoved[] = new boolean[] { false };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -938,7 +931,7 @@ public class BlocklyController {
      * @throws IllegalArgumentException If {@code trashedBlock} is not found in the trashed blocks.
      */
     public BlockGroup addBlockFromTrash(final @NonNull Block previouslyTrashedBlock) {
-        final BlockGroup trashedGroupRoot[] = new BlockGroup[1];
+        final BlockGroup trashedGroupRoot[] = new BlockGroup[] { null };
         groupAndFireEvents(new Runnable() {
             @Override
             public void run() {
@@ -1765,12 +1758,6 @@ public class BlocklyController {
 
         mPendingEvents.clear();
         mPendingEventsMask = 0;
-    }
-
-    private void checkPendingEventsEmpty() {
-        if (DEBUG_CHECK_EVENT_GROUP && !mPendingEvents.isEmpty()) {
-            throw new IllegalStateException("Expecting empty mPendingEvents.");
-        }
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -66,6 +66,10 @@ import java.util.List;
 /**
  * Controller to coordinate the state among all the major Blockly components: Workspace, Toolbox,
  * Trash, models, and views.
+ * <p/>
+ * All calls are expected to be called in the main thread/looper, because they create events that
+ * are processed immediately. Several methods will throw an IllegalStateExceptions if called on a
+ * different thread.
  */
 public class BlocklyController {
     private static final String TAG = "BlocklyController";

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -99,6 +100,7 @@ public class BlocklyController {
     }
 
     private final Context mContext;
+    private final Looper mMainLooper;
     private final BlockFactory mModelFactory;
     private final BlockViewFactory mViewFactory;
     private final WorkspaceHelper mHelper;
@@ -108,6 +110,11 @@ public class BlocklyController {
     private final ConnectionManager mConnectionManager;
     private final ArrayList<EventsCallback> mListeners = new ArrayList<>();
     private final ArrayList<BlocklyEvent> mPendingEvents = new ArrayList<>();
+
+    // Whether the current call stack is actively executing code intended to group and fire events.
+    // See groupAndFireEvents(Runnable)
+    private boolean mInEventGroup = false;
+
     private int mPendingEventsMask = 0;
     private int mEventCallbackMask = 0;
 
@@ -203,6 +210,7 @@ public class BlocklyController {
             throw new IllegalArgumentException("BlockClipDataHelper may not be null.");
         }
         mContext = context;
+        mMainLooper = context.getMainLooper();
         mModelFactory = blockModelFactory;
         mHelper = workspaceHelper;
         mViewFactory = blockViewFactory;
@@ -504,24 +512,76 @@ public class BlocklyController {
     }
 
     /**
+     * Runs a segment of code (immediately) such that all events caused by the changes are collected
+     * into a single event group, and the group of events generated in that code is notified to
+     * {@link EventsCallback}s at the completion of the code. If a {@code groupAndFireEvents()} call
+     * is already in progress, the new code will integrate into that event group. This will catch
+     * side-effect changes, such as block bumps or validation updates.
+     * <p/>
+     * {@code groupAndFireEvents()} must be called from the main thread/looper.
+     */
+    public void groupAndFireEvents(final Runnable runnable) {
+        if (mMainLooper != Looper.myLooper()) {
+            throw new IllegalStateException(
+                    "groupAndFireEvents() must be called from main thread.");
+        }
+        if (mInEventGroup) {
+            // We are already within an event group.  Execute immediately.
+            runnable.run();
+        } else {
+            // Start a new event group, firing events when done.
+            try {
+                mInEventGroup = true;
+                runnable.run();
+            } finally {
+                firePendingEvents();
+                mInEventGroup = false;
+            }
+        }
+    }
+
+    /**
+     * Adds {@code event} to the list of pending events. If this is called outside of a call to
+     * {@link #groupAndFireEvents}, the event will be fired immediately, as its own group.
+     * <p/>
+     * {@code addPendingEvent()} must be called from the main thread/looper.
+     *
+     * @param event The event to append.
+     */
+    public void addPendingEvent(BlocklyEvent event) {
+        if (mMainLooper != Looper.myLooper()) {
+            throw new IllegalStateException("addPendingEvent() must be called from main thread.");
+        }
+        mPendingEvents.add(event);
+        mPendingEventsMask |= event.getTypeId();
+
+        if (!mInEventGroup) {
+            // Outside a prior event group.  Fire immediately.
+            firePendingEvents();
+        }
+    }
+
+    /**
      * Adds the provided block to the list of root blocks.  If the controller has an initialized
      * {@link WorkspaceView}, it will also create corresponding views.
      *
      * @param block The {@link Block} to add to the workspace.
      */
-    public BlockGroup addRootBlock(Block block) {
-        checkPendingEventsEmpty();
-
+    public BlockGroup addRootBlock(final Block block) {
         if (block.getParentBlock() != null) {
             throw new IllegalArgumentException("New root block must not be connected.");
         }
 
-        BlockGroup parentGroup = mHelper.getParentBlockGroup(block);
-        BlockGroup newRootGroup =
-                addRootBlockImpl(block, parentGroup, /* is new BlockView? */ parentGroup == null);
-
-        firePendingEvents();
-        return newRootGroup;
+        final BlockGroup newRootGroup[] = new BlockGroup[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                BlockGroup parentGroup = mHelper.getParentBlockGroup(block);
+                newRootGroup[0] = addRootBlockImpl(
+                        block, parentGroup, /* is new BlockView? */ parentGroup == null);
+            }
+        });
+        return newRootGroup[0];
     }
 
     /**
@@ -530,10 +590,13 @@ public class BlocklyController {
      *
      * @param block {@link Block} to extract as a root block in the workspace.
      */
-    public void extractBlockAsRoot(Block block) {
-        checkPendingEventsEmpty();
-        extractBlockAsRootImpl(block, false);
-        firePendingEvents();
+    public void extractBlockAsRoot(final Block block) {
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                extractBlockAsRootImpl(block, false);
+            }
+        });
     }
 
     /**
@@ -604,11 +667,15 @@ public class BlocklyController {
      * @param variable The desired name of the variable to create.
      * @return The actual variable name that was created.
      */
-    public String addVariable(String variable) {
-        checkPendingEventsEmpty();
-        String result = addVariableImpl(variable, true);
-        firePendingEvents();
-        return result;
+    public String addVariable(final String variable) {
+        final String[] resultVarName = new String[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultVarName[0] = addVariableImpl(variable, true);
+            }
+        });
+        return resultVarName[0];
     }
 
     /**
@@ -620,11 +687,15 @@ public class BlocklyController {
      * @param variable The desired name of the variable to create.
      * @return The variable name that was created or null if creation was not allowed.
      */
-    public String requestAddVariable(String variable) {
-        checkPendingEventsEmpty();
-        String result = addVariableImpl(variable, false);
-        firePendingEvents();
-        return result;
+    public String requestAddVariable(final String variable) {
+        final String resultVarName[] = new String[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultVarName[0] = addVariableImpl(variable, false);
+            }
+        });
+        return resultVarName[0];
     }
 
     /**
@@ -634,11 +705,15 @@ public class BlocklyController {
      *
      * @return True if the variable existed and was deleted, false otherwise.
      */
-    public boolean deleteVariable(String variable) {
-        checkPendingEventsEmpty();
-        boolean result = deleteVariableImpl(variable, true);
-        firePendingEvents();
-        return result;
+    public boolean deleteVariable(final String variable) {
+        final boolean resultSuccess[] = new boolean[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultSuccess[0] = deleteVariableImpl(variable, true);
+            }
+        });
+        return resultSuccess[0];
     }
 
     /**
@@ -649,11 +724,15 @@ public class BlocklyController {
      * @param variable The variable to delete.
      * @return True if the variable existed and was deleted, false otherwise.
      */
-    public boolean requestDeleteVariable(String variable) {
-        checkPendingEventsEmpty();
-        boolean result = deleteVariableImpl(variable, false);
-        firePendingEvents();
-        return result;
+    public boolean requestDeleteVariable(final String variable) {
+        final boolean[] resultSuccess = new boolean[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultSuccess[0] = deleteVariableImpl(variable, false);
+            }
+        });
+        return resultSuccess[0];
     }
 
     /**
@@ -666,11 +745,15 @@ public class BlocklyController {
      *
      * @return The new variable name that was saved.
      */
-    public String renameVariable(String variable, String newVariable) {
-        checkPendingEventsEmpty();
-        String result = renameVariableImpl(variable, newVariable, true);
-        firePendingEvents();
-        return result;
+    public String renameVariable(final String variable, final String newVariable) {
+        final String resultVarName[] = new String[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultVarName[0] = renameVariableImpl(variable, newVariable, true);
+            }
+        });
+        return resultVarName[0];
     }
 
     /**
@@ -684,11 +767,15 @@ public class BlocklyController {
      *
      * @return The new variable name that was saved.
      */
-    public String requestRenameVariable(String variable, String newVariable) {
-        checkPendingEventsEmpty();
-        String result = renameVariableImpl(variable, newVariable, false);
-        firePendingEvents();
-        return result;
+    public String requestRenameVariable(final String variable, final String newVariable) {
+        final String resultVarName[] = new String[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                resultVarName[0] = renameVariableImpl(variable, newVariable, false);
+            }
+        });
+        return resultVarName[0];
     }
 
 
@@ -704,10 +791,13 @@ public class BlocklyController {
      * @param otherConnection The target {@link Connection} to connect to. This may already be
      *                        connected.
      */
-    public void connect(Connection blockConnection, Connection otherConnection) {
-        checkPendingEventsEmpty();
-        connectImpl(blockConnection, otherConnection);
-        firePendingEvents();
+    public void connect(final Connection blockConnection, final Connection otherConnection) {
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                connectImpl(blockConnection, otherConnection);
+            }
+        });
     }
 
     /**
@@ -716,10 +806,13 @@ public class BlocklyController {
      * @param staticConnection The original connection of the block.
      * @param impingingConnection The connection of the block to offset.
      */
-    public void bumpBlock(Connection staticConnection, Connection impingingConnection) {
-        checkPendingEventsEmpty();
-        bumpBlockImpl(staticConnection, impingingConnection);
-        firePendingEvents();
+    public void bumpBlock(final Connection staticConnection, final Connection impingingConnection) {
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                bumpBlockImpl(staticConnection, impingingConnection);
+            }
+        });
     }
 
     /**
@@ -728,17 +821,20 @@ public class BlocklyController {
      *
      * @param currentBlock The {@link Block} to bump others away from.
      */
-    public void bumpNeighbors(Block currentBlock) {
-        checkPendingEventsEmpty();
+    public void bumpNeighbors(final Block currentBlock) {
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                BlockGroup rootBlockGroup = mHelper.getRootBlockGroup(currentBlock);
+                if (rootBlockGroup == null) {
+                    return; // Do nothing, as connection locations are determined by views.
+                }
 
-        BlockGroup rootBlockGroup = mHelper.getRootBlockGroup(currentBlock);
-        if (rootBlockGroup == null) {
-            return; // Do nothing, as connection locations are determined by views.
-        }
+                bumpNeighborsRecursively(currentBlock, rootBlockGroup);
 
-        bumpNeighborsRecursively(currentBlock, rootBlockGroup);
-
-        rootBlockGroup.requestLayout();
+                rootBlockGroup.requestLayout();
+            }
+        });
     }
 
     /**
@@ -748,10 +844,13 @@ public class BlocklyController {
      *
      * @param block The {@link Block} to look up and remove.
      */
-    public void removeBlockTree(Block block) {
-        checkPendingEventsEmpty();
-        removeBlockTreeImpl(block);
-        firePendingEvents();
+    public void removeBlockTree(final Block block) {
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                removeBlockTreeImpl(block);
+            }
+        });
     }
 
     /**
@@ -765,11 +864,15 @@ public class BlocklyController {
      * @return True if the block was removed, false otherwise.
      */
     // TODO(#493): Sound Effect.
-    public boolean trashRootBlock(Block block) {
-        checkPendingEventsEmpty();
-        boolean rootFoundAndRemoved = trashRootBlockImpl(block, true);
-        firePendingEvents(); // May not have any events to fire if block was not found.
-        return rootFoundAndRemoved;
+    public boolean trashRootBlock(final Block block) {
+        final boolean rootFoundAndRemoved[] = new boolean[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                rootFoundAndRemoved[0] = trashRootBlockImpl(block, true);
+            }
+        });
+        return rootFoundAndRemoved[0];
     }
 
     /**
@@ -780,11 +883,15 @@ public class BlocklyController {
      * @param block The block to remove, possibly with descendants attached.
      * @return True if the block was removed, false otherwise.
      */
-    public boolean trashRootBlockIgnoringDeletable(Block block) {
-        checkPendingEventsEmpty();
-        boolean rootFoundAndRemoved = trashRootBlockImpl(block, false);
-        firePendingEvents(); // May not have any events to fire if block was not found.
-        return rootFoundAndRemoved;
+    public boolean trashRootBlockIgnoringDeletable(final Block block) {
+        final boolean rootFoundAndRemoved[] = new boolean[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                rootFoundAndRemoved[0] = trashRootBlockImpl(block, false);
+            }
+        });
+        return rootFoundAndRemoved[0];
     }
 
     /**
@@ -830,11 +937,15 @@ public class BlocklyController {
      *
      * @throws IllegalArgumentException If {@code trashedBlock} is not found in the trashed blocks.
      */
-    public BlockGroup addBlockFromTrash(@NonNull Block previouslyTrashedBlock) {
-        checkPendingEventsEmpty();
-        BlockGroup trashedGroupRoot = addBlockFromTrashImpl(previouslyTrashedBlock);
-        firePendingEvents();  // May not have any events to fire if block was not found in the trash
-        return trashedGroupRoot;
+    public BlockGroup addBlockFromTrash(final @NonNull Block previouslyTrashedBlock) {
+        final BlockGroup trashedGroupRoot[] = new BlockGroup[1];
+        groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                trashedGroupRoot[0] = addBlockFromTrashImpl(previouslyTrashedBlock);
+            }
+        });
+        return trashedGroupRoot[0];
     }
 
     /**
@@ -1632,11 +1743,6 @@ public class BlocklyController {
 
     private boolean hasCallback(@BlocklyEvent.EventType int typeQueryBitMask) {
         return (mEventCallbackMask & typeQueryBitMask) != 0;
-    }
-
-    private void addPendingEvent(BlocklyEvent event) {
-        mPendingEvents.add(event);
-        mPendingEventsMask |= event.getTypeId();
     }
 
     private void recalculateListenerEventMask() {

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
@@ -26,6 +26,11 @@ import com.google.blockly.android.ui.vertical.R;
  * Base class for Android tests with Mockito.
  */
 public class BlocklyTestCase {
+    /**
+     * Default timeout of 1 second, which should be plenty for most UI actions.  Anything longer
+     * is an error.  However, to step through this code with a debugger, use a much longer duration.
+     */
+    protected static final long TEST_TIMEOUT_MILLIS = 1000L;
 
     private Context mThemeContext;
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/BlocklyControllerTest.java
@@ -15,6 +15,10 @@
 
 package com.google.blockly.android.control;
 
+import android.content.Context;
+import android.os.Handler;
+import android.os.HandlerThread;
+
 import com.google.blockly.android.BlocklyTestCase;
 import com.google.blockly.android.test.R;
 import com.google.blockly.android.testui.TestableBlockGroup;
@@ -37,17 +41,27 @@ import com.google.blockly.utils.BlockLoadingException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.AdditionalAnswers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for {@link BlocklyController}.
  */
 public class BlocklyControllerTest extends BlocklyTestCase {
+    private HandlerThread mThread;
+    private Handler mHandler;
+    private Context mMockContext;
+    private Throwable mExceptionInThread = null;
+
     // Controller under test.
     BlocklyController mController;
     BlockFactory mBlockFactory;
@@ -76,9 +90,16 @@ public class BlocklyControllerTest extends BlocklyTestCase {
     public void setUp() throws Exception {
         configureForThemes();
         configureForUIThread();
-        mHelper = new WorkspaceHelper(getContext());
-        mViewFactory = new TestableBlockViewFactory(getContext(), mHelper);
-        mController = new BlocklyController.Builder(getContext())
+        mThread = new HandlerThread("BlocklyControllerTest");
+        mThread.start();
+        mHandler = new Handler(mThread.getLooper());
+
+        mMockContext = mock(Context.class, AdditionalAnswers.delegatesTo(getContext()));
+        doReturn(mThread.getLooper()).when(mMockContext).getMainLooper();
+
+        mHelper = new WorkspaceHelper(mMockContext);
+        mViewFactory = new TestableBlockViewFactory(mMockContext, mHelper);
+        mController = new BlocklyController.Builder(mMockContext)
                 .setWorkspaceHelper(mHelper)
                 .setBlockViewFactory(mViewFactory)
                 .addBlockDefinitions(R.raw.test_blocks)
@@ -96,75 +117,105 @@ public class BlocklyControllerTest extends BlocklyTestCase {
     public void testAddRootBlock() throws BlockLoadingException {
         assertThat(mEventsFired.isEmpty()).isTrue();
 
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        mController.addRootBlock(block);
 
-        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
-        assertThat(1).isEqualTo(mEventsFired.size());
-        assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
-        assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addRootBlock(block);
+
+                assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+                assertThat(1).isEqualTo(mEventsFired.size());
+                assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
+                assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
+            }
+        });
     }
 
     @Test
     public void testTrashRootBlock() throws BlockLoadingException {
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        mController.addRootBlock(block);
 
-        mEventsFired.clear();
-        assertThat(mController.trashRootBlock(block)).isTrue();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addRootBlock(block);
 
-        assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
-        assertThat(mEventsFired.size()).isEqualTo(1);
-        assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
-        assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
+                mEventsFired.clear();
+                assertThat(mController.trashRootBlock(block)).isTrue();
+
+                assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
+                assertThat(mEventsFired.size()).isEqualTo(1);
+                assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
+                assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
+            }
+        });
     }
 
     @Test
     public void testTrashRootBlockNotDeletable() throws BlockLoadingException {
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        block.setDeletable(false);
-        mController.addRootBlock(block);
 
-        mEventsFired.clear();
-        assertThat(mController.trashRootBlock(block)).isFalse();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                block.setDeletable(false);
+                mController.addRootBlock(block);
 
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);  // Still there!
-        assertThat(mEventsFired.size()).isEqualTo(0);
+                mEventsFired.clear();
+                assertThat(mController.trashRootBlock(block)).isFalse();
+
+                assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);  // Still there!
+                assertThat(mEventsFired.size()).isEqualTo(0);
+            }
+        });
     }
 
     @Test
     public void testTrashRootBlockIgnoringDeletable() throws BlockLoadingException {
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        block.setDeletable(false);
-        mController.addRootBlock(block);
 
-        mEventsFired.clear();
-        assertThat(mController.trashRootBlockIgnoringDeletable(block)).isTrue();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                block.setDeletable(false);
+                mController.addRootBlock(block);
 
-        assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
-        assertThat(mEventsFired.size()).isEqualTo(1);
-        assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
-        assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
+                mEventsFired.clear();
+                assertThat(mController.trashRootBlockIgnoringDeletable(block)).isTrue();
+
+                assertThat(mWorkspace.getRootBlocks().isEmpty()).isTrue();
+                assertThat(mEventsFired.size()).isEqualTo(1);
+                assertThat(mEventsFired.get(0).getTypeId()).isEqualTo(BlocklyEvent.TYPE_DELETE);
+                assertThat(mEventsFired.get(0).getBlockId()).isEqualTo(block.getId());
+            }
+        });
     }
 
     @Test
     public void testAddBlockFromTrash() throws BlockLoadingException {
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        mController.addRootBlock(block);
-        mController.trashRootBlock(block);
 
-        mEventsFired.clear();
-        mController.addBlockFromTrash(block);
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addRootBlock(block);
+                mController.trashRootBlock(block);
 
-        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
-        assertThat(1).isEqualTo(mEventsFired.size());
-        assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
-        assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
+                mEventsFired.clear();
+                mController.addBlockFromTrash(block);
+
+                assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+                assertThat(1).isEqualTo(mEventsFired.size());
+                assertThat(BlocklyEvent.TYPE_CREATE).isEqualTo(mEventsFired.get(0).getTypeId());
+                assertThat(block.getId()).isEqualTo(mEventsFired.get(0).getBlockId());
+            }
+        });
     }
 
     @Test
@@ -177,70 +228,75 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_outputToInput(true);
     }
 
-    private void testConnect_outputToInput(boolean withViews) throws BlockLoadingException {
+    private void testConnect_outputToInput(final boolean withViews) throws BlockLoadingException {
         // Setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectTarget"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("connectSource"));
-        Connection targetConnection = target.getOnlyValueInput().getConnection();
-        Connection sourceConnection = source.getOutputConnection();
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(target).withId("connectShadow"));
+        final Connection targetConnection = target.getOnlyValueInput().getConnection();
+        final Connection sourceConnection = source.getOutputConnection();
 
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
 
-            // Validate initial view state.
-            BlockView targetView = mHelper.getView(target);
-            BlockView sourceView = mHelper.getView(source);
-            assertThat(targetView).isNotNull();
-            assertThat(sourceView).isNotNull();
-            assertThat(mHelper.getRootBlockGroup(target))
-                .isNotSameAs(mHelper.getRootBlockGroup(source));
-        }
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-        // Perform test: connection source's output to target's input.
-        mController.connect(sourceConnection, targetConnection);
+                    // Validate initial view state.
+                    BlockView targetView = mHelper.getView(target);
+                    BlockView sourceView = mHelper.getView(source);
+                    assertThat(targetView).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                    assertThat(mHelper.getRootBlockGroup(target))
+                            .isNotSameAs(mHelper.getRootBlockGroup(source));
+                }
 
-        // Validate model changes.
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(sourceConnection.getTargetBlock());
+                // Perform test: connection source's output to target's input.
+                mController.connect(sourceConnection, targetConnection);
 
-        if (withViews) {
-            // Validate view changes
-            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
-        }
+                // Validate model changes.
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(sourceConnection.getTargetBlock());
 
-        // Add the shadow connection and disconnect the block
-        targetConnection.setShadowConnection(shadow.getOutputConnection());
-        mController.extractBlockAsRoot(source);
-        assertThat(source.getParentBlock()).isNull();
-        // Validate the block was replaced by the shadow
-        assertThat(shadow).isEqualTo(targetConnection.getTargetBlock());
+                if (withViews) {
+                    // Validate view changes
+                    BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                }
 
-        if (withViews) {
-            // Check that the shadow block now has views
-            assertThat(mHelper.getView(shadow)).isNotNull();
-            BlockGroup shadowGroup = mHelper.getParentBlockGroup(target);
-            assertThat(shadowGroup).isSameAs(mHelper.getRootBlockGroup(shadow));
-        }
+                // Add the shadow connection and disconnect the block
+                targetConnection.setShadowConnection(shadow.getOutputConnection());
+                mController.extractBlockAsRoot(source);
+                assertThat(source.getParentBlock()).isNull();
+                // Validate the block was replaced by the shadow
+                assertThat(shadow).isEqualTo(targetConnection.getTargetBlock());
 
-        // Reattach the block and verify the shadow is hidden again
-        mController.connect(sourceConnection, targetConnection);
-        assertThat(source).isEqualTo(targetConnection.getTargetBlock());
-        assertThat(shadow.getOutputConnection().getTargetBlock()).isNull();
+                if (withViews) {
+                    // Check that the shadow block now has views
+                    assertThat(mHelper.getView(shadow)).isNotNull();
+                    BlockGroup shadowGroup = mHelper.getParentBlockGroup(target);
+                    assertThat(shadowGroup).isSameAs(mHelper.getRootBlockGroup(shadow));
+                }
 
-        if (withViews) {
-            assertThat(mHelper.getView(shadow)).isNull();
-        }
+                // Reattach the block and verify the shadow is hidden again
+                mController.connect(sourceConnection, targetConnection);
+                assertThat(source).isEqualTo(targetConnection.getTargetBlock());
+                assertThat(shadow.getOutputConnection().getTargetBlock()).isNull();
+
+                if (withViews) {
+                    assertThat(mHelper.getView(shadow)).isNull();
+                }
+            }
+        });
     }
 
     @Test
@@ -253,60 +309,65 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_outputToInputBumpNoInput(true);
     }
 
-    private void testConnect_outputToInputBumpNoInput(boolean withViews)
+    private void testConnect_outputToInputBumpNoInput(final boolean withViews)
             throws BlockLoadingException {
         // Setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("output_no_input").withId("source"));
 
-        // Connect the output of tail to the input of target.
-        target.getOnlyValueInput().getConnection().connect(tail.getOutputConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                // Connect the output of tail to the input of target.
+                target.getOnlyValueInput().getConnection().connect(tail.getOutputConnection());
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
+                }
 
-        // Validate preconditions
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isTrue();
+                // Validate preconditions
+                assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isTrue();
 
-        // Perform test: Connect the source to where the tail is currently attached.
-        mController.connect(
-                source.getOutputConnection(), target.getOnlyValueInput().getConnection());
+                // Perform test: Connect the source to where the tail is currently attached.
+                mController.connect(
+                        source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
-        // source is now a child of target, and tail is a new root block
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
-        assertThat(target).isSameAs(target.getRootBlock());
-        assertThat(target).isSameAs(source.getRootBlock());
-        assertThat(tail).isSameAs(tail.getRootBlock());
-        assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
+                // source is now a child of target, and tail is a new root block
+                assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(mWorkspace.isRootBlock(tail)).isTrue();
+                assertThat(target).isSameAs(target.getRootBlock());
+                assertThat(target).isSameAs(source.getRootBlock());
+                assertThat(tail).isSameAs(tail.getRootBlock());
+                assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
 
-        if (withViews) {
-            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(targetGroup).isNotSameAs(tailGroup);
+                if (withViews) {
+                    BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+                    BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(targetGroup).isNotSameAs(tailGroup);
 
-            // Check that tail has been bumped far enough away.
-            double connectionDist =
-                    tail.getOutputConnection().distanceFrom(source.getOutputConnection());
-            assertThat(connectionDist).named("bumped connection distance")
-                    .isGreaterThan((double) mHelper.getMaxSnapDistance());
-        }
+                    // Check that tail has been bumped far enough away.
+                    double connectionDist =
+                            tail.getOutputConnection().distanceFrom(source.getOutputConnection());
+                    assertThat(connectionDist).named("bumped connection distance")
+                            .isGreaterThan((double) mHelper.getMaxSnapDistance());
+                }
+            }
+        });
     }
 
     @Test
@@ -321,57 +382,62 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_outputToInputBumpMultipleInputs(true);
     }
 
-    private void testConnect_outputToInputBumpMultipleInputs(boolean withViews)
+    private void testConnect_outputToInputBumpMultipleInputs(final boolean withViews)
             throws BlockLoadingException {
         // Setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("multiple_input_output").withId("source"));
 
-        // Connect the output of tail to the input of target.
-        tail.getOutputConnection().connect(target.getOnlyValueInput().getConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                // Connect the output of tail to the input of target.
+                tail.getOutputConnection().connect(target.getOnlyValueInput().getConnection());
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
+                }
 
-        // Perform test: Connect the source to where the tail is currently attached.
-        mController.connect(
-                source.getOutputConnection(), target.getOnlyValueInput().getConnection());
+                // Perform test: Connect the source to where the tail is currently attached.
+                mController.connect(
+                        source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
-        // Source is now a child of target
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
-        assertThat(target).isSameAs(source.getRootBlock());
+                // Source is now a child of target
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
+                assertThat(target).isSameAs(source.getRootBlock());
 
-        // Tail has been returned to the workspace root, bumped some distance.
-        assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
-        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
+                // Tail has been returned to the workspace root, bumped some distance.
+                assertThat(tail.getOutputConnection().getTargetBlock()).isNull();
+                assertThat(mWorkspace.isRootBlock(tail)).isTrue();
 
-        if (withViews) {
-            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
+                if (withViews) {
+                    BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+                    BlockGroup tailGroup = mHelper.getParentBlockGroup(tail);
 
-            targetGroup.updateAllConnectorLocations();
-            tailGroup.updateAllConnectorLocations();
+                    targetGroup.updateAllConnectorLocations();
+                    tailGroup.updateAllConnectorLocations();
 
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(targetGroup).isNotSameAs(tailGroup);
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(tailGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(targetGroup).isNotSameAs(tailGroup);
 
-            double connectionDist =
-                    source.getOutputConnection().distanceFrom(tail.getOutputConnection());
-            assertThat(connectionDist).named("bumped connection distance")
-                    .isGreaterThan((double) mHelper.getMaxSnapDistance());
-        }
+                    double connectionDist =
+                            source.getOutputConnection().distanceFrom(tail.getOutputConnection());
+                    assertThat(connectionDist).named("bumped connection distance")
+                            .isGreaterThan((double) mHelper.getMaxSnapDistance());
+                }
+            }
+        });
     }
 
     @Test
@@ -386,59 +452,64 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_outputToInputShadowSplice(true);
     }
 
-    private void testConnect_outputToInputShadowSplice(boolean withViews)
+    private void testConnect_outputToInputShadowSplice(final boolean withViews)
             throws BlockLoadingException {
         // Setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(source).withId("shadow"));
-        Connection sourceInputConnection = source.getOnlyValueInput().getConnection();
+        final Connection sourceInputConnection = source.getOnlyValueInput().getConnection();
 
-        // Connect the output of tail to the input of target.
-        target.getOnlyValueInput().getConnection().connect(tail.getOutputConnection());
-        // Add the shadow to the source
-        sourceInputConnection.setShadowConnection(shadow.getOutputConnection());
-        sourceInputConnection.connect(shadow.getOutputConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                // Connect the output of tail to the input of target.
+                target.getOnlyValueInput().getConnection().connect(tail.getOutputConnection());
+                // Add the shadow to the source
+                sourceInputConnection.setShadowConnection(shadow.getOutputConnection());
+                sourceInputConnection.connect(shadow.getOutputConnection());
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
+                }
 
-        // Validate preconditions
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isTrue();
+                // Validate preconditions
+                assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(2);
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isTrue();
 
-        // Perform test: Connect the source to where the tail is currently attached.
-        mController.connect(
-                source.getOutputConnection(), target.getOnlyValueInput().getConnection());
+                // Perform test: Connect the source to where the tail is currently attached.
+                mController.connect(
+                        source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
-        // source is now a child of target, and tail replaced the shadow
-        assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(target).isSameAs(target.getRootBlock());
-        assertThat(target).isSameAs(source.getRootBlock());
-        assertThat(target).isSameAs(tail.getRootBlock());
-        assertThat(source).isSameAs(tail.getParentBlock());
+                // source is now a child of target, and tail replaced the shadow
+                assertThat(mWorkspace.getRootBlocks().size()).isEqualTo(1);
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(target).isSameAs(target.getRootBlock());
+                assertThat(target).isSameAs(source.getRootBlock());
+                assertThat(target).isSameAs(tail.getRootBlock());
+                assertThat(source).isSameAs(tail.getParentBlock());
 
-        if (withViews) {
-            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(mHelper.getView(shadow)).isNull();
-        }
+                if (withViews) {
+                    BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(mHelper.getView(shadow)).isNull();
+                }
+            }
+        });
     }
 
     @Test
@@ -451,48 +522,54 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_outputToInputSplice(true);
     }
 
-    private void testConnect_outputToInputSplice(boolean withViews) throws BlockLoadingException {
+    private void testConnect_outputToInputSplice(final boolean withViews)
+            throws BlockLoadingException {
         // Setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("multiple_input_output").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(tail).withId("shadow"));
 
-        // Add a hidden shadow to the target to ensure it has no effect.
-        target.getOnlyValueInput().getConnection()
-                .setShadowConnection(shadow.getOutputConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                // Add a hidden shadow to the target to ensure it has no effect.
+                target.getOnlyValueInput().getConnection()
+                        .setShadowConnection(shadow.getOutputConnection());
 
-        // Connect the output of tail to the input of source.
-        tail.getOutputConnection().connect(target.getOnlyValueInput().getConnection());
+                // Connect the output of tail to the input of source.
+                tail.getOutputConnection().connect(target.getOnlyValueInput().getConnection());
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
+                }
 
-        // Splice third between second and first.
-        mController.connect(
-                source.getOutputConnection(), target.getOnlyValueInput().getConnection());
+                // Splice third between second and first.
+                mController.connect(
+                        source.getOutputConnection(), target.getOnlyValueInput().getConnection());
 
-        // Validate
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
-        assertThat(source).isSameAs(tail.getOutputConnection().getTargetBlock());
+                // Validate
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(source.getOutputConnection().getTargetBlock());
+                assertThat(source).isSameAs(tail.getOutputConnection().getTargetBlock());
 
-        if (withViews) {
-            BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
-        }
+                if (withViews) {
+                    BlockGroup targetGroup = mHelper.getParentBlockGroup(target);
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(target));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(targetGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                }
+            }
+        });
     }
 
     @Test
@@ -505,68 +582,74 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToNext(true);
     }
 
-    private void testConnect_previousToNext(boolean withViews) throws BlockLoadingException {
+    private void testConnect_previousToNext(final boolean withViews) throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("target"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(target).withId("connectShadow"));
-        BlockView targetView = null, sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView targetView = null, sourceView = null;
 
-            targetView = mHelper.getView(target);
-            sourceView = mHelper.getView(source);
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-            assertThat(targetView).isNotNull();
-            assertThat(sourceView).isNotNull();
-        }
+                    targetView = mHelper.getView(target);
+                    sourceView = mHelper.getView(source);
 
-        // Connect source after target. No prior connection to bump or splice.
-        mController.connect(source.getPreviousConnection(), target.getNextConnection());
+                    assertThat(targetView).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                }
 
-        // Validate
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(source.getPreviousBlock());
+                // Connect source after target. No prior connection to bump or splice.
+                mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
-        if (withViews) {
-            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
-            assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
-            assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));
-        }
+                // Validate
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(source.getPreviousBlock());
 
-        // Add the shadow to the target's next connection so the view will be created.
-        target.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
-        mController.extractBlockAsRoot(source);
+                if (withViews) {
+                    BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
+                    assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
+                    assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));
+                }
 
-        assertThat(mWorkspace.isRootBlock(source)).isTrue();
-        assertThat(target.getNextBlock()).isSameAs(shadow);
+                // Add the shadow to the target's next connection so the view will be created.
+                target.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
+                mController.extractBlockAsRoot(source);
 
-        if (withViews) {
-            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(shadow));
-            assertThat(rootGroup).isNotSameAs(mHelper.getParentBlockGroup(source));
-            assertThat(mHelper.getView(shadow)).isSameAs(rootGroup.getChildAt(1));
-        }
+                assertThat(mWorkspace.isRootBlock(source)).isTrue();
+                assertThat(target.getNextBlock()).isSameAs(shadow);
 
-        // Reattach the source and verify the shadow went away.
-        mController.connect(source.getPreviousConnection(), target.getNextConnection());
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target.getNextBlock()).isSameAs(source);
-        assertThat(shadow.getPreviousBlock()).isNull();
+                if (withViews) {
+                    BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(shadow));
+                    assertThat(rootGroup).isNotSameAs(mHelper.getParentBlockGroup(source));
+                    assertThat(mHelper.getView(shadow)).isSameAs(rootGroup.getChildAt(1));
+                }
 
-        if (withViews) {
-            assertThat(mHelper.getView(shadow)).isNull();
-        }
+                // Reattach the source and verify the shadow went away.
+                mController.connect(source.getPreviousConnection(), target.getNextConnection());
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target.getNextBlock()).isSameAs(source);
+                assertThat(shadow.getPreviousBlock()).isNull();
+
+                if (withViews) {
+                    assertThat(mHelper.getView(shadow)).isNull();
+                }
+            }
+        });
     }
 
     @Test
@@ -579,53 +662,59 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToNextSplice(true);
     }
 
-    private void testConnect_previousToNextSplice(boolean withViews) throws BlockLoadingException {
+    private void testConnect_previousToNextSplice(final boolean withViews) throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().ofType("statement_no_input").withId("shadowTail"));
-        BlockView targetView = null, tailView = null, sourceView = null;
 
-        // Add a shadow to make sure it doesn't have any effects.
-        Connection targetNext = target.getNextConnection();
-        targetNext.setShadowConnection(shadow.getPreviousConnection());
-        tail.getPreviousConnection().connect(targetNext);
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView targetView = null, tailView = null, sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                // Add a shadow to make sure it doesn't have any effects.
+                Connection targetNext = target.getNextConnection();
+                targetNext.setShadowConnection(shadow.getPreviousConnection());
+                tail.getPreviousConnection().connect(targetNext);
 
-            targetView = mHelper.getView(target);
-            tailView = mHelper.getView(tail);
-            sourceView = mHelper.getView(source);
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-            assertThat(targetView).isNotNull();
-            assertThat(tailView).isNotNull();
-            assertThat(sourceView).isNotNull();
-        }
+                    targetView = mHelper.getView(target);
+                    tailView = mHelper.getView(tail);
+                    sourceView = mHelper.getView(source);
 
-        // Connect source after target, where tail is currently attached, causing a splice.
-        mController.connect(source.getPreviousConnection(), target.getNextConnection());
+                    assertThat(targetView).isNotNull();
+                    assertThat(tailView).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                }
 
-        assertThat(target).isSameAs(source.getPreviousBlock());
-        assertThat(source).isSameAs(tail.getPreviousBlock());
+                // Connect source after target, where tail is currently attached, causing a splice.
+                mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
-        if (withViews) {
-            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
-            assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
-            assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));  // Spliced in between.
-            assertThat(tailView).isSameAs(rootGroup.getChildAt(2));
-        }
+                assertThat(target).isSameAs(source.getPreviousBlock());
+                assertThat(source).isSameAs(tail.getPreviousBlock());
+
+                if (withViews) {
+                    BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(source));
+                    assertThat(targetView).isSameAs(rootGroup.getChildAt(0));
+                    assertThat(sourceView).isSameAs(rootGroup.getChildAt(1));  // Spliced in between.
+                    assertThat(tailView).isSameAs(rootGroup.getChildAt(2));
+                }
+            }
+        });
     }
 
     @Test
@@ -638,74 +727,80 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToNextBumpRemainder(true);
     }
 
-    private void testConnect_previousToNextBumpRemainder(boolean withViews)
+    private void testConnect_previousToNextBumpRemainder(final boolean withViews)
             throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("target"));
-        Block tail1 = mBlockFactory.obtainBlockFrom(
+        final Block tail1 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("tail1"));
-        Block tail2 = mBlockFactory.obtainBlockFrom(
+        final Block tail2 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("tail2"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_next").withId("source"));
-        BlockView targetView = null, tailView1 = null, tailView2 = null, sourceView = null;
 
-        // Create a sequence of target, tail1, and tail2.
-        tail1.getPreviousConnection().connect(target.getNextConnection());
-        tail2.getPreviousConnection().connect(tail1.getNextConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView targetView = null, tailView1 = null, tailView2 = null, sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                // Create a sequence of target, tail1, and tail2.
+                tail1.getPreviousConnection().connect(target.getNextConnection());
+                tail2.getPreviousConnection().connect(tail1.getNextConnection());
 
-            targetView = mHelper.getView(target);
-            tailView1 = mHelper.getView(tail1);
-            tailView2 = mHelper.getView(tail2);
-            sourceView = mHelper.getView(source);
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-            assertThat(targetView).isNotNull();
-            assertThat(tailView1).isNotNull();
-            assertThat(tailView2).isNotNull();
-            assertThat(sourceView).isNotNull();
-        }
+                    targetView = mHelper.getView(target);
+                    tailView1 = mHelper.getView(tail1);
+                    tailView2 = mHelper.getView(tail2);
+                    sourceView = mHelper.getView(source);
 
-        // Run test: Connect source after target, where tail is currently attached.
-        // Since source does not have a next connection, bump the tail.
-        mController.connect(source.getPreviousConnection(), target.getNextConnection());
+                    assertThat(targetView).isNotNull();
+                    assertThat(tailView1).isNotNull();
+                    assertThat(tailView2).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                }
 
-        // Target and source are connected.
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(target).isSameAs(source.getPreviousBlock());
+                // Run test: Connect source after target, where tail is currently attached.
+                // Since source does not have a next connection, bump the tail.
+                mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
-        // Tail has been returned to the workspace root.
-        assertThat(mWorkspace.isRootBlock(tail1)).isTrue();
-        assertThat(tail1.getPreviousBlock()).isNull();
-        assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(tail1).isSameAs(tail1.getRootBlock());
-        assertThat(tail1).isSameAs(tail2.getRootBlock());
+                // Target and source are connected.
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(target).isSameAs(source.getPreviousBlock());
 
-        if (withViews) {
-            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
-            BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail1);
-            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
-            assertThat(tailRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
-            assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
-            assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
-            assertThat(tailView1).isSameAs(tailRootGroup.getChildAt(0));
-            assertThat(tailView2).isSameAs(tailRootGroup.getChildAt(1));
+                // Tail has been returned to the workspace root.
+                assertThat(mWorkspace.isRootBlock(tail1)).isTrue();
+                assertThat(tail1.getPreviousBlock()).isNull();
+                assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(tail1).isSameAs(tail1.getRootBlock());
+                assertThat(tail1).isSameAs(tail2.getRootBlock());
 
-            // Check that tail has been bumped far enough away.
-            double connectionDistance =
-                    tail1.getPreviousConnection().distanceFrom(target.getNextConnection());
-            assertThat(connectionDistance).named("bumped connection distance")
-                    .isGreaterThan((double) mHelper.getMaxSnapDistance());
-        }
+                if (withViews) {
+                    BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+                    BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail1);
+                    assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
+                    assertThat(tailRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
+                    assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
+                    assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
+                    assertThat(tailView1).isSameAs(tailRootGroup.getChildAt(0));
+                    assertThat(tailView2).isSameAs(tailRootGroup.getChildAt(1));
+
+                    // Check that tail has been bumped far enough away.
+                    double connectionDistance =
+                            tail1.getPreviousConnection().distanceFrom(target.getNextConnection());
+                    assertThat(connectionDistance).named("bumped connection distance")
+                            .isGreaterThan((double) mHelper.getMaxSnapDistance());
+                }
+            }
+        });
     }
 
 
@@ -719,76 +814,82 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToNextShadowSplice(true);
     }
 
-    private void testConnect_previousToNextShadowSplice(boolean withViews)
+    private void testConnect_previousToNextShadowSplice(final boolean withViews)
             throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("target"));
-        Block tail1 = mBlockFactory.obtainBlockFrom(
+        final Block tail1 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("tail1"));
-        Block tail2 = mBlockFactory.obtainBlockFrom(
+        final Block tail2 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("tail2"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("source"));
-        Block shadowTail = mBlockFactory.obtainBlockFrom(
+        final Block shadowTail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(tail1).withId("shadowTail"));
-        BlockView targetView = null, tailView1 = null, tailView2 = null, sourceView = null;
 
-        // Create a sequence of target, tail1, and tail2.
-        tail1.getPreviousConnection().connect(target.getNextConnection());
-        tail2.getPreviousConnection().connect(tail1.getNextConnection());
-        source.getNextConnection().setShadowConnection(shadowTail.getPreviousConnection());
-        source.getNextConnection().connect(shadowTail.getPreviousConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView targetView = null, tailView1 = null, tailView2 = null, sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                // Create a sequence of target, tail1, and tail2.
+                tail1.getPreviousConnection().connect(target.getNextConnection());
+                tail2.getPreviousConnection().connect(tail1.getNextConnection());
+                source.getNextConnection().setShadowConnection(shadowTail.getPreviousConnection());
+                source.getNextConnection().connect(shadowTail.getPreviousConnection());
 
-            targetView = mHelper.getView(target);
-            tailView1 = mHelper.getView(tail1);
-            tailView2 = mHelper.getView(tail2);
-            sourceView = mHelper.getView(source);
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-            assertThat(targetView).isNotNull();
-            assertThat(tailView1).isNotNull();
-            assertThat(tailView2).isNotNull();
-            assertThat(sourceView).isNotNull();
-            assertThat(mHelper.getView(shadowTail)).isNotNull();
-        }
+                    targetView = mHelper.getView(target);
+                    tailView1 = mHelper.getView(tail1);
+                    tailView2 = mHelper.getView(tail2);
+                    sourceView = mHelper.getView(source);
 
-        // Run test: Connect source after target, where tail is currently attached.
-        // Since source has a shadow connected to next, tail should replace it.
-        mController.connect(source.getPreviousConnection(), target.getNextConnection());
+                    assertThat(targetView).isNotNull();
+                    assertThat(tailView1).isNotNull();
+                    assertThat(tailView2).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                    assertThat(mHelper.getView(shadowTail)).isNotNull();
+                }
 
-        // Target and source are connected.
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(target).isSameAs(source.getPreviousBlock());
+                // Run test: Connect source after target, where tail is currently attached.
+                // Since source has a shadow connected to next, tail should replace it.
+                mController.connect(source.getPreviousConnection(), target.getNextConnection());
 
-        // Tail has replaced the shadow.
-        assertThat(mWorkspace.isRootBlock(tail1)).isFalse();
-        assertThat(shadowTail.getPreviousBlock()).isNull();
-        assertThat(source).isSameAs(tail1.getParentBlock());
-        assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(tail1.getRootBlock());
-        assertThat(target).isSameAs(tail2.getRootBlock());
+                // Target and source are connected.
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(target).isSameAs(source.getPreviousBlock());
 
-        if (withViews) {
-            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
-            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail1));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
+                // Tail has replaced the shadow.
+                assertThat(mWorkspace.isRootBlock(tail1)).isFalse();
+                assertThat(shadowTail.getPreviousBlock()).isNull();
+                assertThat(source).isSameAs(tail1.getParentBlock());
+                assertThat(mWorkspace.isRootBlock(tail2)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(tail1.getRootBlock());
+                assertThat(target).isSameAs(tail2.getRootBlock());
 
-            assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
-            assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
-            assertThat(tailView1).isSameAs(targetRootGroup.getChildAt(2));
-            assertThat(tailView2).isSameAs(targetRootGroup.getChildAt(3));
+                if (withViews) {
+                    BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+                    assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail1));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail2));
 
-            assertThat(mHelper.getView(shadowTail)).isNull();
-        }
+                    assertThat(targetView).isSameAs(targetRootGroup.getChildAt(0));
+                    assertThat(sourceView).isSameAs(targetRootGroup.getChildAt(1));
+                    assertThat(tailView1).isSameAs(targetRootGroup.getChildAt(2));
+                    assertThat(tailView2).isSameAs(targetRootGroup.getChildAt(3));
+
+                    assertThat(mHelper.getView(shadowTail)).isNull();
+                }
+            }
+        });
     }
 
     @Test
@@ -801,63 +902,69 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToStatement(true);
     }
 
-    private void testConnect_previousToStatement(boolean withViews) throws BlockLoadingException {
+    private void testConnect_previousToStatement(final boolean withViews)
+            throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("target"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(source).withId("shadow"));
 
-        Connection statementConnection = target.getInputByName("statement input").getConnection();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                Connection statementConnection = target.getInputByName("statement input").getConnection();
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
+                }
 
-        // Run test: Connect source inside target. No prior connection to bump.
-        mController.connect(source.getPreviousConnection(), statementConnection);
+                // Run test: Connect source inside target. No prior connection to bump.
+                mController.connect(source.getPreviousConnection(), statementConnection);
 
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(source.getPreviousBlock());
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(source.getPreviousBlock());
 
-        if (withViews) {
-            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(source));
-        }
+                if (withViews) {
+                    BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+                    assertThat(rootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                }
 
-        // Add the shadow block
-        statementConnection.setShadowConnection(shadow.getPreviousConnection());
-        // disconnect the real blocks which should attach the shadow to replace it.
-        mController.extractBlockAsRoot(source);
+                // Add the shadow block
+                statementConnection.setShadowConnection(shadow.getPreviousConnection());
+                // disconnect the real blocks which should attach the shadow to replace it.
+                mController.extractBlockAsRoot(source);
 
-        assertThat(mWorkspace.isRootBlock(source)).isTrue();
-        assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
-        assertThat(statementConnection.getTargetBlock()).isSameAs(shadow);
+                assertThat(mWorkspace.isRootBlock(source)).isTrue();
+                assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
+                assertThat(statementConnection.getTargetBlock()).isSameAs(shadow);
 
-        if (withViews) {
-            assertThat(mHelper.getView(shadow)).isNotNull();
-            assertThat(mHelper.getRootBlockGroup(target))
-                    .isSameAs(mHelper.getRootBlockGroup(shadow));
-        }
+                if (withViews) {
+                    assertThat(mHelper.getView(shadow)).isNotNull();
+                    assertThat(mHelper.getRootBlockGroup(target))
+                            .isSameAs(mHelper.getRootBlockGroup(shadow));
+                }
 
-        // Reconnect the source and make sure the shadow goes away
-        mController.connect(source.getPreviousConnection(), statementConnection);
-        assertThat(shadow.getPreviousBlock()).isNull();
-        assertThat(statementConnection.getTargetBlock()).isSameAs(source);
-        assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
+                // Reconnect the source and make sure the shadow goes away
+                mController.connect(source.getPreviousConnection(), statementConnection);
+                assertThat(shadow.getPreviousBlock()).isNull();
+                assertThat(statementConnection.getTargetBlock()).isSameAs(source);
+                assertThat(mWorkspace.isRootBlock(shadow)).isFalse();
 
-        if (withViews) {
-            assertThat(mHelper.getView(shadow)).isNull();
-            assertThat(mHelper.getRootBlockGroup(target))
-                    .isSameAs(mHelper.getRootBlockGroup(source));
-        }
+                if (withViews) {
+                    assertThat(mHelper.getView(shadow)).isNull();
+                    assertThat(mHelper.getRootBlockGroup(target))
+                            .isSameAs(mHelper.getRootBlockGroup(source));
+                }
+            }
+        });
     }
 
     @Test
@@ -872,58 +979,65 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToStatementSpliceRemainder(true);
     }
 
-    private void testConnect_previousToStatementSpliceRemainder(boolean withViews)
+    private void testConnect_previousToStatementSpliceRemainder(final boolean withViews)
             throws BlockLoadingException {
         // setup
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(new BlockTemplate().shadow().copyOf(source));
-        BlockView targetView = null, tailView = null, sourceView = null;
+        final Block shadow = mBlockFactory.obtainBlockFrom(
+                new BlockTemplate().shadow().copyOf(source));
 
-        Connection statementConnection =  target.getInputByName("statement input").getConnection();
-        // and set a shadow to make sure it has no effects
-        statementConnection.setShadowConnection(shadow.getPreviousConnection());
-        // Connect the tail inside target.
-        statementConnection.connect(tail.getPreviousConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView targetView = null, tailView = null, sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                Connection statementConnection =  target.getInputByName("statement input").getConnection();
+                // and set a shadow to make sure it has no effects
+                statementConnection.setShadowConnection(shadow.getPreviousConnection());
+                // Connect the tail inside target.
+                statementConnection.connect(tail.getPreviousConnection());
 
-            targetView = mHelper.getView(target);
-            tailView = mHelper.getView(tail);
-            sourceView = mHelper.getView(source);
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-            assertThat(targetView).isNotNull();
-            assertThat(tailView).isNotNull();
-            assertThat(sourceView).isNotNull();
-        }
+                    targetView = mHelper.getView(target);
+                    tailView = mHelper.getView(tail);
+                    sourceView = mHelper.getView(source);
 
-        // Run test: Connect source inside target, where tail is attached, resulting in a splice.
-        mController.connect(source.getPreviousConnection(), statementConnection);
+                    assertThat(targetView).isNotNull();
+                    assertThat(tailView).isNotNull();
+                    assertThat(sourceView).isNotNull();
+                }
 
-        // Validate result.
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target).isSameAs(source.getPreviousBlock());
-        assertThat(source).isSameAs(tail.getPreviousBlock());
+                // Run test: Connect source inside target, where tail is attached, resulting in a splice.
+                mController.connect(source.getPreviousConnection(), statementConnection);
 
-        if (withViews) {
-            BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
-            BlockGroup secondGroup = mHelper.getParentBlockGroup(tail);
-            assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(rootGroup).isNotSameAs(secondGroup);
-            assertThat(secondGroup).isSameAs(mHelper.getParentBlockGroup(source));
-            assertThat(sourceView).isSameAs(secondGroup.getChildAt(0));
-            assertThat(tailView).isSameAs(secondGroup.getChildAt(1));
-        }
+                // Validate result.
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target).isSameAs(source.getPreviousBlock());
+                assertThat(source).isSameAs(tail.getPreviousBlock());
+
+                if (withViews) {
+                    BlockGroup rootGroup = mHelper.getRootBlockGroup(target);
+                    BlockGroup secondGroup = mHelper.getParentBlockGroup(tail);
+                    assertThat(rootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(rootGroup).isNotSameAs(secondGroup);
+                    assertThat(secondGroup).isSameAs(mHelper.getParentBlockGroup(source));
+                    assertThat(sourceView).isSameAs(secondGroup.getChildAt(0));
+                    assertThat(tailView).isSameAs(secondGroup.getChildAt(1));
+                }
+            }
+        });
     }
 
     @Test
@@ -938,60 +1052,66 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToStatementBumpRemainder(true);
     }
 
-    private void testConnect_previousToStatementBumpRemainder(boolean withViews)
+    private void testConnect_previousToStatementBumpRemainder(final boolean withViews)
             throws BlockLoadingException {
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_next").withId("source"));
-        BlockView sourceView = null;
 
-        // Connect tail inside target.
-        target.getInputByName("statement input").getConnection()
-                .connect(tail.getPreviousConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView sourceView = null;
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                // Connect tail inside target.
+                target.getInputByName("statement input").getConnection()
+                        .connect(tail.getPreviousConnection());
 
-            sourceView = mHelper.getView(source);
-            assertThat(sourceView).isNotNull();
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-        // Connect source inside target, where tail is attached.  Source does not have a next, so
-        // this will bump tail back to the root.
-        mController.connect(source.getPreviousConnection(),
-                            target.getInputByName("statement input").getConnection());
+                    sourceView = mHelper.getView(source);
+                    assertThat(sourceView).isNotNull();
+                }
 
-        // Validate
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isTrue();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(target.getInputByName("statement input").getConnection())
-            .isSameAs(source.getPreviousConnection().getTargetConnection());
-        assertThat(tail.getPreviousBlock()).isNull();
+                // Connect source inside target, where tail is attached.  Source does not have a next, so
+                // this will bump tail back to the root.
+                mController.connect(source.getPreviousConnection(),
+                        target.getInputByName("statement input").getConnection());
 
-        if (withViews) {
-            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
-            BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail);
-            BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
-            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
-            assertThat(tailRootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(sourceGroup.getParent())
-                    .isSameAs(target.getInputByName("statement input").getView());
-            assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
+                // Validate
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isTrue();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(target.getInputByName("statement input").getConnection())
+                        .isSameAs(source.getPreviousConnection().getTargetConnection());
+                assertThat(tail.getPreviousBlock()).isNull();
 
-            double connectionDist =
-                    source.getPreviousConnection().distanceFrom(tail.getPreviousConnection());
-            assertThat(connectionDist).named("bumped connection distance")
-                    .isGreaterThan((double) mHelper.getMaxSnapDistance());
-        }
+                if (withViews) {
+                    BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+                    BlockGroup tailRootGroup = mHelper.getRootBlockGroup(tail);
+                    BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
+                    assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(targetRootGroup).isNotSameAs(tailRootGroup);
+                    assertThat(tailRootGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(sourceGroup.getParent())
+                            .isSameAs(target.getInputByName("statement input").getView());
+                    assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
+
+                    double connectionDist =
+                            source.getPreviousConnection().distanceFrom(tail.getPreviousConnection());
+                    assertThat(connectionDist).named("bumped connection distance")
+                            .isGreaterThan((double) mHelper.getMaxSnapDistance());
+                }
+            }
+        });
     }
 
     @Test
@@ -1006,67 +1126,73 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testConnect_previousToStatementShadowSplice(true);
     }
 
-    private void testConnect_previousToStatementShadowSplice(boolean withViews)
+    private void testConnect_previousToStatementShadowSplice(final boolean withViews)
             throws BlockLoadingException {
-        Block target = mBlockFactory.obtainBlockFrom(
+        final Block target = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("target"));
-        Block tail = mBlockFactory.obtainBlockFrom(
+        final Block tail = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("tail"));
-        Block source = mBlockFactory.obtainBlockFrom(
+        final Block source = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_no_input").withId("source"));
-        Block shadow = mBlockFactory.obtainBlockFrom(
+        final Block shadow = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().shadow().copyOf(source).withId("shadow"));
-        BlockView sourceView = null;
 
-        // Connect tail inside target.
-        Connection statementConnection = target.getInputByName("statement input").getConnection();
-        statementConnection.connect(tail.getPreviousConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                BlockView sourceView = null;
 
-        // Add the shadow to the source
-        source.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
-        source.getNextConnection().connect(shadow.getPreviousConnection());
+                // Connect tail inside target.
+                Connection statementConnection = target.getInputByName("statement input").getConnection();
+                statementConnection.connect(tail.getPreviousConnection());
 
-        mController.addRootBlock(target);
-        mController.addRootBlock(source);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(target, source);
+                // Add the shadow to the source
+                source.getNextConnection().setShadowConnection(shadow.getPreviousConnection());
+                source.getNextConnection().connect(shadow.getPreviousConnection());
 
-            sourceView = mHelper.getView(source);
-            assertThat(sourceView).isNotNull();
-            assertThat(mHelper.getView(shadow)).isNotNull();
-        }
+                mController.addRootBlock(target);
+                mController.addRootBlock(source);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(target, source);
 
-        // Connect source inside target, where tail is attached.  Source has a shadow on next, so
-        // tail should replace it.
-        mController.connect(source.getPreviousConnection(), statementConnection);
+                    sourceView = mHelper.getView(source);
+                    assertThat(sourceView).isNotNull();
+                    assertThat(mHelper.getView(shadow)).isNotNull();
+                }
 
-        // Validate
-        assertThat(mWorkspace.isRootBlock(target)).isTrue();
-        assertThat(mWorkspace.isRootBlock(tail)).isFalse();
-        assertThat(mWorkspace.isRootBlock(source)).isFalse();
-        assertThat(statementConnection)
-                .isSameAs(source.getPreviousConnection().getTargetConnection());
-        assertThat(source).isSameAs(tail.getPreviousBlock());
-        assertThat(shadow.getParentBlock()).isNull();
+                // Connect source inside target, where tail is attached.  Source has a shadow on next, so
+                // tail should replace it.
+                mController.connect(source.getPreviousConnection(), statementConnection);
 
-        if (withViews) {
-            BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
-            BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
-            assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
-            assertThat(sourceGroup).isSameAs(mHelper.getParentBlockGroup(tail));
-            assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
-            assertThat(sourceGroup.getParent())
-                    .isSameAs(target.getInputByName("statement input").getView());
-            assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
-            assertThat(mHelper.getView(tail)).isSameAs(sourceGroup.getChildAt(1));
+                // Validate
+                assertThat(mWorkspace.isRootBlock(target)).isTrue();
+                assertThat(mWorkspace.isRootBlock(tail)).isFalse();
+                assertThat(mWorkspace.isRootBlock(source)).isFalse();
+                assertThat(statementConnection)
+                        .isSameAs(source.getPreviousConnection().getTargetConnection());
+                assertThat(source).isSameAs(tail.getPreviousBlock());
+                assertThat(shadow.getParentBlock()).isNull();
 
-            assertThat(mHelper.getView(shadow)).isNull();
-        }
+                if (withViews) {
+                    BlockGroup targetRootGroup = mHelper.getRootBlockGroup(target);
+                    BlockGroup sourceGroup = mHelper.getParentBlockGroup(source);
+                    assertThat(targetRootGroup).isSameAs(mHelper.getParentBlockGroup(target));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(tail));
+                    assertThat(sourceGroup).isSameAs(mHelper.getParentBlockGroup(tail));
+                    assertThat(targetRootGroup).isSameAs(mHelper.getRootBlockGroup(source));
+                    assertThat(sourceGroup.getParent())
+                            .isSameAs(target.getInputByName("statement input").getView());
+                    assertThat(sourceView).isSameAs(sourceGroup.getChildAt(0));
+                    assertThat(mHelper.getView(tail)).isSameAs(sourceGroup.getChildAt(1));
 
-        // Make sure nothing breaks when we detach the tail and the shadow comes back
-        mController.extractBlockAsRoot(tail);
+                    assertThat(mHelper.getView(shadow)).isNull();
+                }
+
+                // Make sure nothing breaks when we detach the tail and the shadow comes back
+                mController.extractBlockAsRoot(tail);
+            }
+        });
     }
 
     @Test
@@ -1079,32 +1205,38 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testExtractAsRootBlock_alreadyRoot(true);
     }
 
-    private void testExtractAsRootBlock_alreadyRoot(boolean withViews)
+    private void testExtractAsRootBlock_alreadyRoot(final boolean withViews)
             throws BlockLoadingException {
         // Configure
-        Block block = mBlockFactory.obtainBlockFrom(
+        final Block block = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("block"));
-        mController.addRootBlock(block);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(block);
-        }
 
-        // Check Preconditions
-        assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
-        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addRootBlock(block);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(block);
+                }
 
-        // Run test: Make block a root (even though it already is).
-        mController.extractBlockAsRoot(block);
+                // Check Preconditions
+                assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
+                assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
 
-        // Validate (no change)
-        assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
-        assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+                // Run test: Make block a root (even though it already is).
+                mController.extractBlockAsRoot(block);
 
-        if (withViews) {
-            BlockGroup firstGroup = mHelper.getParentBlockGroup(block);
-            assertThat(firstGroup).isSameAs(mHelper.getRootBlockGroup(block));
-        }
+                // Validate (no change)
+                assertThat(1).isEqualTo(mWorkspace.getRootBlocks().size());
+                assertThat(mWorkspace.getRootBlocks().contains(block)).isTrue();
+
+                if (withViews) {
+                    BlockGroup firstGroup = mHelper.getParentBlockGroup(block);
+                    assertThat(firstGroup).isSameAs(mHelper.getRootBlockGroup(block));
+                }
+            }
+        });
     }
 
     @Test
@@ -1117,41 +1249,48 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testExtractBlockAsRoot_fromInput(true);
     }
 
-    private void testExtractBlockAsRoot_fromInput(boolean withViews) throws BlockLoadingException {
-        Block first = mBlockFactory.obtainBlockFrom(
+    private void testExtractBlockAsRoot_fromInput(final boolean withViews)
+            throws BlockLoadingException {
+        final Block first = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("first block"));
-        Block second = mBlockFactory.obtainBlockFrom(
+        final Block second = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("simple_input_output").withId("second block"));
-        mController.connect(
-                second.getOutputConnection(), first.getOnlyValueInput().getConnection());
-        mController.addRootBlock(first);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(first, second);
-        }
 
-        // Check preconditions
-        List<Block> rootBlocks = mWorkspace.getRootBlocks();
-        assertThat(1).isEqualTo(rootBlocks.size());
-        assertThat(first).isEqualTo(rootBlocks.get(0));
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.connect(
+                        second.getOutputConnection(), first.getOnlyValueInput().getConnection());
+                mController.addRootBlock(first);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(first, second);
+                }
 
-        // Run test: Extract second out from under first.
-        mController.extractBlockAsRoot(second);
+                // Check preconditions
+                List<Block> rootBlocks = mWorkspace.getRootBlocks();
+                assertThat(1).isEqualTo(rootBlocks.size());
+                assertThat(first).isEqualTo(rootBlocks.get(0));
 
-        rootBlocks = mWorkspace.getRootBlocks();
-        assertThat(2).isEqualTo(rootBlocks.size());
-        assertThat(rootBlocks.contains(first)).isTrue();
-        assertThat(rootBlocks.contains(second)).isTrue();
-        assertThat(first.getOnlyValueInput().getConnection().isConnected()).isFalse();
-        assertThat(second.getOutputConnection().isConnected()).isFalse();
+                // Run test: Extract second out from under first.
+                mController.extractBlockAsRoot(second);
 
-        if (withViews) {
-            BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
-            assertThat(firstGroup).isNotNull();
-            BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
-            assertThat(secondGroup).isNotNull();
-            assertThat(secondGroup).isNotSameAs(firstGroup);
-        }
+                rootBlocks = mWorkspace.getRootBlocks();
+                assertThat(2).isEqualTo(rootBlocks.size());
+                assertThat(rootBlocks.contains(first)).isTrue();
+                assertThat(rootBlocks.contains(second)).isTrue();
+                assertThat(first.getOnlyValueInput().getConnection().isConnected()).isFalse();
+                assertThat(second.getOutputConnection().isConnected()).isFalse();
+
+                if (withViews) {
+                    BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
+                    assertThat(firstGroup).isNotNull();
+                    BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
+                    assertThat(secondGroup).isNotNull();
+                    assertThat(secondGroup).isNotSameAs(firstGroup);
+                }
+            }
+        });
     }
 
     @Test
@@ -1164,269 +1303,311 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         testExtractBlockAsRoot_fromNext(true);
     }
 
-    private void testExtractBlockAsRoot_fromNext(boolean withViews) throws BlockLoadingException {
+    private void testExtractBlockAsRoot_fromNext(final boolean withViews)
+            throws BlockLoadingException {
         // Configure
-        Block first = mBlockFactory.obtainBlockFrom(
+        final Block first = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("first block"));
-        Block second = mBlockFactory.obtainBlockFrom(
+        final Block second = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("second block"));
-        mController.connect(second.getPreviousConnection(), first.getNextConnection());
-        mController.addRootBlock(first);
-        if (withViews) {
-            mController.initWorkspaceView(mWorkspaceView);
-            fakeOnAttachToWindow(first, second);
-        }
 
-        // Check preconditions
-        List<Block> rootBlocks = mWorkspace.getRootBlocks();
-        assertThat(1).isEqualTo(rootBlocks.size());
-        assertThat(first).isEqualTo(rootBlocks.get(0));
-        assertThat(first.getNextConnection().getTargetBlock()).isEqualTo(second);
-        if (withViews) {
-            assertThat(mHelper.getParentBlockGroup(first))
-                .isSameAs(mHelper.getParentBlockGroup(second));
-        }
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.connect(second.getPreviousConnection(), first.getNextConnection());
+                mController.addRootBlock(first);
+                if (withViews) {
+                    mController.initWorkspaceView(mWorkspaceView);
+                    fakeOnAttachToWindow(first, second);
+                }
 
-        // Run test: Extract second out from under first.
-        mController.extractBlockAsRoot(second);
+                // Check preconditions
+                List<Block> rootBlocks = mWorkspace.getRootBlocks();
+                assertThat(1).isEqualTo(rootBlocks.size());
+                assertThat(first).isEqualTo(rootBlocks.get(0));
+                assertThat(first.getNextConnection().getTargetBlock()).isEqualTo(second);
+                if (withViews) {
+                    assertThat(mHelper.getParentBlockGroup(first))
+                            .isSameAs(mHelper.getParentBlockGroup(second));
+                }
 
-        // Validate
-        rootBlocks = mWorkspace.getRootBlocks();
-        assertThat(2).isEqualTo(rootBlocks.size());
-        assertThat(rootBlocks.contains(first)).isTrue();
-        assertThat(rootBlocks.contains(second)).isTrue();
-        assertThat(first.getNextConnection().isConnected()).isFalse();
-        assertThat(second.getPreviousConnection().isConnected()).isFalse();
+                // Run test: Extract second out from under first.
+                mController.extractBlockAsRoot(second);
 
-        if (withViews) {
-            BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
-            assertThat(firstGroup).isNotNull();
-            BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
-            assertThat(secondGroup).isNotNull();
-            assertThat(secondGroup).isNotSameAs(firstGroup);
-        }
+                // Validate
+                rootBlocks = mWorkspace.getRootBlocks();
+                assertThat(2).isEqualTo(rootBlocks.size());
+                assertThat(rootBlocks.contains(first)).isTrue();
+                assertThat(rootBlocks.contains(second)).isTrue();
+                assertThat(first.getNextConnection().isConnected()).isFalse();
+                assertThat(second.getPreviousConnection().isConnected()).isFalse();
+
+                if (withViews) {
+                    BlockGroup firstGroup = mHelper.getParentBlockGroup(first);
+                    assertThat(firstGroup).isNotNull();
+                    BlockGroup secondGroup = mHelper.getParentBlockGroup(second);
+                    assertThat(secondGroup).isNotNull();
+                    assertThat(secondGroup).isNotSameAs(firstGroup);
+                }
+            }
+        });
     }
 
     @Test
     public void testVariableCallback_onCreate() {
-        NameManager.VariableNameManager nameManager =
-                (NameManager.VariableNameManager) mController.getWorkspace()
-                        .getVariableNameManager();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                NameManager.VariableNameManager nameManager =
+                        (NameManager.VariableNameManager) mController.getWorkspace()
+                                .getVariableNameManager();
 
-        assertThat(mVariableCallback.onCreateVariable).isNull();
+                assertThat(mVariableCallback.onCreateVariable).isNull();
 
-        // Calling requestAddVariable and the callback blocking creation
-        mVariableCallback.whenOnCreateCalled = false;
-        mController.requestAddVariable("var1");
-        assertThat(mVariableCallback.onCreateVariable).isEqualTo("var1");
-        assertThat(nameManager.getUsedNames().size()).isEqualTo(0);
+                // Calling requestAddVariable and the callback blocking creation
+                mVariableCallback.whenOnCreateCalled = false;
+                mController.requestAddVariable("var1");
+                assertThat(mVariableCallback.onCreateVariable).isEqualTo("var1");
+                assertThat(nameManager.getUsedNames().size()).isEqualTo(0);
 
-        // Calling addVariable bypasses the callback
-        mVariableCallback.onCreateVariable = null;
-        mController.addVariable("var1");
-        assertThat(mVariableCallback.onCreateVariable).isNull();
-        assertThat(nameManager.contains("var1")).isTrue();
+                // Calling addVariable bypasses the callback
+                mVariableCallback.onCreateVariable = null;
+                mController.addVariable("var1");
+                assertThat(mVariableCallback.onCreateVariable).isNull();
+                assertThat(nameManager.contains("var1")).isTrue();
 
-        // Calling requestAddVariable and the callback allows creation
-        mVariableCallback.reset();
-        mVariableCallback.whenOnCreateCalled = true;
-        mController.requestAddVariable("var2");
-        assertThat(mVariableCallback.onCreateVariable).isEqualTo("var2");
-        assertThat(nameManager.contains("var2")).isTrue();
+                // Calling requestAddVariable and the callback allows creation
+                mVariableCallback.reset();
+                mVariableCallback.whenOnCreateCalled = true;
+                mController.requestAddVariable("var2");
+                assertThat(mVariableCallback.onCreateVariable).isEqualTo("var2");
+                assertThat(nameManager.contains("var2")).isTrue();
+            }
+        });
     }
 
     @Test
     public void testVariableCallback_onRename() {
-        NameManager.VariableNameManager nameManager =
-                (NameManager.VariableNameManager) mController.getWorkspace()
-                        .getVariableNameManager();
-        mController.addVariable("var1");
-        mController.addVariable("var2");
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                NameManager.VariableNameManager nameManager =
+                        (NameManager.VariableNameManager) mController.getWorkspace()
+                                .getVariableNameManager();
+                mController.addVariable("var1");
+                mController.addVariable("var2");
 
-        // Calling rename without forcing and the callback blocks it
-        mVariableCallback.whenOnRenameCalled = false;
-        mController.requestRenameVariable("var1", "var3");
-        assertThat(mVariableCallback.onRenameVariable).isEqualTo("var1");
-        assertThat(nameManager.contains("var3")).isFalse();
-        assertThat(nameManager.contains("var1")).isTrue();
+                // Calling rename without forcing and the callback blocks it
+                mVariableCallback.whenOnRenameCalled = false;
+                mController.requestRenameVariable("var1", "var3");
+                assertThat(mVariableCallback.onRenameVariable).isEqualTo("var1");
+                assertThat(nameManager.contains("var3")).isFalse();
+                assertThat(nameManager.contains("var1")).isTrue();
 
-        // Calling rename with forcing skips the callback
-        mVariableCallback.onRenameVariable = null;
-        mController.renameVariable("var1", "var3");
-        assertThat(mVariableCallback.onRenameVariable).isNull();
-        assertThat(nameManager.contains("var3")).isTrue();
-        assertThat(nameManager.contains("var1")).isFalse();
+                // Calling rename with forcing skips the callback
+                mVariableCallback.onRenameVariable = null;
+                mController.renameVariable("var1", "var3");
+                assertThat(mVariableCallback.onRenameVariable).isNull();
+                assertThat(nameManager.contains("var3")).isTrue();
+                assertThat(nameManager.contains("var1")).isFalse();
 
-        // Calling rename without forcing and the callback allows it
-        mVariableCallback.whenOnRenameCalled = true;
-        mController.requestRenameVariable("var2", "var4");
-        assertThat(mVariableCallback.onRenameVariable).isEqualTo("var2");
-        assertThat(nameManager.contains("var4")).isTrue();
-        assertThat(nameManager.contains("var2")).isFalse();
+                // Calling rename without forcing and the callback allows it
+                mVariableCallback.whenOnRenameCalled = true;
+                mController.requestRenameVariable("var2", "var4");
+                assertThat(mVariableCallback.onRenameVariable).isEqualTo("var2");
+                assertThat(nameManager.contains("var4")).isTrue();
+                assertThat(nameManager.contains("var2")).isFalse();
 
-        // Verify that we have two variables still
-        assertThat(nameManager.size()).isEqualTo(2);
+                // Verify that we have two variables still
+                assertThat(nameManager.size()).isEqualTo(2);
+            }
+        });
     }
 
     @Test
     public void testVariableCallback_onRemove() {
-        NameManager.VariableNameManager nameManager =
-                (NameManager.VariableNameManager) mController.getWorkspace()
-                        .getVariableNameManager();
-        mController.addVariable("var3");
-        mController.addVariable("var4");
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                NameManager.VariableNameManager nameManager =
+                        (NameManager.VariableNameManager) mController.getWorkspace()
+                                .getVariableNameManager();
+                mController.addVariable("var3");
+                mController.addVariable("var4");
 
-        // Calling delete without forcing and the callback blocks it
-        mVariableCallback.whenOnDeleteCalled = false;
-        mController.requestDeleteVariable("var3");
-        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var3");
-        assertThat(nameManager.contains("var3")).isTrue();
+                // Calling delete without forcing and the callback blocks it
+                mVariableCallback.whenOnDeleteCalled = false;
+                mController.requestDeleteVariable("var3");
+                assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var3");
+                assertThat(nameManager.contains("var3")).isTrue();
 
-        // Calling delete with forcing skips callback
-        mVariableCallback.onDeleteVariable = null;
-        mController.deleteVariable("var3");
-        assertThat(mVariableCallback.onDeleteVariable).isNull();
-        assertThat(nameManager.contains("var3")).isFalse();
+                // Calling delete with forcing skips callback
+                mVariableCallback.onDeleteVariable = null;
+                mController.deleteVariable("var3");
+                assertThat(mVariableCallback.onDeleteVariable).isNull();
+                assertThat(nameManager.contains("var3")).isFalse();
 
-        // Calling delete without forcing and callback allows it
-        mVariableCallback.whenOnDeleteCalled = true;
-        mController.requestDeleteVariable("var4");
-        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var4");
-        assertThat(nameManager.contains("var4")).isFalse();
+                // Calling delete without forcing and callback allows it
+                mVariableCallback.whenOnDeleteCalled = true;
+                mController.requestDeleteVariable("var4");
+                assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var4");
+                assertThat(nameManager.contains("var4")).isFalse();
 
-        // Verify that we have no variables left
-        assertThat(nameManager.size()).isEqualTo(0);
+                // Verify that we have no variables left
+                assertThat(nameManager.size()).isEqualTo(0);
+            }
+        });
     }
 
     @Test
     public void testCreateVariableDoesNotChangeCase() {
-        String name = "NEW VAR NAME";
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                String name = "NEW VAR NAME";
 
-        String finalName = mController.addVariable(name);
+                String finalName = mController.addVariable(name);
 
-        assertThat(finalName).isEqualTo(name);
+                assertThat(finalName).isEqualTo(name);
+            }
+        });
     }
 
     @Test
     public void testRenameVariableDoesNotChangeCase() {
-        String oldName = "oldName";
-        String newName = "TEST";
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                String oldName = "oldName";
+                String newName = "TEST";
 
-        String finalName = mController.renameVariable(oldName, newName);
+                String finalName = mController.renameVariable(oldName, newName);
 
-        assertThat(finalName).isEqualTo(newName);
+                assertThat(finalName).isEqualTo(newName);
+            }
+        });
     }
 
     @Test
     public void testCreateVariableDoesNotAllowDuplicateNamesWithDifferentCases() {
-        String name1 = "VAR";
-        String name2 = "var";
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                String name1 = "VAR";
+                String name2 = "var";
 
-        String finalName1 = mController.addVariable(name1);
-        String finalName2 = mController.addVariable(name2);
+                String finalName1 = mController.addVariable(name1);
+                String finalName2 = mController.addVariable(name2);
 
-        assertWithMessage("Second similar variable name (matching all but case) was renamed.")
-            .that(finalName2).isNotEqualTo(name2);
-        assertWithMessage("Renamed second variable does not match first variable.")
-            .that(finalName1.toLowerCase()).isNotEqualTo(finalName2.toLowerCase());
+                assertWithMessage("Second similar variable name (matching all but case) was renamed.")
+                        .that(finalName2).isNotEqualTo(name2);
+                assertWithMessage("Renamed second variable does not match first variable.")
+                        .that(finalName1.toLowerCase()).isNotEqualTo(finalName2.toLowerCase());
+            }
+        });
     }
 
     @Test
     public void testRemoveVariable() throws BlockLoadingException {
-        mController.addVariable("var1");
-        mController.addVariable("var2");
-        mController.addVariable("var3");
-        mController.addVariable("var4");
-
-        Block set1 = mBlockFactory.obtainBlockFrom(
+        final Block set1 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("first block"));
-        Block set2 = mBlockFactory.obtainBlockFrom(
+        final Block set2 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("second block"));
-        Block set3 = mBlockFactory.obtainBlockFrom(
+        final Block set3 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("third block"));
-        Block set4 = mBlockFactory.obtainBlockFrom(
+        final Block set4 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("fourth block"));
-        Block set5 = mBlockFactory.obtainBlockFrom(
+        final Block set5 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("fifth block"));
-        Block set6 = mBlockFactory.obtainBlockFrom(
+        final Block set6 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("set_variable").withId("sixth block"));
-        Block statement = mBlockFactory.obtainBlockFrom(
+        final Block statement = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("statement_statement_input").withId("statement block"));
-        Block get1 = mBlockFactory.obtainBlockFrom(
+        final Block get1 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("get_variable").withId("get1"));
-        Block get2 = mBlockFactory.obtainBlockFrom(
+        final Block get2 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("get_variable").withId("get2"));
-        Block get3 = mBlockFactory.obtainBlockFrom(
+        final Block get3 = mBlockFactory.obtainBlockFrom(
                 new BlockTemplate().ofType("get_variable").withId("get3"));
 
-        mController.connect(statement.getInputs().get(0).getConnection(),
-                set1.getPreviousConnection());
-        mController.connect(set1.getNextConnection(), set2.getPreviousConnection());
-        mController.connect(set2.getNextConnection(), set3.getPreviousConnection());
-        mController.connect(set3.getNextConnection(), set4.getPreviousConnection());
-        mController.connect(set4.getNextConnection(), set5.getPreviousConnection());
-        mController.connect(set2.getOnlyValueInput().getConnection(), get1.getOutputConnection());
-        mController.connect(set5.getOnlyValueInput().getConnection(), get2.getOutputConnection());
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.addVariable("var1");
+                mController.addVariable("var2");
+                mController.addVariable("var3");
+                mController.addVariable("var4");
 
-        FieldVariable var = (FieldVariable) set1.getFieldByName("variable");
-        var.setVariable("var1");
-        var = (FieldVariable) set2.getFieldByName("variable");
-        var.setVariable("var2");
-        var = (FieldVariable) set3.getFieldByName("variable");
-        var.setVariable("var1");
-        var = (FieldVariable) set4.getFieldByName("variable");
-        var.setVariable("var3");
-        var = (FieldVariable) set5.getFieldByName("variable");
-        var.setVariable("var1");
-        var = (FieldVariable) set6.getFieldByName("variable");
-        var.setVariable("var1");
-        var = (FieldVariable) get1.getFieldByName("variable");
-        var.setVariable("var1");
-        var = (FieldVariable) get2.getFieldByName("variable");
-        var.setVariable("var4");
-        var = (FieldVariable) get3.getFieldByName("variable");
-        var.setVariable("var1");
+                mController.connect(statement.getInputs().get(0).getConnection(),
+                        set1.getPreviousConnection());
+                mController.connect(set1.getNextConnection(), set2.getPreviousConnection());
+                mController.connect(set2.getNextConnection(), set3.getPreviousConnection());
+                mController.connect(set3.getNextConnection(), set4.getPreviousConnection());
+                mController.connect(set4.getNextConnection(), set5.getPreviousConnection());
+                mController.connect(set2.getOnlyValueInput().getConnection(), get1.getOutputConnection());
+                mController.connect(set5.getOnlyValueInput().getConnection(), get2.getOutputConnection());
 
-        mController.addRootBlock(statement);
-        mController.addRootBlock(set6);
-        mController.addRootBlock(get3);
+                FieldVariable var = (FieldVariable) set1.getFieldByName("variable");
+                var.setVariable("var1");
+                var = (FieldVariable) set2.getFieldByName("variable");
+                var.setVariable("var2");
+                var = (FieldVariable) set3.getFieldByName("variable");
+                var.setVariable("var1");
+                var = (FieldVariable) set4.getFieldByName("variable");
+                var.setVariable("var3");
+                var = (FieldVariable) set5.getFieldByName("variable");
+                var.setVariable("var1");
+                var = (FieldVariable) set6.getFieldByName("variable");
+                var.setVariable("var1");
+                var = (FieldVariable) get1.getFieldByName("variable");
+                var.setVariable("var1");
+                var = (FieldVariable) get2.getFieldByName("variable");
+                var.setVariable("var4");
+                var = (FieldVariable) get3.getFieldByName("variable");
+                var.setVariable("var1");
 
-        // Workspace setup:
-        // Statement block with a statement input
-        //     set1 "var1"
-        //     set2 "var2" <- get1 "var1"
-        //     set3 "var1"
-        //     set4 "var3"
-        //     set5 "var1" <- get2 "var4"
-        //
-        // set6 "var1"
-        //
-        // get3 "var1"
+                mController.addRootBlock(statement);
+                mController.addRootBlock(set6);
+                mController.addRootBlock(get3);
 
-        // Expected state after deleting var1:
-        // Statement block with a statement input
-        //     set2 "var2"
-        //     set4 "var 3"
-        List<Block> rootBlocks = mController.getWorkspace().getRootBlocks();
-        assertThat(rootBlocks.size()).isEqualTo(3);
+                // Workspace setup:
+                // Statement block with a statement input
+                //     set1 "var1"
+                //     set2 "var2" <- get1 "var1"
+                //     set3 "var1"
+                //     set4 "var3"
+                //     set5 "var1" <- get2 "var4"
+                //
+                // set6 "var1"
+                //
+                // get3 "var1"
 
-        mVariableCallback.whenOnDeleteCalled = true;
-        mVariableCallback.onDeleteVariable = null;
-        mController.requestDeleteVariable("var1");
+                // Expected state after deleting var1:
+                // Statement block with a statement input
+                //     set2 "var2"
+                //     set4 "var 3"
+                List<Block> rootBlocks = mController.getWorkspace().getRootBlocks();
+                assertThat(rootBlocks.size()).isEqualTo(3);
 
-        assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var1");
-        assertThat(rootBlocks.size()).isEqualTo(1);
+                mVariableCallback.whenOnDeleteCalled = true;
+                mVariableCallback.onDeleteVariable = null;
+                mController.requestDeleteVariable("var1");
 
-        Block block = rootBlocks.get(0);
-        assertThat(block).isSameAs(statement);
-        block = block.getInputs().get(0).getConnectedBlock();
-        assertThat(block).isSameAs(set2);
+                assertThat(mVariableCallback.onDeleteVariable).isEqualTo("var1");
+                assertThat(rootBlocks.size()).isEqualTo(1);
 
-        block = block.getNextBlock();
-        assertThat(block).isSameAs(set4);
+                Block block = rootBlocks.get(0);
+                assertThat(block).isSameAs(statement);
+                block = block.getInputs().get(0).getConnectedBlock();
+                assertThat(block).isSameAs(set2);
 
-        block = block.getNextBlock();
-        assertThat(block).isNull();
+                block = block.getNextBlock();
+                assertThat(block).isSameAs(set4);
+
+                block = block.getNextBlock();
+                assertThat(block).isNull();
+            }
+        });
     }
 
     @Test
@@ -1450,21 +1631,30 @@ public class BlocklyControllerTest extends BlocklyTestCase {
 
     @Test
     public void testLoadWorkspaceContents_andTrashAllBlocks() throws BlockLoadingException {
-        mController.initWorkspaceView(mWorkspaceView);
-        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
-        assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(0);
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                mController.initWorkspaceView(mWorkspaceView);
+                assertThat(mWorkspace.getRootBlocks()).hasSize(0);
+                assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(0);
 
-        mController.loadWorkspaceContents(
-            BlockTestStrings.EMPTY_BLOCK_WITH_POSITION +
-                BlockTestStrings.EMPTY_BLOCK_WITH_POSITION.replace(
-                    BlockTestStrings.EMPTY_BLOCK_ID,
-                    BlockTestStrings.EMPTY_BLOCK_ID + '2'));
-        assertThat(mWorkspace.getRootBlocks()).hasSize(2);
-        assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(0);
+                try {
+                    mController.loadWorkspaceContents(
+                            BlockTestStrings.EMPTY_BLOCK_WITH_POSITION +
+                                    BlockTestStrings.EMPTY_BLOCK_WITH_POSITION.replace(
+                                            BlockTestStrings.EMPTY_BLOCK_ID,
+                                            BlockTestStrings.EMPTY_BLOCK_ID + '2'));
+                } catch (BlockLoadingException e) {
+                    throw new IllegalStateException(e);  // Throw as RuntimeException.
+                }
+                assertThat(mWorkspace.getRootBlocks()).hasSize(2);
+                assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(0);
 
-        mController.trashAllBlocks();
-        assertThat(mWorkspace.getRootBlocks()).hasSize(0);
-        assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(2);
+                mController.trashAllBlocks();
+                assertThat(mWorkspace.getRootBlocks()).hasSize(0);
+                assertThat(mWorkspace.getTrashCategory().getItems()).hasSize(2);
+            }
+        });
     }
 
     /**
@@ -1477,6 +1667,37 @@ public class BlocklyControllerTest extends BlocklyTestCase {
         for (int i = 0; i < blocks.length; ++i) {
             ((TestableBlockGroup) mHelper.getRootBlockGroup(blocks[i]))
                     .setWorkspaceView(mWorkspaceView);
+        }
+    }
+
+    private void runAndSync(final Runnable runnable) {
+        assertThat(mExceptionInThread).isNull();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    runnable.run();
+                } catch (Throwable e) {
+                    mExceptionInThread = e;
+                }
+                latch.countDown();
+            }
+        });
+        awaitTimeout(latch);
+
+        if (mExceptionInThread != null) {
+            throw new IllegalStateException("Unhandled exception in mock main thread.",
+                    mExceptionInThread);
+        }
+    }
+
+    private void awaitTimeout(CountDownLatch latch) {
+        try {
+            latch.await(TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Timeout exceeded.", e);
         }
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/DraggerTest.java
@@ -66,12 +66,6 @@ import static org.mockito.Mockito.when;
  * Tests for the {@link Dragger}.
  */
 public class DraggerTest extends BlocklyTestCase {
-    /**
-     * Default timeout of 1 second, which should be plenty for most UI actions.  Anything longer
-     * is an error.  However, to step through this code with a debugger, use a much longer duration.
-     */
-    private static final long TIMEOUT = 1000L;
-
     private Context mMockContext;
     private BlocklyController mMockController;
     private BlockClipDataHelper mMockBlockClipDataHelper;
@@ -185,7 +179,7 @@ public class DraggerTest extends BlocklyTestCase {
                 when(mDragLocationEvent.getAction()).thenReturn(DragEvent.ACTION_DRAG_LOCATION);
                 when(mDropEvent.getAction()).thenReturn(DragEvent.ACTION_DROP);
             }
-        }, TIMEOUT);
+        });
 
     }
 
@@ -393,7 +387,7 @@ public class DraggerTest extends BlocklyTestCase {
                 mDragger.onTouchBlockImpl(
                         Dragger.DRAG_MODE_SLOPPY, mDragHandler, mTouchedView, me, false);
             }
-        }, TIMEOUT);
+        });
     }
 
     private void dragMove() {
@@ -408,10 +402,10 @@ public class DraggerTest extends BlocklyTestCase {
                                 Dragger.DRAG_MODE_SLOPPY, mDragHandler, mTouchedView, me, false))
                         .isTrue();
             }
-        }, TIMEOUT);
+        });
 
         // Allow mDragGroupCreator to run.
-        await(mDragGroupCreatorLatch, TIMEOUT);
+        awaitTimeout(mDragGroupCreatorLatch);
         assertWithMessage("Dragger must call Runnable to construct draggable BlockGroup")
                 .that(mDragGroupCreatorCallCount).isEqualTo(1);
 
@@ -420,7 +414,7 @@ public class DraggerTest extends BlocklyTestCase {
             public void run() {
                 mDragger.getDragEventListener().onDrag(mWorkspaceView, mDragStartedEvent);
             }
-        }, TIMEOUT);
+        });
 
     }
 
@@ -445,10 +439,10 @@ public class DraggerTest extends BlocklyTestCase {
 
                 mDragger.getDragEventListener().onDrag(mWorkspaceView, mDropEvent);
             }
-        }, TIMEOUT);
+        });
     }
 
-    private void runAndSync(final Runnable runnable, long timeoutMilliseconds) {
+    private void runAndSync(final Runnable runnable) {
         assertThat(mExceptionInThread).isNull();
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -463,7 +457,7 @@ public class DraggerTest extends BlocklyTestCase {
                 latch.countDown();
             }
         });
-        await(latch, timeoutMilliseconds);
+        awaitTimeout(latch);
 
         if (mExceptionInThread != null) {
             throw new IllegalStateException("Unhandled exception in mock main thread.",
@@ -471,9 +465,9 @@ public class DraggerTest extends BlocklyTestCase {
         }
     }
 
-    private void await(CountDownLatch latch, long timeoutMilliseconds) {
+    private void awaitTimeout(CountDownLatch latch) {
         try {
-            latch.await(timeoutMilliseconds, TimeUnit.MILLISECONDS);
+            latch.await(TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Timeout exceeded.", e);
         }


### PR DESCRIPTION
Adding `BlocklyController.groupAndFireEvents(..)`, and making `.addPendingEvent(..)` public.

These form the basis of a replacement of the prior event framework, allowing better
support for chaining events, and allowing methods outside of `BlocklyController` to initiate
event groups (e.g., `Block.setPosition(..)`, `Field.setValue(..)`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/566)
<!-- Reviewable:end -->
