### PR TITLE
Add getBlockViewFactory to BlocklyController

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -477,6 +477,10 @@ public class BlocklyController {
         return mModelFactory;
     }
 
+    public BlockViewFactory getBlockViewFactory() {
+        return mViewFactory;
+    }
+
     public WorkspaceHelper getWorkspaceHelper() {
         return mHelper;
     }


### PR DESCRIPTION
We had a way to access the model factory but not he view factory. This
is useful for configureMutators() to avoid having to keep an extra
reference to the view factory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/611)
<!-- Reviewable:end -->
