### PR TITLE
Adding ChangeEvent support to field changes.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/WorkspaceHelper.java
@@ -167,7 +167,7 @@ public class WorkspaceHelper {
      */
     @Nullable
     public BlockView getView(Block block) {
-        return mViewFactory.getView(block);
+        return (mViewFactory == null) ? null : mViewFactory.getView(block);
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -184,6 +184,14 @@ public class Block extends Observable<Block.Observer> {
     }
 
     /**
+     * @return The controller for this Blockly instance.
+     */
+    @NonNull
+    public BlocklyController getController() {
+        return mController;
+    }
+
+    /**
      * {@code getEventWorkspaceId} returns the id of the "workspace", as seen by the event
      * framework. This might be the {@link Workspace#getId() workspace id}, if attached to a
      * {@link Workspace}. It may also be {@link BlocklyEvent#WORKSPACE_ID_TOOLBOX} or
@@ -1270,9 +1278,9 @@ public class Block extends Observable<Block.Observer> {
 
     /**
      * Creates and emits a {@link BlocklyEvent.ChangeEvent} only if {@link #mEventWorkspaceId} is
-     * set.
+     * set. Accessed by Field.
      */
-    private void maybeAddPendingChangeEvent(
+    /* package private */ void maybeAddPendingChangeEvent(
             String element, Field field, String oldValue, String newValue) {
         if (mEventWorkspaceId != null) {
             mController.addPendingEvent(

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -399,7 +399,7 @@ public class Block extends Observable<Block.Observer> {
         if (mDisabled == disabled) {
             return;
         }
-        groupAndMaybeFireEvents(new Runnable() {
+        runAsPossibleEventGroup(new Runnable() {
             @Override
             public void run() {
                 mDisabled = disabled;
@@ -430,7 +430,7 @@ public class Block extends Observable<Block.Observer> {
         if (collapsed == mCollapsed) {
             return;
         }
-        groupAndMaybeFireEvents(new Runnable() {
+        runAsPossibleEventGroup(new Runnable() {
             @Override
             public void run() {
                 mCollapsed = collapsed;
@@ -519,7 +519,7 @@ public class Block extends Observable<Block.Observer> {
         if (comment == mComment || (comment != null && comment.equals(mComment))) {
             return;
         }
-        groupAndMaybeFireEvents(new Runnable() {
+        runAsPossibleEventGroup(new Runnable() {
             @Override
             public void run() {
                 String oldValue = mComment;
@@ -572,7 +572,7 @@ public class Block extends Observable<Block.Observer> {
         if (inputsInline == mInputsInline) {
             return;
         }
-        groupAndMaybeFireEvents(new Runnable() {
+        runAsPossibleEventGroup(new Runnable() {
             @Override
             public void run() {
                 mInputsInline = inputsInline;
@@ -1266,9 +1266,11 @@ public class Block extends Observable<Block.Observer> {
     /**
      * Runs the provided closure. If {@link #mEventWorkspaceId} is set, it will run it through
      * {@link BlocklyController#groupAndFireEvents(Runnable)}.
+     * @see Field#runAsPossibleEventGroup(Runnable)
+     *
      * @param runnable Code to run.
      */
-    private void groupAndMaybeFireEvents(Runnable runnable) {
+    /* package private */ void runAsPossibleEventGroup(Runnable runnable) {
         if (mEventWorkspaceId == null) {
             runnable.run();
         } else {
@@ -1278,7 +1280,11 @@ public class Block extends Observable<Block.Observer> {
 
     /**
      * Creates and emits a {@link BlocklyEvent.ChangeEvent} only if {@link #mEventWorkspaceId} is
-     * set. Accessed by Field.
+     * set.
+     * @param element The identifying element type string.
+     * @param field The field changed, if any.
+     * @param oldValue The prior value, in serialized string form.
+     * @param newValue The new value, in serialized string form.
      */
     /* package private */ void maybeAddPendingChangeEvent(
             String element, Field field, String oldValue, String newValue) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -243,14 +243,14 @@ public abstract class Field extends Observable<Field.Observer> implements Clonea
     }
 
     /**
-     * Run the closure immediately, as an event group if connected to a block & controller.
-     * @param closure
+     * Runs the runnable immediately, as an event group if connected to a block & controller.
+     * @param runnable
      */
-    private void runAsPossibleEventGroup(Runnable closure) {
+    private void runAsPossibleEventGroup(Runnable runnable) {
         if (mBlock != null) {
-            mBlock.getController().groupAndFireEvents(closure);
+            mBlock.runAsPossibleEventGroup(runnable);
         } else {
-            closure.run();
+            runnable.run();
         }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Field.java
@@ -18,6 +18,8 @@ package com.google.blockly.model;
 import android.database.Observable;
 import android.support.annotation.IntDef;
 
+import com.google.blockly.model.BlocklyEvent.ChangeEvent;
+
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
@@ -30,6 +32,9 @@ import java.lang.annotation.RetentionPolicy;
  */
 public abstract class Field extends Observable<Field.Observer> implements Cloneable {
     private static final String TAG = "Field";
+
+    // TODO: These FieldTypes are not extensible without editing this file. It should be possible
+    //       to add a new field type by extending BlockFactory and BlockViewFactory.
     public static final int TYPE_UNKNOWN = -1;
     public static final int TYPE_LABEL = 0;
     public static final int TYPE_INPUT = 1;
@@ -214,9 +219,38 @@ public abstract class Field extends Observable<Field.Observer> implements Clonea
         }
     }
 
-    protected void fireValueChanged(String oldText, String newText) {
-        for (int i = 0; i < mObservers.size(); i++) {
-            mObservers.get(i).onValueChanged(this, oldText, newText);
+    /**
+     * Triggers events (both {@link ChangeEvent}s and {@link Observer}s) in response to a value
+     * change. If the field is attached to a event workspace (workspace, toolbox, or trash), must be
+     * called on the main thread.
+     *
+     * @param oldText Old value in serialized string form.
+     * @param newText New value in serialized string form.
+     */
+    protected void fireValueChanged(final String oldText, final String newText) {
+        runAsPossibleEventGroup(new Runnable() {
+            @Override
+            public void run() {
+                if (mBlock != null) {
+                    mBlock.maybeAddPendingChangeEvent(
+                            BlocklyEvent.ELEMENT_FIELD, Field.this, oldText, newText);
+                }
+                for (int i = 0; i < mObservers.size(); i++) {
+                    mObservers.get(i).onValueChanged(Field.this, oldText, newText);
+                }
+            }
+        });
+    }
+
+    /**
+     * Run the closure immediately, as an event group if connected to a block & controller.
+     * @param closure
+     */
+    private void runAsPossibleEventGroup(Runnable closure) {
+        if (mBlock != null) {
+            mBlock.getController().groupAndFireEvents(closure);
+        } else {
+            closure.run();
         }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
@@ -100,7 +100,7 @@ public abstract class Input implements Cloneable {
         INPUT_TYPES.add(TYPE_DUMMY_STRING);
     }
 
-    private final String mName;
+    private final @Nullable String mName;
     private List<Field> mFields;
     private final Connection mConnection;
     @InputType
@@ -118,7 +118,7 @@ public abstract class Input implements Cloneable {
      * @param align The alignment for fields in this input (left, right, center).
      * @param connection (Optional) The connection for this input, if any..
      */
-    public Input(String name, @InputType int type, @Nullable List<Field> fields,
+    public Input(@Nullable String name, @InputType int type, @Nullable List<Field> fields,
                  @Alignment int align, Connection connection) {
         mName = name;
         mType = type;
@@ -433,13 +433,13 @@ public abstract class Input implements Cloneable {
      */
     public static final class InputValue extends Input implements Cloneable {
 
-        public InputValue(String name, @Nullable List<Field> fields, String alignString,
+        public InputValue(@Nullable String name, @Nullable List<Field> fields, String alignString,
                           String[] checks) {
             super(name, TYPE_VALUE, fields, alignString,
                     new Connection(Connection.CONNECTION_TYPE_INPUT, checks));
         }
 
-        public InputValue(String name, @Nullable List<Field> fields, @Alignment int align,
+        public InputValue(@Nullable String name, @Nullable List<Field> fields, @Alignment int align,
                           String[] checks) {
             super(name, TYPE_VALUE, fields, align,
                     new Connection(Connection.CONNECTION_TYPE_INPUT, checks));
@@ -471,14 +471,16 @@ public abstract class Input implements Cloneable {
      */
     public static final class InputStatement extends Input implements Cloneable {
 
-        public InputStatement(String name, @Nullable List<Field> fields, String alignString,
-                              String[] checks) {
+        public InputStatement(
+                @Nullable String name, @Nullable List<Field> fields, String alignString,
+                String[] checks) {
             super(name, TYPE_STATEMENT, fields, alignString,
                     new Connection(Connection.CONNECTION_TYPE_NEXT, checks));
         }
 
-        public InputStatement(String name, @Nullable List<Field> fields, @Alignment int align,
-                              String[] checks) {
+        public InputStatement(
+                @Nullable String name, @Nullable List<Field> fields, @Alignment int align,
+                String[] checks) {
             super(name, TYPE_STATEMENT, fields, align,
                     new Connection(Connection.CONNECTION_TYPE_NEXT, checks));
         }
@@ -508,11 +510,12 @@ public abstract class Input implements Cloneable {
      */
     public static final class InputDummy extends Input implements Cloneable {
 
-        public InputDummy(String name, @Nullable List<Field> fields, String alignString) {
+        public InputDummy(@Nullable String name, @Nullable List<Field> fields, String alignString) {
             super(name, TYPE_DUMMY, fields, alignString, null);
         }
 
-        public InputDummy(String name, @Nullable List<Field> fields, @Alignment int align) {
+        public InputDummy(
+                @Nullable String name, @Nullable List<Field> fields, @Alignment int align) {
             super(name, TYPE_DUMMY, fields, align, null);
         }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Input.java
@@ -16,9 +16,12 @@
 package com.google.blockly.model;
 
 import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.util.Pair;
 
 import com.google.blockly.android.ui.InputView;
+import com.google.blockly.utils.BlockLoadingException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -335,12 +338,12 @@ public abstract class Input implements Cloneable {
      *
      * @return An instance of {@link Input} generated from the json.
      */
-    public static Input fromJson(JSONObject json, List<Field> fields) {
+    public static Input fromJson(JSONObject json, List<Field> fields) throws BlockLoadingException {
         String type = null;
         try {
             type = json.getString("type");
         } catch (JSONException e) {
-            throw new RuntimeException("Error getting the field type.", e);
+            throw new BlockLoadingException("Input definition missing \"type\".", e);
         }
 
         switch (type) {
@@ -413,6 +416,14 @@ public abstract class Input implements Cloneable {
         return ALIGN_LEFT;
     }
 
+    private static String getInputName(JSONObject json) throws BlockLoadingException {
+        try {
+            return json.getString("name");
+        } catch (JSONException e) {
+            throw new BlockLoadingException("Input definition missing \"name\" attribute.");
+        }
+    }
+
     @Nullable
     public Block getConnectedBlock() {
         return (mConnection == null) ? null : mConnection.getTargetBlock();
@@ -433,13 +444,13 @@ public abstract class Input implements Cloneable {
      */
     public static final class InputValue extends Input implements Cloneable {
 
-        public InputValue(@Nullable String name, @Nullable List<Field> fields, String alignString,
+        public InputValue(@NonNull String name, @Nullable List<Field> fields, String alignString,
                           String[] checks) {
             super(name, TYPE_VALUE, fields, alignString,
                     new Connection(Connection.CONNECTION_TYPE_INPUT, checks));
         }
 
-        public InputValue(@Nullable String name, @Nullable List<Field> fields, @Alignment int align,
+        public InputValue(@NonNull String name, @Nullable List<Field> fields, @Alignment int align,
                           String[] checks) {
             super(name, TYPE_VALUE, fields, align,
                     new Connection(Connection.CONNECTION_TYPE_INPUT, checks));
@@ -449,8 +460,8 @@ public abstract class Input implements Cloneable {
             super(inv);
         }
 
-        private InputValue(JSONObject json, List<Field> fields) {
-            this(json.optString("name", "NAME"), fields, json.optString("align"),
+        private InputValue(JSONObject json, List<Field> fields) throws BlockLoadingException {
+            this(getInputName(json), fields, json.optString("align"),
                     getChecksFromJson(json, "check"));
         }
 
@@ -472,14 +483,14 @@ public abstract class Input implements Cloneable {
     public static final class InputStatement extends Input implements Cloneable {
 
         public InputStatement(
-                @Nullable String name, @Nullable List<Field> fields, String alignString,
+                @NonNull String name, @Nullable List<Field> fields, String alignString,
                 String[] checks) {
             super(name, TYPE_STATEMENT, fields, alignString,
                     new Connection(Connection.CONNECTION_TYPE_NEXT, checks));
         }
 
         public InputStatement(
-                @Nullable String name, @Nullable List<Field> fields, @Alignment int align,
+                @NonNull String name, @Nullable List<Field> fields, @Alignment int align,
                 String[] checks) {
             super(name, TYPE_STATEMENT, fields, align,
                     new Connection(Connection.CONNECTION_TYPE_NEXT, checks));
@@ -489,8 +500,8 @@ public abstract class Input implements Cloneable {
             super(ins);
         }
 
-        private InputStatement(JSONObject json, List<Field> fields) {
-            this(json.optString("name", "NAME"), fields, json.optString("align"),
+        private InputStatement(JSONObject json, List<Field> fields) throws BlockLoadingException {
+            this(getInputName(json), fields, json.optString("align"),
                     getChecksFromJson(json, "check"));
         }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
@@ -35,7 +35,6 @@ import static com.google.common.truth.Truth.assertThat;
 public class BlocklyTestCase {
     protected Looper mTargetMainLooper = null;  // set during configureForUIThread()
     private Handler mHandler;
-    private Throwable mExceptionInThread = null;
 
     /**
      * Default timeout of 1 second, which should be plenty for most UI actions.  Anything longer
@@ -76,8 +75,7 @@ public class BlocklyTestCase {
      * @param runnable The code to run.
      */
     protected void runAndSync(final Runnable runnable) {
-        assertThat(mExceptionInThread).isNull();
-
+        final Throwable[] thrownRef = {null};
         final CountDownLatch latch = new CountDownLatch(1);
         mHandler.post(new Runnable() {
             @Override
@@ -85,16 +83,16 @@ public class BlocklyTestCase {
                 try {
                     runnable.run();
                 } catch (Throwable e) {
-                    mExceptionInThread = e;
+                    thrownRef[0] = e;
                 }
                 latch.countDown();
             }
         });
         awaitTimeout(latch);
 
-        if (mExceptionInThread != null) {
+        if (thrownRef[0] != null) {
             throw new IllegalStateException("Unhandled exception in mock main thread.",
-                    mExceptionInThread);
+                    thrownRef[0]);
         }
     }
 

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockFactoryTest.java
@@ -14,7 +14,6 @@
  */
 package com.google.blockly.model;
 
-import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.logging.LogLogcatRule;
 import android.support.test.rule.logging.RuleLoggingUtils;
 
@@ -28,7 +27,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -181,9 +179,10 @@ public class BlockFactoryTest extends BlocklyTestCase {
 
     @Test
     public void testBlockWithGoodFields() throws BlockLoadingException {
-        Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock("block", "8",
-            BlockTestStrings.FIELD_HAS_NAME));
-        assertThat(((FieldInput) loaded.getFieldByName("text_input")).getText()).isEqualTo("item");
+        Block loaded = parseBlockFromXml(BlockTestStrings.assembleFrankenblock(
+                "block", "8", BlockTestStrings.FIELD_HAS_NAME));
+        assertThat(((FieldInput) loaded.getFieldByName("text_input")).getText())
+                .isEqualTo("item");
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTest.java
@@ -1,0 +1,44 @@
+package com.google.blockly.model;
+
+import com.google.blockly.android.BlocklyTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link Field} class.
+ */
+
+public class FieldTest extends BlocklyTestCase {
+    @Before
+    public void setUp() {
+        configureForUIThread();
+    }
+
+    @Test
+    public void testFireValueChanged() {
+        Field field = new FieldImpl();
+
+    }
+
+    class FieldImpl extends Field {
+        String value = "unset";
+
+        public FieldImpl(String name) {
+            super(name, TYPE_UNKNOWN);
+        }
+
+        @Override
+        public boolean setFromString(String newValue) {
+            String oldValue = value;
+            value = newValue;
+            fireValueChanged(oldValue, newValue);
+            return true;
+        }
+
+        @Override
+        public String getSerializedValue() {
+            return value;
+        }
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/FieldTest.java
@@ -1,28 +1,99 @@
 package com.google.blockly.model;
 
 import com.google.blockly.android.BlocklyTestCase;
+import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.utils.BlockLoadingException;
+import com.google.blockly.utils.TestEventsCallback;
+import com.google.blockly.utils.TestFieldObserver;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests {@link Field} class.
  */
 
 public class FieldTest extends BlocklyTestCase {
+    static final String FIELD_NAME = "Field name";
+
+    static final String INITIAL_VALUE = "initial value";
+    static final String NEW_VALUE1 = "new value #1";
+    static final String NEW_VALUE2 = "new value #2";
+
+    BlocklyController mController;
+    BlockFactory mFactory;
+    Block mBlock;
+
+    Field mField;
+
+    TestEventsCallback mEventsCallback = new TestEventsCallback();
+    TestFieldObserver mFieldObserver = new TestFieldObserver();
+
     @Before
-    public void setUp() {
+    public void setUp() throws BlockLoadingException {
         configureForUIThread();
+
+        mController = new BlocklyController.Builder(getContext())
+                .build();
+        mFactory = mController.getBlockFactory();
+        mBlock = mFactory.obtainBlockFrom(new BlockTemplate().fromJson("{type:\"test block\"}"));
+
+        mField = new FieldImpl(FIELD_NAME);
+        Input input = new Input.InputDummy(
+                null, Collections.singletonList(mField), Input.ALIGN_LEFT);
+        mBlock.reshape(Collections.singletonList(input), null, null, null);
+
+        mController.addCallback(mEventsCallback);
+        mField.registerObserver(mFieldObserver);
     }
 
     @Test
     public void testFireValueChanged() {
-        Field field = new FieldImpl();
+        runAndSync(new Runnable() {
+            @Override
+            public void run() {
+                assertThat(mEventsCallback.mEventsReceived).isEmpty();
+                assertThat(mFieldObserver.mObservations).isEmpty();
 
+                mField.setFromString(NEW_VALUE1);
+
+                assertThat(mFieldObserver.mObservations).hasSize(1);
+                assertThat(mFieldObserver.mObservations.get(0).mField).isSameAs(mField);
+                assertThat(mFieldObserver.mObservations.get(0).mOldValue).isSameAs(INITIAL_VALUE);
+                assertThat(mFieldObserver.mObservations.get(0).mNewValue).isSameAs(NEW_VALUE1);
+
+                assertThat(mEventsCallback.mEventsReceived).isEmpty();  // Not attached
+
+                mController.addRootBlock(mBlock);
+
+                mEventsCallback.mEventsReceived.clear();
+                mFieldObserver.mObservations.clear();
+
+                mField.setFromString(NEW_VALUE2);
+
+                assertThat(mFieldObserver.mObservations).hasSize(1);
+                assertThat(mFieldObserver.mObservations.get(0).mField).isSameAs(mField);
+                assertThat(mFieldObserver.mObservations.get(0).mOldValue).isSameAs(NEW_VALUE1);
+                assertThat(mFieldObserver.mObservations.get(0).mNewValue).isSameAs(NEW_VALUE2);
+
+                assertThat(mEventsCallback.mEventsReceived).hasSize(1);         // One event group
+                assertThat(mEventsCallback.mEventsReceived.get(0)).hasSize(1);  // One event
+                BlocklyEvent.ChangeEvent changeEvent =
+                        (BlocklyEvent.ChangeEvent) mEventsCallback.mEventsReceived.get(0).get(0);
+                assertThat(changeEvent.getElement()).isSameAs(BlocklyEvent.ELEMENT_FIELD);
+                assertThat(changeEvent.getFieldName()).isEqualTo(FIELD_NAME);
+                assertThat(changeEvent.getOldValue()).isEqualTo(NEW_VALUE1);
+                assertThat(changeEvent.getNewValue()).isEqualTo(NEW_VALUE2);
+            }
+        });
     }
 
     class FieldImpl extends Field {
-        String value = "unset";
+        String value = INITIAL_VALUE;
 
         public FieldImpl(String name) {
             super(name, TYPE_UNKNOWN);

--- a/blocklytest/src/androidTest/java/com/google/blockly/utils/TestBlockObserver.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/utils/TestBlockObserver.java
@@ -1,0 +1,29 @@
+package com.google.blockly.utils;
+
+import com.google.blockly.model.Block;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Implementation of {@link Block.Observer} the stashes all events groups received from
+ * {@link #onBlockUpdated} into {@link #mObservations}.
+ */
+public class TestBlockObserver implements Block.Observer {
+    public final List<Observation> mObservations = new LinkedList<>();
+
+    @Override
+    public void onBlockUpdated(Block block, @Block.UpdateState int updateStateMask) {
+        mObservations.add(new Observation(block, updateStateMask));
+    }
+
+    public static class Observation {
+        public final Block mBlock;
+        public final @Block.UpdateState int mUpdateStateMask;
+
+        Observation(Block block, @Block.UpdateState int updateStateMask) {
+            mBlock = block;
+            mUpdateStateMask = updateStateMask;
+        }
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/utils/TestEventsCallback.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/utils/TestEventsCallback.java
@@ -1,0 +1,26 @@
+package com.google.blockly.utils;
+
+import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.android.control.BlocklyController.EventsCallback;
+import com.google.blockly.model.BlocklyEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of {@link EventsCallback} the stashes all events groups received from
+ * {@link #onEventGroup} into {@link #mEventsReceived}.
+ */
+public class TestEventsCallback implements BlocklyController.EventsCallback {
+    public final List<List<BlocklyEvent>> mEventsReceived = new ArrayList<>();
+
+    @Override
+    public int getTypesBitmask() {
+        return BlocklyEvent.TYPE_ALL;
+    }
+
+    @Override
+    public void onEventGroup(List<BlocklyEvent> events) {
+        mEventsReceived.add(events);
+    }
+}

--- a/blocklytest/src/androidTest/java/com/google/blockly/utils/TestFieldObserver.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/utils/TestFieldObserver.java
@@ -1,0 +1,32 @@
+package com.google.blockly.utils;
+
+import com.google.blockly.model.Block;
+import com.google.blockly.model.Field;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Implementation of {@link Block.Observer} the stashes all events groups received from
+ * {@link #onValueChanged} into {@link #mObservations}.
+ */
+public class TestFieldObserver implements Field.Observer {
+    public final List<Observation> mObservations = new LinkedList<>();
+
+    @Override
+    public void onValueChanged(Field field, String oldValue, String newValue) {
+        mObservations.add(new Observation(field, oldValue, newValue));
+    }
+
+    public static class Observation {
+        public final Field mField;
+        public final String mOldValue;
+        public final String mNewValue;
+
+        Observation(Field field, String oldValue, String newValue) {
+            mField = field;
+            mOldValue = oldValue;
+            mNewValue = newValue;
+        }
+    }
+}

--- a/blocklytest/src/main/res/raw/test_blocks.json
+++ b/blocklytest/src/main/res/raw/test_blocks.json
@@ -187,10 +187,12 @@
         "type": "input_dummy"
       },
       {
-        "type": "input_value"
+        "type": "input_value",
+        "name": "the_value"
       },
       {
-        "type": "input_statement"
+        "type": "input_statement",
+        "name": "the_statement"
       }
     ]
   },


### PR DESCRIPTION
Also
 * Adding TestEventCallback, TestBlockObserver, and TestFieldObserver, implementations that each collect their respect events for testing replacing some prior implementations.
 * Fix issue with WorkspaceHelper.getView() in a headless mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/572)
<!-- Reviewable:end -->
