### PR TITLE
Adding Block.setEventCallback(EventCallback)

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -507,6 +508,14 @@ public class BlocklyController {
             recalculateListenerEventMask();
         }
         return found;
+    }
+
+    /**
+     * @return A count of registered {@link EventsCallback}s.
+     */
+    @VisibleForTesting
+    public int getCallbackCount() {
+        return mListeners.size();
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -118,6 +118,7 @@ public class Block extends Observable<Block.Observer> {
     private boolean mInputsInlineModified = false;
 
     private String mEventWorkspaceId = null;
+    private BlocklyController.EventsCallback mEventCallback = null;
 
     /** Position of the block in the workspace. Only serialized for the root block. */
     private WorkspacePoint mPosition;
@@ -697,6 +698,7 @@ public class Block extends Observable<Block.Observer> {
      *
      * @return A new block tree with a copy of this block as the root.
      */
+    @NonNull
     public Block deepCopy() {
         try {
             String xml = BlocklyXmlHelper.writeBlockToXml(this,
@@ -776,6 +778,7 @@ public class Block extends Observable<Block.Observer> {
     /**
      * @return The {@link Block} for the last non-shadow child in this sequence, possibly itself.
      */
+    @NonNull
     public Block getLastBlockInSequence() {
         Block last = this;
         Block next = this.getNextBlock();
@@ -796,6 +799,7 @@ public class Block extends Observable<Block.Observer> {
      *
      * @return the {@link Connection} on the only input on the last block in the chain.
      */
+    @Nullable
     public Connection getLastUnconnectedInputConnection() {
         Block block = this;
 
@@ -824,6 +828,7 @@ public class Block extends Observable<Block.Observer> {
      *
      * @return The highest block found.
      */
+    @NonNull
     public Block getRootBlock() {
         Block block = this;
         Block parent = block.getParentBlock();
@@ -862,9 +867,29 @@ public class Block extends Observable<Block.Observer> {
      * @return The block connected to the output or previous {@link Connection}, if present.
      *         Otherwise null.
      */
+    @Nullable
     public Block getParentBlock() {
         Connection parentConnection = getParentConnection();
         return parentConnection == null ? null : parentConnection.getBlock();
+    }
+
+    /**
+     * Sets a event callback that will follow the block to any workspace (or workspace equivalent:
+     * toolbox or trash) it is attached to. This get called on all events.
+     * @param callback The block's callback or null
+     */
+    public void setEventCallback(@Nullable BlocklyController.EventsCallback callback) {
+        if (mEventCallback != null) {
+            mController.removeCallback(mEventCallback);
+        }
+        mEventCallback = callback;
+        if (mEventCallback != null) {
+            mController.addCallback(mEventCallback);
+        }
+    }
+
+    public BlocklyController.EventsCallback getEventCallback() {
+        return mEventCallback;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -877,7 +877,7 @@ public class Block extends Observable<Block.Observer> {
     }
 
     /**
-     * Sets a event callback that will receive {@link BlocklyEvent}s for the lifetime of the block.
+     * Sets an event callback that will receive {@link BlocklyEvent}s for the lifetime of the block.
      * @param callback The block's callback, or null to unset.
      */
     public void setEventCallback(@Nullable BlocklyController.EventsCallback callback) {

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -1244,6 +1244,10 @@ public class BlockTest extends BlocklyTestCase {
                 .isEqualTo(Block.UPDATE_IS_DELETABLE);
     }
 
+    public void testSetEventCallback() {
+        
+    }
+
     private String toXml(Block block) {
         StringOutputStream out = new StringOutputStream();
         try {

--- a/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/model/BlockTest.java
@@ -1253,7 +1253,8 @@ public class BlockTest extends BlocklyTestCase {
         runAndSync(new Runnable() {
             @Override
             public void run() {
-                mController.addRootBlock(block);
+                assertThat(mController.getCallbackCount()).isEqualTo(0);
+                block.setEventWorkspaceId("Fake Workspace Id");
 
                 // Reference the event list directly, for later verification.
                 List<List<BlocklyEvent>> eventsReceived = mEventsCallback.mEventsReceived;
@@ -1265,6 +1266,7 @@ public class BlockTest extends BlocklyTestCase {
 
                 // Set callback and attempt to remove the direct reference to the callback.
                 block.setEventCallback(mEventsCallback);
+                assertThat(mController.getCallbackCount()).isEqualTo(1);
                 mEventsCallback = null;
                 System.gc();
                 try {
@@ -1282,6 +1284,8 @@ public class BlockTest extends BlocklyTestCase {
                 block.setEventCallback(null);
                 mController.addPendingEvent(event);
                 assertThat(eventsReceived).isEmpty();
+
+                assertThat(mController.getCallbackCount()).isEqualTo(0);
             }
         });
     }


### PR DESCRIPTION
Compare to web's block.setOnChange(..), although this (currently) adds the callback to the controller, listening regardless of whether the block is attached to a workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/573)
<!-- Reviewable:end -->
