### PR TITLE
Add an autosave feature to AbstractBlocklyActivity

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/DevTestsActivity.java
@@ -45,7 +45,8 @@ import java.util.List;
 public class DevTestsActivity extends BlocklySectionsActivity {
     private static final String TAG = "DevTestsActivity";
 
-    public static final String SAVED_WORKSPACE_FILENAME = "dev_tests_workspace.xml";
+    public static final String SAVE_FILENAME = "dev_tests_workspace.xml";
+
     private static final List<String> BLOCK_DEFINITIONS = Collections.unmodifiableList(
             Arrays.asList(
                     DefaultBlocks.LIST_BLOCKS_PATH,
@@ -113,16 +114,6 @@ public class DevTestsActivity extends BlocklySectionsActivity {
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onLoadWorkspace() {
-        mBlocklyActivityHelper.loadWorkspaceFromAppDirSafely(SAVED_WORKSPACE_FILENAME);
-    }
-
-    @Override
-    public void onSaveWorkspace() {
-        mBlocklyActivityHelper.saveWorkspaceToAppDirSafely(SAVED_WORKSPACE_FILENAME);
     }
 
     /**
@@ -263,9 +254,23 @@ public class DevTestsActivity extends BlocklySectionsActivity {
         controller.addVariable("tak");
     }
 
-    @NonNull
     @Override
+    protected void onAutosave() {
+        // Dev tests doesn't autosave/restore the user's workspace by default as we load a specific
+        // workspace in onLoadInitialWorkspace.
+        return;
+    }
+
+    @Override
+    protected boolean onAutoload() {
+        // Dev tests doesn't autosave/restore the user's workspace by default as we load a specific
+        // workspace in onLoadInitialWorkspace.
+        return false;
+    }
+
+    @Override
+    @NonNull
     protected String getWorkspaceSavePath() {
-        return "devtests_workspace.xml";
+        return SAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/LuaActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/LuaActivity.java
@@ -38,7 +38,8 @@ import java.util.List;
 public class LuaActivity extends AbstractBlocklyActivity {
     private static final String TAG = "LuaActivity";
 
-    private static final String SAVED_WORKSPACE_FILENAME = "lua_workspace.xml";
+    private static final String SAVE_FILENAME = "lua_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "lua_workspace_temp.xml";
     // Add custom blocks to this list.
     private static final List<String> BLOCK_DEFINITIONS = DefaultBlocks.getAllBlockDefinitions();
     private static final List<String> LUA_GENERATORS = Arrays.asList();
@@ -154,11 +155,15 @@ public class LuaActivity extends AbstractBlocklyActivity {
         mGeneratedTextView.setMinWidth((int) (maxline * 13 * density));
     }
 
-    @NonNull
     @Override
+    @NonNull
     protected String getWorkspaceSavePath() {
-        // SplitActivity uses the turtle block definitions, and thus shares the same file as
-        // TurtleActivity.
-        return SAVED_WORKSPACE_FILENAME;
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/SimpleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/SimpleActivity.java
@@ -30,6 +30,9 @@ import java.util.List;
 public class SimpleActivity extends AbstractBlocklyActivity {
     private static final String TAG = "SimpleActivity";
 
+    private static final String SAVE_FILENAME = "simple_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "simple_workspace_temp.xml";
+
     // Add custom blocks to this list.
     private static final List<String> BLOCK_DEFINITIONS = Arrays.asList(
             DefaultBlocks.COLOR_BLOCKS_PATH,
@@ -72,5 +75,17 @@ public class SimpleActivity extends AbstractBlocklyActivity {
     protected CodeGenerationRequest.CodeGeneratorCallback getCodeGenerationCallback() {
         // Uses the same callback for every generation call.
         return mCodeGeneratorCallback;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceSavePath() {
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/SplitActivity.java
@@ -36,6 +36,9 @@ import java.util.List;
 public class SplitActivity extends AbstractBlocklyActivity {
     private static final String TAG = "SplitActivity";
 
+    private static final String SAVE_FILENAME = "split_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "split_workspace_temp.xml";
+
     private TextView mGeneratedTextView;
     private Handler mHandler;
 
@@ -140,11 +143,15 @@ public class SplitActivity extends AbstractBlocklyActivity {
         mGeneratedTextView.setMinWidth((int) (maxline * 13 * density));
     }
 
-    @NonNull
     @Override
+    @NonNull
     protected String getWorkspaceSavePath() {
-        // SplitActivity uses the turtle block definitions, and thus shares the same file as
-        // TurtleActivity.
-        return TurtleActivity.SAVED_WORKSPACE_FILENAME;
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/StylesActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/StylesActivity.java
@@ -30,6 +30,9 @@ import java.util.List;
 public class StylesActivity extends AbstractBlocklyActivity {
     private static final String TAG = "StylesActivity";
 
+    private static final String SAVE_FILENAME = "styles_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "styles_workspace_temp.xml";
+
     CodeGenerationRequest.CodeGeneratorCallback mCodeGeneratorCallback =
             new LoggingCodeGeneratorCallback(this, TAG);
 
@@ -58,5 +61,17 @@ public class StylesActivity extends AbstractBlocklyActivity {
     protected CodeGenerationRequest.CodeGeneratorCallback getCodeGenerationCallback() {
         // Uses the same callback for every generation call.
         return mCodeGeneratorCallback;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceSavePath() {
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/TurtleActivity.java
@@ -46,7 +46,9 @@ import java.util.List;
 public class TurtleActivity extends BlocklySectionsActivity {
     private static final String TAG = "TurtleActivity";
 
-    public static final String SAVED_WORKSPACE_FILENAME = "turtle_workspace.xml";
+    private static final String SAVE_FILENAME = "turtle_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "turtle_workspace_temp.xml";
+
     static final List<String> TURTLE_BLOCK_DEFINITIONS = Arrays.asList(
             DefaultBlocks.COLOR_BLOCKS_PATH,
             DefaultBlocks.LOGIC_BLOCKS_PATH,
@@ -98,12 +100,12 @@ public class TurtleActivity extends BlocklySectionsActivity {
 
     @Override
     public void onLoadWorkspace() {
-        mBlocklyActivityHelper.loadWorkspaceFromAppDirSafely(SAVED_WORKSPACE_FILENAME);
+        mBlocklyActivityHelper.loadWorkspaceFromAppDirSafely(SAVE_FILENAME);
     }
 
     @Override
     public void onSaveWorkspace() {
-        mBlocklyActivityHelper.saveWorkspaceToAppDirSafely(SAVED_WORKSPACE_FILENAME);
+        mBlocklyActivityHelper.saveWorkspaceToAppDirSafely(SAVE_FILENAME);
     }
 
     @Override
@@ -226,9 +228,15 @@ public class TurtleActivity extends BlocklySectionsActivity {
         controller.addVariable("android");
     }
 
-    @NonNull
     @Override
+    @NonNull
     protected String getWorkspaceSavePath() {
-        return SAVED_WORKSPACE_FILENAME;
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/flyout/AlwaysOpenToolboxActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/flyout/AlwaysOpenToolboxActivity.java
@@ -32,7 +32,10 @@ import java.util.List;
  * TODO: Add menu to switch between different layouts.
  */
 public class AlwaysOpenToolboxActivity extends AbstractBlocklyActivity {
-    private static final String TAG = "StyledFlyouts";
+    private static final String TAG = "AlwaysOpenToolbox";
+
+    private static final String SAVE_FILENAME = "always_open_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "always_open_workspace_temp.xml";
 
     private static final List<String> BLOCK_DEFINITIONS = Arrays.asList(
             "default/logic_blocks.json",
@@ -92,5 +95,17 @@ public class AlwaysOpenToolboxActivity extends AbstractBlocklyActivity {
     protected View onCreateContentView(int parentId) {
         View root = getLayoutInflater().inflate(R.layout.styled_content, null);
         return root;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceSavePath() {
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/flyout/NoCategoriesToolboxActivity.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/flyout/NoCategoriesToolboxActivity.java
@@ -19,6 +19,9 @@ import java.util.List;
 public class NoCategoriesToolboxActivity extends AbstractBlocklyActivity {
     private static final String TAG = "NoCatsActivity";
 
+    private static final String SAVE_FILENAME = "no_cats_workspace.xml";
+    private static final String AUTOSAVE_FILENAME = "no_cats_workspace_temp.xml";
+
     private static final List<String> BLOCK_DEFINITIONS = Arrays.asList(
             "default/logic_blocks.json",
             "default/loop_blocks.json",
@@ -72,5 +75,17 @@ public class NoCategoriesToolboxActivity extends AbstractBlocklyActivity {
         // Initialize variable names.
         // TODO: (#22) Remove this override when variables are supported properly
         getController().addVariable("item");
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceSavePath() {
+        return SAVE_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return AUTOSAVE_FILENAME;
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -331,10 +331,12 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     /**
      *
      * Returns true if the app should proceed to restore the blockly state from the
-     * {@code savedInstanceState} Bundle. By default, it always returns true, but Activity
-     * developers can override this method to add conditional logic.
+     * {@code savedInstanceState} Bundle or the {@link #onAutoload() auto save} file. By default, it
+     * always returns true, but Activity developers can override this method to add conditional
+     * logic.
      * <p/>
-     * This does not prevent the state from saving to a Bundle during {@link #onSaveInstanceState}.
+     * This does not prevent the state from saving to a Bundle during {@link #onSaveInstanceState}
+     * or saving to a file in {@link #onAutosave()}.
      *
      * @param savedInstanceState The Bundle to restore state from.
      * @return True if Blockly state should be restored. Otherwise, null.

--- a/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/AbstractBlocklyActivity.java
@@ -40,11 +40,13 @@ import com.google.blockly.android.ui.BlockViewFactory;
 import com.google.blockly.android.ui.MutatorFragment;
 import com.google.blockly.model.BlocklyCategory;
 import com.google.blockly.model.BlockExtension;
+import com.google.blockly.model.BlocklySerializerException;
 import com.google.blockly.model.CategoryFactory;
 import com.google.blockly.model.DefaultBlocks;
 import com.google.blockly.model.Mutator;
 import com.google.blockly.utils.BlockLoadingException;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -267,7 +269,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
 
         // Load the workspace.
         boolean loadedPriorInstance = checkAllowRestoreBlocklyState(savedInstanceState)
-                && getController().onRestoreSnapshot(savedInstanceState);
+                && (getController().onRestoreSnapshot(savedInstanceState) || onAutoload());
         if (!loadedPriorInstance) {
             onLoadInitialWorkspace();
         }
@@ -292,6 +294,7 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
         mBlocklyActivityHelper.onPause();
+        onAutosave();
     }
 
     /** Propagate lifecycle event to BlocklyActivityHelper. */
@@ -347,6 +350,36 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     protected void onLoadInitialWorkspace() {
         onInitBlankWorkspace();
         getController().closeFlyouts();
+    }
+
+    /**
+     * Called when an autosave of the workspace is triggered, typically by {@link #onPause()}.
+     * By default this saves the workspace to a file in the app's directory.
+     */
+    protected void onAutosave() {
+        try {
+            mBlocklyActivityHelper.saveWorkspaceToAppDir(getWorkspaceAutosavePath());
+        } catch (FileNotFoundException | BlocklySerializerException e) {
+            Log.e(TAG, "Failed to autosaving workspace.", e);
+        }
+    }
+
+    /**
+     * Called when the activity tries to restore the autosaved workspace, typically by
+     * {@link #onCreate(Bundle)} if there was no workspace data in the bundle.
+     *
+     * @return true if a previously saved workspace was loaded, false otherwise.
+     */
+    protected boolean onAutoload() {
+        try {
+            mBlocklyActivityHelper.loadWorkspaceFromAppDir(getWorkspaceAutosavePath());
+            return true;
+        } catch (FileNotFoundException e) {
+            // No workspace was saved previously.
+        } catch (BlockLoadingException | IOException e) {
+            Log.e(TAG, "Failed to load workspace", e);
+        }
+        return false;
     }
 
     /**
@@ -475,6 +508,15 @@ public abstract class AbstractBlocklyActivity extends AppCompatActivity {
     @NonNull
     protected String getWorkspaceSavePath() {
         return "workspace.xml";
+    }
+
+    /**
+     * @return The path to the automatically saved workspace file on the local device. By default,
+     *         "autosave_workspace.xml".
+     */
+    @NonNull
+    protected String getWorkspaceAutosavePath() {
+        return "autosave_workspace.xml";
     }
 
     /**


### PR DESCRIPTION
Adds auto saving and auto loading the workspace to the AbstractBlocklyActivity
with hooks to override the file it is saved to or to override the functionality.
All demo apps are updated to use a unique filename for saving and autosaving
and DevTests overrides the autosave/load to prevent replacing the test
workspace that is loaded each time the activity is started.

Fixes #534

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/594)
<!-- Reviewable:end -->
