### PR TITLE
 Adding DefaultBlocks, constants related to the default/playground blocks

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_2/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_2/toolbox.xml
@@ -21,12 +21,17 @@
         <block type="statement_statement_input"></block>
         <block type="statement_value_input"></block>
     </category>
-    <category name="Outputs">
-        <block type="simple_input_output"></block>
-        <block type="multiple_input_output"></block>
-        <block type="statement_multiple_value_input"></block>
-        <block type="statement_statement_input"></block>
-        <block type="statement_value_input"></block>
+    <category name="Loops">
+        <block type="controls_repeat_ext">
+            <value name="TIMES">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="controls_whileUntil">
+            <field name="MODE">UNTIL</field>
+        </block>
     </category>
     <category name="Numbers">
         <block type="test_number">

--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -26,7 +26,7 @@
         <block type="output_no_input"></block>
         <block type="statement_no_next"></block>
     </category>
-    <category name="Outputs">
+    <category name="Loops">
         <block type="controls_repeat_ext">
             <value name="TIMES">
                 <shadow type="math_number">
@@ -37,11 +37,6 @@
         <block type="controls_whileUntil">
             <field name="MODE">UNTIL</field>
         </block>
-        <block type="simple_input_output"></block>
-        <block type="multiple_input_output"></block>
-        <block type="statement_multiple_value_input"></block>
-        <block type="statement_statement_input"></block>
-        <block type="statement_value_input"></block>
     </category>
     <category name="Groups">
         <block type="statement_no_input">

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -29,6 +29,7 @@ import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.android.codegen.LoggingCodeGeneratorCallback;
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.model.Block;
+import com.google.blockly.model.DefaultBlocks;
 import com.google.blockly.utils.BlockLoadingException;
 
 import java.io.IOException;
@@ -47,12 +48,12 @@ public class DevTestsActivity extends BlocklySectionsActivity {
     public static final String SAVED_WORKSPACE_FILENAME = "dev_tests_workspace.xml";
     private static final List<String> BLOCK_DEFINITIONS = Collections.unmodifiableList(
             Arrays.asList(
-                    "default/list_blocks.json",
-                    "default/logic_blocks.json",
-                    "default/loop_blocks.json",
-                    "default/math_blocks.json",
-                    "default/text_blocks.json",
-                    "default/variable_blocks.json",
+                    DefaultBlocks.LIST_BLOCKS_PATH,
+                    DefaultBlocks.LOGIC_BLOCKS_PATH,
+                    DefaultBlocks.LOOP_BLOCKS_PATH,
+                    DefaultBlocks.MATH_BLOCKS_PATH,
+                    DefaultBlocks.TEXT_BLOCKS_PATH,
+                    DefaultBlocks.VARIABLE_BLOCKS_PATH,
                     "default/test_blocks.json",
                     "sample_sections/mock_block_definitions.json"
             ));

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/SimpleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/SimpleActivity.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 import com.google.blockly.android.AbstractBlocklyActivity;
 import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.android.codegen.LoggingCodeGeneratorCallback;
+import com.google.blockly.model.DefaultBlocks;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,14 +30,15 @@ import java.util.List;
 public class SimpleActivity extends AbstractBlocklyActivity {
     private static final String TAG = "SimpleActivity";
 
+    // Add custom blocks to this list.
     private static final List<String> BLOCK_DEFINITIONS = Arrays.asList(
-            "default/logic_blocks.json",
-            "default/loop_blocks.json",
-            "default/math_blocks.json",
-            "default/text_blocks.json",
-            "default/list_blocks.json",
-            "default/colour_blocks.json",
-            "default/variable_blocks.json"
+            DefaultBlocks.COLOR_BLOCKS_PATH,
+            DefaultBlocks.LIST_BLOCKS_PATH,
+            DefaultBlocks.LOGIC_BLOCKS_PATH,
+            DefaultBlocks.LOOP_BLOCKS_PATH,
+            DefaultBlocks.MATH_BLOCKS_PATH,
+            DefaultBlocks.TEXT_BLOCKS_PATH,
+            DefaultBlocks.VARIABLE_BLOCKS_PATH
     );
     private static final List<String> JAVASCRIPT_GENERATORS = Arrays.asList(
         // Custom block generators go here. Default blocks are already included.
@@ -55,7 +57,8 @@ public class SimpleActivity extends AbstractBlocklyActivity {
     @NonNull
     @Override
     protected String getToolboxContentsXmlPath() {
-        return "default/toolbox.xml";
+        // Replace with a toolbox that includes application specific blocks.
+        return DefaultBlocks.TOOLBOX_PATH;
     }
 
     @NonNull

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
@@ -31,6 +31,7 @@ import com.google.blockly.android.AbstractBlocklyActivity;
 import com.google.blockly.android.BlocklySectionsActivity;
 import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.android.control.BlocklyController;
+import com.google.blockly.model.DefaultBlocks;
 import com.google.blockly.util.JavascriptUtil;
 import com.google.blockly.utils.BlockLoadingException;
 
@@ -47,12 +48,12 @@ public class TurtleActivity extends BlocklySectionsActivity {
 
     public static final String SAVED_WORKSPACE_FILENAME = "turtle_workspace.xml";
     static final List<String> TURTLE_BLOCK_DEFINITIONS = Arrays.asList(
-            "default/logic_blocks.json",
-            "default/loop_blocks.json",
-            "default/math_blocks.json",
-            "default/variable_blocks.json",
-            "default/colour_blocks.json",
-            "default/text_blocks.json",
+            DefaultBlocks.COLOR_BLOCKS_PATH,
+            DefaultBlocks.LOGIC_BLOCKS_PATH,
+            DefaultBlocks.LOOP_BLOCKS_PATH,
+            DefaultBlocks.MATH_BLOCKS_PATH,
+            DefaultBlocks.TEXT_BLOCKS_PATH,
+            DefaultBlocks.VARIABLE_BLOCKS_PATH,
             "turtle/turtle_blocks.json"
     );
     static final List<String> TURTLE_BLOCK_GENERATORS = Arrays.asList(

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -21,6 +21,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.util.ArrayMap;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -38,6 +39,8 @@ import com.google.blockly.android.codegen.CodeGenerationRequest;
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.ui.BlockViewFactory;
 import com.google.blockly.model.BlockExtension;
+import com.google.blockly.model.DefaultBlocks;
+import com.google.blockly.model.Mutator;
 import com.google.blockly.utils.BlockLoadingException;
 
 import java.io.IOException;
@@ -392,15 +395,33 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
 
     /**
      * Loads the list of {@link BlockExtension}s that support the block definitions in this
-     * activity. By default, returns {@link BlockExtension#STANDARD_EXTENSIONS}. Called from
-     * {@link #resetBlockFactory()}.
+     * activity. By default, returns a mutable version of {@link DefaultBlocks#getExtensions()} so
+     * subclasses can easily append their own extensions. Called from {@link #resetBlockFactory()}.
      *
-     * @return The list of extensions to use for future blocks. Null is treated like an empty list.
+     * @return A list of extensions to use for future blocks. Null is treated like an empty list.
      */
     @Nullable
     protected Map<String, BlockExtension> getBlockExtensions() {
         // Create a new instance so it is easy to append by subclasses.  Not called very often.
-        return new HashMap<>(BlockExtension.STANDARD_EXTENSIONS);
+        Map<String, BlockExtension> extensions = new ArrayMap<>();
+        extensions.putAll(DefaultBlocks.getExtensions());
+        return extensions;
+    }
+
+    /**
+     * Loads the list of {@link Mutator.Factory}s that support the block definitions in this
+     * activity. By default, returns a mutable versions of {@link DefaultBlocks#getMutators()} so
+     * subclasses can easily append their own mutators. Called from {@link #resetBlockFactory()}.
+     *
+     * @return A list of mutator factories to use for future blocks. Null is treated like an empty
+     *         list.
+     */
+    @Nullable
+    protected Map<String, Mutator.Factory> getMutators() {
+        // Create a new instance so it is easy to append by subclasses.  Not called very often.
+        Map<String, Mutator.Factory> mutators = new ArrayMap<>();
+        mutators.putAll(DefaultBlocks.getMutators());
+        return mutators;
     }
 
     /**
@@ -585,7 +606,8 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     protected void resetBlockFactory() {
         mBlockly.resetBlockFactory(
                 getBlockDefinitionsJsonPaths(),
-                getBlockExtensions());
+                getBlockExtensions(),
+                getMutators());
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/BlocklyActivityHelper.java
@@ -36,6 +36,7 @@ import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.BlockExtension;
 import com.google.blockly.model.BlockFactory;
 import com.google.blockly.model.BlocklySerializerException;
+import com.google.blockly.model.Mutator;
 import com.google.blockly.model.Workspace;
 import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.StringOutputStream;
@@ -482,16 +483,23 @@ public class BlocklyActivityHelper {
      */
     public void resetBlockFactory(
             @Nullable List<String> blockDefinitionsJsonPaths,
-            @Nullable Map<String, BlockExtension> blockExtensions) {
+            @Nullable Map<String, BlockExtension> blockExtensions,
+            @Nullable Map<String, Mutator.Factory> mutators) {
         AssetManager assets = mActivity.getAssets();
         BlockFactory factory = mController.getBlockFactory();
         factory.clear();
 
         String assetPath = null;
         try {
+            // Register Extensions and Mutators before parsing block definition JSON
             if (blockExtensions != null) {
-                for (String id : blockExtensions.keySet()) {
-                    factory.registerExtension(id, blockExtensions.get(id));
+                for (String extensionId : blockExtensions.keySet()) {
+                    factory.registerExtension(extensionId, blockExtensions.get(extensionId));
+                }
+            }
+            if (mutators != null) {
+                for (String mutatorId : mutators.keySet()) {
+                    factory.registerMutator(mutatorId, mutators.get(mutatorId));
                 }
             }
             if (blockDefinitionsJsonPaths != null) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockExtension.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockExtension.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * {@link AbstractBlocklyActivity#getBlockExtensions()} to register several extensions at start up.
  * <p/>
  * All extensions used by the blocks found in {@code src/main/assets/default/} are defined in
- * {@link #STANDARD_EXTENSIONS}, the default return value of
+ * {@link DefaultBlocks#getExtensions()}, the default return value of
  * {@linkplain AbstractBlocklyActivity#getBlockExtensions()}.
  * <p/>
  * Block definitions can refer to these extensions two ways. If a extension installs a
@@ -43,9 +43,6 @@ import java.util.Map;
  * extensions and mutators</a>.
  */
 public interface BlockExtension {
-    Map<String, BlockExtension> STANDARD_EXTENSIONS =
-            Collections.<String, BlockExtension>emptyMap();  // TODO
-
     /**
      * Applies the extension to the provided block.
      * @param block The block to update

--- a/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
@@ -1,0 +1,85 @@
+package com.google.blockly.model;
+
+import android.support.v4.util.ArrayMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Constants class for all default block definitions and supporting files.
+ */
+public final class DefaultBlocks {
+    /** Path to block definitions for blocks related to colors. */
+    public static final String COLOR_BLOCKS_PATH = "default/colour_blocks.json";
+    /** Path to block definitions for blocks related to lists. Does not include math on lists. */
+    public static final String LIST_BLOCKS_PATH = "default/list_blocks.json";
+    /** Path to block definitions for blocks related to logic (if statements, etc.). */
+    public static final String LOGIC_BLOCKS_PATH = "default/logic_blocks.json";
+    /** Path to block definitions for blocks related to loops. */
+    public static final String LOOP_BLOCKS_PATH = "default/loop_blocks.json";
+    /** Path to block definitions for blocks related to math, including math on lists. */
+    public static final String MATH_BLOCKS_PATH = "default/math_blocks.json";
+    /** Path to block definitions for blocks related to strings/text. */
+    public static final String TEXT_BLOCKS_PATH = "default/text_blocks.json";
+    /** Path to block definitions for blocks related to variables. */
+    public static final String VARIABLE_BLOCKS_PATH = "default/variable_blocks.json";
+
+    /** Path to a toolbox that has most of the default blocks organized into categories. */
+    public static final String TOOLBOX_PATH = "default/toolbox.xml";
+
+    // Lazily constructed collections.
+    private static List<String> ALL_BLOCK_DEFINITIONS = null;
+    private static Map<String, BlockExtension> DEFAULT_EXTENSIONS  = null;
+    private static Map<String, Mutator.Factory> DEFAULT_MUTATORS = null;
+
+    /**
+     * Returns the default list of {@link BlockExtension}s. This list is loaded lazily, so it will
+     * not load the Extension and related classes if never called.
+     * @return The map of default extensions, keyed by extension id.
+     */
+    public static List<String> getAllBlockDefinitions() {
+        if (ALL_BLOCK_DEFINITIONS == null) {
+            ALL_BLOCK_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
+                    COLOR_BLOCKS_PATH,
+                    LIST_BLOCKS_PATH,
+                    LOGIC_BLOCKS_PATH,
+                    LOOP_BLOCKS_PATH,
+                    MATH_BLOCKS_PATH,
+                    TEXT_BLOCKS_PATH,
+                    VARIABLE_BLOCKS_PATH
+            ));
+        }
+        return ALL_BLOCK_DEFINITIONS;
+    }
+
+    /**
+     * Returns the default list of {@link BlockExtension}s. This list is loaded lazily, so it will
+     * not load the Extension and related classes if never called.
+     * @return The map of default extensions, keyed by extension id.
+     */
+    public static Map<String, BlockExtension> getExtensions() {
+        if (DEFAULT_EXTENSIONS == null) {
+            Map<String, BlockExtension> temp = new ArrayMap<>();
+            DEFAULT_EXTENSIONS = Collections.unmodifiableMap(temp);
+        }
+        return DEFAULT_EXTENSIONS;
+    }
+
+    /**
+     * Returns the default list of factories for the default {@link Mutator}s. This list is loaded
+     * lazily, so it will not the related classes if never called.
+     * @return The map of factories for the default mutators, keyed by mutator id.
+     */
+    public static Map<String, Mutator.Factory> getMutators() {
+        if (DEFAULT_MUTATORS == null) {
+            Map<String, Mutator.Factory> temp = new ArrayMap<>();
+            DEFAULT_MUTATORS = Collections.unmodifiableMap(temp);
+        }
+        return DEFAULT_MUTATORS;
+    }
+
+    // Not for instantiation.
+    private DefaultBlocks() {}
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
@@ -62,6 +62,7 @@ public final class DefaultBlocks {
     public static Map<String, BlockExtension> getExtensions() {
         if (DEFAULT_EXTENSIONS == null) {
             Map<String, BlockExtension> temp = new ArrayMap<>();
+            // TODO: Put new BlockExtensions
             DEFAULT_EXTENSIONS = Collections.unmodifiableMap(temp);
         }
         return DEFAULT_EXTENSIONS;
@@ -75,6 +76,7 @@ public final class DefaultBlocks {
     public static Map<String, Mutator.Factory> getMutators() {
         if (DEFAULT_MUTATORS == null) {
             Map<String, Mutator.Factory> temp = new ArrayMap<>();
+            // TODO: Put new Mutator.Factorys
             DEFAULT_MUTATORS = Collections.unmodifiableMap(temp);
         }
         return DEFAULT_MUTATORS;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
@@ -70,7 +70,7 @@ public final class DefaultBlocks {
 
     /**
      * Returns the default list of factories for the default {@link Mutator}s. This list is loaded
-     * lazily, so it will not the related classes if never called.
+     * lazily, so it will not load the related classes if never called.
      * @return The map of factories for the default mutators, keyed by mutator id.
      */
     public static Map<String, Mutator.Factory> getMutators() {


### PR DESCRIPTION
 * Adding `DefaultBlocks`, a class to store constants related to the default/playground blocks.
 * Adding support for Mutators in the `AbstractBlocklyActivity` and `BlocklyActivityHelper`.
 * Minor tweaks to DevTests toolbox (previously, "Some blocks" and "Outputs" were identical, looking like a bug).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/574)
<!-- Reviewable:end -->
