### PR TITLE
Fill in block background to end of line

### DIFF
--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -270,15 +270,11 @@ public class BlockView extends AbstractBlockView<InputView> {
         if (!isInHorizontalRangeOfBlock(x)) {
             return false;
         }
-
-        for (InputView inputView : mInputViews) {
-            if (inputView.isOnFields(
-                x - getXOffset(mHelper.useRtl(), inputView),
-                y - inputView.getTop())) {
+        for (Rect rect : mFillRects) {
+            if (rect.contains(x, y)) {
                 return true;
             }
         }
-
         return false;
     }
 
@@ -730,14 +726,16 @@ public class BlockView extends AbstractBlockView<InputView> {
             fillRectBySize(xFrom + inputLayoutOrigin.x, inputLayoutOrigin.y,
                     inputView.getFieldLayoutWidth(), inputView.getRowHeight());
 
-            switch (inputView.getInput().getType()) {
+            int inputType = inputView.getInput().getType();
+            boolean isLastInput = (i + 1 == mInputCount);
+            boolean nextIsStatement = !isLastInput
+                    && mInputViews.get(i + 1).getInput().getType() == Input.TYPE_STATEMENT;
+            boolean isEndOfLine = !mBlock.getInputsInline() || isLastInput
+                    || nextIsStatement;
+
+            switch (inputType) {
                 default:
                 case Input.TYPE_DUMMY: {
-                    boolean isLastInput = (i + 1 == mInputCount);
-                    boolean nextIsStatement = !isLastInput
-                            && mInputViews.get(i + 1).getInput().getType() == Input.TYPE_STATEMENT;
-                    boolean isEndOfLine = !mBlock.getInputsInline() || isLastInput
-                            || nextIsStatement;
                     if (isEndOfLine) {
                         addDummyBoundaryPatch(isShadow, xTo, inputView, inputLayoutOrigin);
                     }
@@ -773,6 +771,16 @@ public class BlockView extends AbstractBlockView<InputView> {
                     break;
                 }
             }
+            // If there's leftover space on the right fill it in with a rect
+            if (inputType != Input.TYPE_STATEMENT && isEndOfLine && mBlock.getInputsInline()) {
+                int start = inputLayoutOrigin.x + inputView.getMeasuredWidth();
+                int width = xTo - start;
+                if (width > 0) {
+                    fillRectBySize(start, inputLayoutOrigin.y, width, inputView.getRowHeight());
+                }
+            }
+
+
         }
 
         // Select and position correct patch for bottom and left-hand side of the block, including

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
@@ -131,16 +131,6 @@ public class InputView extends AbstractInputView {
     }
 
     /**
-     * @return True if and only if a coordinate is on the fields of this view, including the padding
-     * to the left and right of the fields.  Any connected inputs should handle events themselves
-     * and are thus not allowed here.
-     */
-    public boolean isOnFields(int eventX, int eventY) {
-        return (eventX >= 0 && eventX < (mFieldLayoutWidth + mPatchManager.mBlockTotalPaddingX)) &&
-                eventY >= 0 && eventY < mRowHeight;
-    }
-
-    /**
      * @return Total measured width of all fields in this input, including spacing between them.
      */
     int getTotalFieldWidth() {


### PR DESCRIPTION
Fixes #504. For inline inputs if the inputs didn't go to the end
of the line there would be an emtpy rectangle after them. This checks
if there's empty space after the last input on a line and fills it in.

Also simplifies the check if a location is within a block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/583)
<!-- Reviewable:end -->
