### PR TITLE
Implement (crudely) changing the shape of a BlockView

### DIFF
--- a/blocklylib-core/src/main/assets/default/logic_blocks.json
+++ b/blocklylib-core/src/main/assets/default/logic_blocks.json
@@ -16,7 +16,7 @@
     "previousStatement": null,
     "nextStatement": null,
     "colour": 210,
-    "TODO: mutator": "controls_if_mutator",
+    "mutator": "controls_if_mutator",
     "tooltip": "If a value is true, then do some statements."
   },
   {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
@@ -125,6 +125,13 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
             }
         }
         addInputViewsToViewHierarchy();
+
+        block.registerObserver(new Block.Observer() {
+            @Override
+            public void onBlockUpdated(Block block, @Block.UpdateState int updateMask) {
+                AbstractBlockView.this.onBlockUpdated(updateMask);
+            }
+        });
     }
 
     /**
@@ -225,6 +232,22 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
     @Override
     public WorkspaceView getWorkspaceView() {
         return mWorkspaceView;
+    }
+
+    /**
+     * @return The ConnectionManager managing the connections of this view.
+     */
+    @Override
+    public ConnectionManager getConnectionManager() {
+        return mConnectionManager;
+    }
+
+    /**
+     * @return The touch handler for handling the touch and drag events for this view.
+     */
+    @Override
+    public BlockTouchHandler getTouchHandler() {
+        return mTouchHandler;
     }
 
     /**
@@ -380,6 +403,10 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
      */
     protected boolean isEntireBlockHighlighted() {
         return isPressed() || isFocused() || isSelected();
+    }
+
+    protected void onBlockUpdated(@Block.UpdateState int updateMask) {
+        // Default, always rebuild view.
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
@@ -405,9 +405,12 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
         return isPressed() || isFocused() || isSelected();
     }
 
-    protected void onBlockUpdated(@Block.UpdateState int updateMask) {
-        // Default, always rebuild view.
-    }
+    /**
+     * Called when the underlying block has been updated. The view implementation should override
+     * this method to appropriately update the view to reflect the new state.
+     * @param updateMask A bit mask denoting {@link Block.UpdateState} changes.
+     */
+    protected abstract void onBlockUpdated(@Block.UpdateState int updateMask);
 
     /**
      * Test whether a {@link MotionEvent} event that has happened on this view is (approximately)

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/AbstractBlockView.java
@@ -83,6 +83,8 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
     // Currently highlighted connection.
     @Nullable protected Connection mHighlightedConnection = null;
 
+    private final MemorySafeBlockObserver mBlockObserver = new MemorySafeBlockObserver(this);
+
     /**
      * Creates a BlockView for the given {@link Block}.
      *
@@ -127,7 +129,7 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
         }
         addInputViewsToViewHierarchy();
 
-        block.registerObserver(new MemorySafeBlockObserver(this));
+        block.registerObserver(mBlockObserver);
     }
 
     /**
@@ -320,6 +322,7 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
      */
     // TODO(#146): Move tree traversal to BlockViewFactory.unregisterView(..)
     public void unlinkModel() {
+        mBlock.unregisterObserver(mBlockObserver);
         mFactory.unregisterView(this); // TODO(#137): factory -> ViewPool
 
         int max = mInputViews.size();
@@ -381,7 +384,7 @@ public abstract class AbstractBlockView<InputView extends com.google.blockly.and
                 mWorkspaceView = (WorkspaceView) parent;
                 return;
             }
-            parent = ((ViewGroup) parent).getParent();
+            parent = parent.getParent();
         }
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockView.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+import com.google.blockly.android.control.ConnectionManager;
 import com.google.blockly.model.Block;
 import com.google.blockly.model.Connection;
 import com.google.blockly.model.Input;
@@ -120,4 +121,8 @@ public interface BlockView {
      */
     @Nullable
     InputView getInputView(int n);
+
+    ConnectionManager getConnectionManager();
+
+    BlockTouchHandler getTouchHandler();
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -274,6 +274,16 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
 
         original.unlinkModel();
 
+        for (Input input : model.getInputs()) {
+            Block childBlock = input.getConnectedBlock();
+            BlockView childBlockView = childBlock == null ? null : getView(childBlock);
+            ViewGroup inputView = childBlockView == null ? null :
+                    (ViewGroup)childBlockView.getParent();
+            if (inputView != null) {
+                inputView.removeView((View) childBlockView);
+            }
+        }
+
         List<InputView> inputViews = buildInputViews(model, connectionManager, touchHandler);
         BlockView newBlockView = buildBlockView(model, inputViews, connectionManager, touchHandler);
 
@@ -436,7 +446,8 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
                         subgroup =
                                 buildBlockGroupTree(targetBlock, connectionManager, touchHandler);
                     } else {
-                        // BlockViews might already exist, especially in the case of
+                        // BlockViews might already exist, especially in the case of children of
+                        // mutated blocks.
                         ViewParent targetBlockViewParent = targetBlockView.getParent();
                         if (targetBlockViewParent == null) {
                             subgroup = buildBlockGroup();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -261,17 +261,19 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
      * @return The newly reconstructed BlockView.
      * @throws ClassCastException If original is connected to a parent that is not a ViewGroup.
      */
-    // TODO: Replace with in-place view shaping, to preserve view state (open dropdowns, text
-    //       selection, etc.) and minimize risk of breaking object references.
+    // TODO(#588): Replace with in-place view shaping, to preserve view state (open dropdowns, text
+    //             selection, etc.) and minimize risk of breaking object references.
+    // TODO(#589): Testing
+    @NonNull
     public BlockView rebuildBlockView(BlockView original) {
         if (Looper.getMainLooper() != Looper.myLooper()) {
             throw new IllegalStateException("rebuildBlockView() must run on the main thread.");
         }
 
         Block model = original.getBlock();
-        if (getView(original.getBlock()) != original) {
-            Log.w(TAG, "Refusing to rebuild a BlockView that is not in the current view.");
-            return null;  // This should very rarely happen.
+        if (getView(model) != original) {
+            throw new IllegalStateException(
+                    "Refusing to rebuild a BlockView that is not the block's current/active view.");
         }
 
         // Get parent as ViewGroup first, so any failure to cast to ViewGroup fails early.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -20,7 +20,6 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v13.view.ViewCompat;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -20,6 +20,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v13.view.ViewCompat;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -65,6 +66,8 @@ import java.util.Map;
  */
 public abstract class BlockViewFactory<BlockView extends com.google.blockly.android.ui.BlockView,
                                        InputView extends com.google.blockly.android.ui.InputView> {
+    private static final String TAG = "BlockViewFactory";
+
     /**
      * Context for creating or loading views.
      */
@@ -265,10 +268,16 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
             throw new IllegalStateException("rebuildBlockView() must run on the main thread.");
         }
 
+        Block model = original.getBlock();
+        if (getView(original.getBlock()) != original) {
+            Log.w(TAG, "Refusing to rebuild a BlockView that is not in the current view.");
+            return null;  // This should very rarely happen.
+        }
+
         // Get parent as ViewGroup first, so any failure to cast to ViewGroup fails early.
         ViewGroup parent = (ViewGroup) original.getParent();
 
-        Block model = original.getBlock();
+
         ConnectionManager connectionManager = original.getConnectionManager();
         BlockTouchHandler touchHandler = original.getTouchHandler();
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -250,9 +250,12 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
     }
 
     /**
+     * Rebuilds a BlockView based on the latest model state, replacing it in-place in the view tree.
+     * Some minor view state is not propagated (pressed, highlight, text selection, etc.) during the
+     * replacement.
      *
-     * @param original
-     * @return
+     * @param original The original BlockView to be rebuilt and replaced.
+     * @return The newly reconstructed BlockView.
      * @throws ClassCastException If original is connected to a parent that is not a ViewGroup.
      */
     // TODO: Replace with in-place view shaping, to preserve view state (open dropdowns, text
@@ -262,7 +265,7 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
             throw new IllegalStateException("rebuildBlockView() must run on the main thread.");
         }
 
-        // Get parent as ViewGroup first, so any failure to cast fails early.
+        // Get parent as ViewGroup first, so any failure to cast to ViewGroup fails early.
         ViewGroup parent = (ViewGroup) original.getParent();
 
         Block model = original.getBlock();
@@ -282,6 +285,8 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
             parent.removeView(originalView);
             parent.addView((View) newBlockView, viewIndex, lp);
         }
+
+        mBlockIdToView.put(model.getId(), new WeakReference<>(newBlockView));
         return newBlockView;
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/mutator/IfElseMutatorFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/mutator/IfElseMutatorFragment.java
@@ -41,9 +41,7 @@ import org.xmlpull.v1.XmlPullParser;
  */
 public class IfElseMutatorFragment extends MutatorFragment {
     private IfElseMutator mMutator;
-    private Block mBlock;
     private String mElseIfCountString;
-    private String mElseCountString;
     private int mElseIfCount;
     private boolean mHasElse;
 
@@ -59,7 +57,6 @@ public class IfElseMutatorFragment extends MutatorFragment {
      */
     public void init(IfElseMutator mutator) {
         mMutator = mutator;
-        mBlock = mutator.getBlock();
         mElseIfCount = mutator.getElseIfCount();
         mHasElse = mutator.hasElse();
     }
@@ -69,7 +66,6 @@ public class IfElseMutatorFragment extends MutatorFragment {
         super.onAttach(context);
         Resources res = context.getResources();
         mElseIfCountString = res.getString(R.string.mutator_if_else_ifelse_count);
-        mElseCountString = res.getString(R.string.mutator_if_else_else_count);
     }
 
     @Override
@@ -131,7 +127,8 @@ public class IfElseMutatorFragment extends MutatorFragment {
     }
 
     private void updateCountString() {
-        String elseIfCount = String.format(mElseIfCountString, mElseIfCount);
+        // Because the user always sees at least one "if", start the count at one.
+        String elseIfCount = String.format(mElseIfCountString, mElseIfCount + 1);
         mElseIfCountView.setText(elseIfCount);
     }
 
@@ -141,7 +138,6 @@ public class IfElseMutatorFragment extends MutatorFragment {
     }
 
     public static class Factory implements MutatorFragment.Factory {
-
         @Override
         public MutatorFragment newMutatorFragment(Mutator mutator) {
             IfElseMutatorFragment fragment = new IfElseMutatorFragment();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/mutator/IfElseMutatorFragment.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/mutator/IfElseMutatorFragment.java
@@ -29,11 +29,8 @@ import android.widget.TextView;
 
 import com.google.blockly.android.R;
 import com.google.blockly.android.ui.MutatorFragment;
-import com.google.blockly.model.Block;
 import com.google.blockly.model.Mutator;
 import com.google.blockly.model.mutator.IfElseMutator;
-
-import org.xmlpull.v1.XmlPullParser;
 
 /**
  * Standard fragment UI for editing an if-else block. This fragment does not support restoring

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -1015,6 +1015,7 @@ public class Block extends Observable<Block.Observer> {
      * @param updatedPrev The updated previous connection, if any.
      * @param updatedNext The updated next connection, if any.
      */
+    // TODO: Needs lots of tests.
     public void reshape(@Nullable List<Input> newInputList,
                         @Nullable Connection updatedOutput,
                         @Nullable Connection updatedPrev,
@@ -1051,7 +1052,7 @@ public class Block extends Observable<Block.Observer> {
                     // This is a critical failure, as it may leave inputs in an invalid state if
                     // another input was already removed (i.e., setBlock(null) was already called).
                     throw new IllegalStateException(
-                            "Cannot remove input \"" + in.getName() + "\" while connected.");
+                            "Cannot remove input \"" + in.getName() + "\" while connected.");       // TODO: Make test for this
                 }
                 in.setBlock(null); // Reset the block reference in removed Inputs and Fields.
             }
@@ -1062,7 +1063,7 @@ public class Block extends Observable<Block.Observer> {
                     // This is a critical failure, as it may leave inputs in an invalid state if
                     // an old input was removed above (i.e., setBlock(null) was already called).
                     throw new IllegalStateException(
-                            "Cannot add input \"" + in.getName() + "\" while connected.");
+                            "Cannot add input \"" + in.getName() + "\" while connected.");          // TODO: Make test for this
                 }
                 in.setBlock(this);
             }
@@ -1293,7 +1294,9 @@ public class Block extends Observable<Block.Observer> {
      * @param updateStateMask A bit mask of {@link UpdateState} bits for the updated parts.
      */
     private void fireUpdate(@UpdateState int updateStateMask) {
-        for (Observer observer: mObservers) {
+        // Allow mObservers to update while notifying prior observers.
+        ArrayList<Observer> observers = new ArrayList<>(mObservers);
+        for (Observer observer: observers) {
             observer.onBlockUpdated(this, updateStateMask);
         }
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -66,6 +66,7 @@ public class Block extends Observable<Block.Observer> {
     public static final int UPDATE_CONTEXT_MENU = 1 << 9;  // TODO: Not implemented/emitted
     public static final int UPDATE_INPUTS_INLINE = 1 << 10;
     public static final int UPDATE_IS_MOVEABLE = 1 << 11;
+    public static final int UPDATE_WARNING = 1 << 12; // TODO: Not implemented/emitted
 
     public interface Observer {
         /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/IfElseMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/IfElseMutator.java
@@ -6,7 +6,6 @@ import android.util.Log;
 
 import com.google.blockly.android.R;
 import com.google.blockly.android.control.BlocklyController;
-import com.google.blockly.android.ui.MutatorFragment;
 import com.google.blockly.android.ui.mutator.IfElseMutatorFragment;
 import com.google.blockly.model.Block;
 import com.google.blockly.model.Field;
@@ -37,7 +36,6 @@ public class IfElseMutator extends Mutator {
     private static final String[] CHECKS = {"Boolean"};
     private static final int ALIGN = Input.ALIGN_LEFT;
 
-    private final Context mContext;
     private final BlocklyController mController;
 
     private Block mBlock;
@@ -47,7 +45,6 @@ public class IfElseMutator extends Mutator {
     private String mIfLabel;
     private String mThenLabel;
     private String mElseLabel;
-    private String[] mChecks = {"Boolean"};
 
     /**
      * Create a new mutator for the given context and controller.
@@ -60,12 +57,11 @@ public class IfElseMutator extends Mutator {
             BlocklyController controller) {
         super(factory);
 
-        mContext = context;
         mController = controller;
         // TODO: Replace with Blockly string table/TranslationsManager call
-        mIfLabel = mContext.getString(R.string.mutator_if_else_if_label);
-        mThenLabel = mContext.getString(R.string.mutator_if_else_then_label);
-        mElseLabel = mContext.getString(R.string.mutator_if_else_else_label);
+        mIfLabel = context.getString(R.string.mutator_if_else_if_label);
+        mThenLabel = context.getString(R.string.mutator_if_else_then_label);
+        mElseLabel = context.getString(R.string.mutator_if_else_else_label);
     }
 
     @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/MathIsDivisibleByMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/MathIsDivisibleByMutator.java
@@ -1,7 +1,6 @@
 package com.google.blockly.model.mutator;
 
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.model.Block;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/MathIsDivisibleByMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/MathIsDivisibleByMutator.java
@@ -1,6 +1,7 @@
 package com.google.blockly.model.mutator;
 
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.model.Block;
@@ -33,7 +34,7 @@ public final class MathIsDivisibleByMutator extends Mutator {
     public static final class Factory implements Mutator.Factory<MathIsDivisibleByMutator> {
         @Override
         public MathIsDivisibleByMutator newMutator(BlocklyController controller) {
-            return new MathIsDivisibleByMutator(this);
+            return new MathIsDivisibleByMutator(this, controller);
         }
 
         @Override
@@ -43,6 +44,7 @@ public final class MathIsDivisibleByMutator extends Mutator {
     }
 
     private Block mBlock;
+    private BlocklyController mController;
     @VisibleForTesting FieldDropdown mDropdown;
 
     private Input mDivisorInput =
@@ -51,8 +53,9 @@ public final class MathIsDivisibleByMutator extends Mutator {
     private List<Input> mInputsWithoutDivisor;
     private List<Input> mInputsWithDivisor;
 
-    protected MathIsDivisibleByMutator(Mutator.Factory factory) {
+    protected MathIsDivisibleByMutator(Mutator.Factory factory, BlocklyController controller) {
         super(factory);
+        this.mController = controller;
     }
 
     @Override
@@ -98,10 +101,22 @@ public final class MathIsDivisibleByMutator extends Mutator {
     }
 
     private void updateShape() {
-        boolean isSelected = mDropdown.getSelectedValue().equals(DIVISIBLE_BY);
-        boolean isShown = mDivisorInput.getBlock() != null;
-        if (isSelected != isShown) {
-            mBlock.reshape(isSelected ? mInputsWithDivisor : mInputsWithoutDivisor);
-        }
+        mController.groupAndFireEvents(new Runnable() {
+            @Override
+            public void run() {
+                boolean isSelected = mDropdown.getSelectedValue().equals(DIVISIBLE_BY);
+                boolean isShown = mDivisorInput.getBlock() != null;
+                if (isSelected != isShown) {
+                    if (isShown) {
+                        Block connectedBlock = mDivisorInput.getConnectedBlock();
+                        if (connectedBlock != null) {
+                            mController.extractBlockAsRoot(connectedBlock);
+                        }
+
+                    }
+                    mBlock.reshape(isSelected ? mInputsWithDivisor : mInputsWithoutDivisor);
+                }
+            }
+        });
     }
 }

--- a/blocklylib-core/src/main/res/values/strings.xml
+++ b/blocklylib-core/src/main/res/values/strings.xml
@@ -43,8 +43,8 @@
     <string name="mutator_icon_alt_text">Modify the block\'s shape.</string>
 
     <string name="mutator_if_else_title">Update if else block</string>
-    <string name="mutator_if_else_ifelse_count">if else count: %d</string>
-    <string name="mutator_if_else_else_count">else</string>
+    <string name="mutator_if_else_ifelse_count">Number of “if” tests: %d</string>
+    <string name="mutator_if_else_else_count">Final “else” statement?</string>
     <string name="mutator_if_else_if_label">if</string>
     <string name="mutator_if_else_then_label">do</string>
     <string name="mutator_if_else_else_label">else</string>

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -52,8 +52,10 @@ public class BlockView extends AbstractBlockView<InputView> {
     private static final float SHADOW_VALUE_MULTIPLIER = 1.2f;
 
     private static final int UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS =
-            Block.UPDATE_INPUTS_FIELDS_CONNECTIONS | Block.UPDATE_IS_COLLAPSED
-            | Block.UPDATE_IS_DISABLED | Block.UPDATE_IS_SHADOW;
+            Block.UPDATE_COLOR | Block.UPDATE_IS_DISABLED | Block.UPDATE_IS_SHADOW;
+    private static final int UPDATES_THAT_MIGHT_MODIFY_CHILDREN_OR_SIZE =
+            Block.UPDATE_INPUTS_FIELDS_CONNECTIONS | Block.UPDATE_COMMENT
+                    | Block.UPDATE_INPUTS_INLINE | Block.UPDATE_IS_COLLAPSED | Block.UPDATE_WARNING;
 
     // TODO(#86): Determine from 9-patch measurements.
     private final int mMinBlockWidth;
@@ -122,15 +124,6 @@ public class BlockView extends AbstractBlockView<InputView> {
         setWillNotDraw(false);
 
         initDrawingObjects();
-
-        block.registerObserver(new Block.Observer() {
-            @Override
-            public void onBlockUpdated(Block block, @Block.UpdateState int updateMask) {
-                if ((updateMask & UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS) != 0) {
-                    onBlockStructureUpdated();
-                }
-            }
-        });
     }
 
     @Override
@@ -257,9 +250,11 @@ public class BlockView extends AbstractBlockView<InputView> {
      * Called when a block's inputs, fields, comment, or mutator is/are updated, and thus the
      * shape may have changed.
      */
-    protected void onBlockStructureUpdated() {
-        // TODO(AnmAtAnm): Mark view for full recalc?
-        requestLayout();
+    @Override
+    protected void onBlockUpdated(@Block.UpdateState int updateMask) {
+        if ((updateMask & UPDATES_THAT_MIGHT_MODIFY_CHILDREN_OR_SIZE) != 0) {
+            mFactory.rebuildBlockView(this);
+        }
     }
 
     /**

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractBlockViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/AbstractBlockViewTest.java
@@ -98,6 +98,11 @@ public class AbstractBlockViewTest extends BlocklyTestCase {
             protected void onLayout(boolean changed, int l, int t, int r, int b) {
                 // Fake. Do nothing.
             }
+
+            @Override
+            protected void onBlockUpdated(@Block.UpdateState int updateMask) {
+                // Fake. Do nothing.
+            }
         };
     }
 }


### PR DESCRIPTION
Implements support for the `Block.reshape(..)` changes. This crude implementation rebuilds the view from the model, and replaces the original view in the view tree. It looses some minor UI state, like highlight and text selection. Be careful of direct references to BlockViews.

Enables `controls_if_mutator` and minor fixes to `math_is_divisible_mutator`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/586)
<!-- Reviewable:end -->
