### PR TITLE
Fix field name in test_blocks json

### DIFF
--- a/blocklylib-core/src/main/assets/default/test_blocks.json
+++ b/blocklylib-core/src/main/assets/default/test_blocks.json
@@ -359,7 +359,7 @@
       },
       {
         "type": "input_statement",
-        "name": "NAME"
+        "name": "DO"
       }
     ],
     "inputsInline": true,


### PR DESCRIPTION
This was causing a crash in DevTests Section 3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/607)
<!-- Reviewable:end -->
