### PR TITLE
Fixes crash where procedure reference came before the definition

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
@@ -143,6 +143,7 @@ public class WorkspaceStats {
      */
     public void collectStats(Block block, boolean recursive) {
         boolean isProcedureDef = ProcedureManager.isDefinition(block);
+        List<Block> procRefs = new ArrayList<>();
         if (isProcedureDef || ProcedureManager.isReference(block)) {
             List<String> procedureArgs = ProcedureManager.getProcedureArguments(block);
             if (procedureArgs != null) {
@@ -155,9 +156,14 @@ public class WorkspaceStats {
             if (isProcedureDef) {
                 mProcedureManager.addDefinition(block);
             } else {
-                mProcedureManager.addReference(block);
+                procRefs.add(block);
             }
         }
+        // Only register procedure calls/references after all definitions have also been loaded.
+        for (Block procRef : procRefs) {
+            mProcedureManager.addReference(procRef);
+        }
+
 
         for (int i = 0; i < block.getInputs().size(); i++) {
             Input input = block.getInputs().get(i);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
@@ -25,6 +25,7 @@ import com.google.blockly.model.FieldVariable;
 import com.google.blockly.model.Input;
 import com.google.blockly.model.ProcedureInfo;
 import com.google.blockly.model.VariableInfo;
+import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.SimpleArraySet;
 
 import java.lang.ref.WeakReference;
@@ -141,51 +142,43 @@ public class WorkspaceStats {
      * @param recursive Whether to recursively collect stats for all descendants of the current
      *                  block.
      */
-    public void collectStats(Block block, boolean recursive) {
-        boolean isProcedureDef = ProcedureManager.isDefinition(block);
-        List<Block> procRefs = new ArrayList<>();
-        if (isProcedureDef || ProcedureManager.isReference(block)) {
-            List<String> procedureArgs = ProcedureManager.getProcedureArguments(block);
-            if (procedureArgs != null) {
-                String procedureName = ProcedureManager.getProcedureName(block);
-                for (String arg : procedureArgs) {
-                    getVarInfoImpl(arg, true).addProcedure(procedureName);
-                }
-            }
+    public void collectStats(Block block, boolean recursive) throws BlockLoadingException {
+        collectStats(Collections.singletonList(block), recursive);
+    }
 
-            if (isProcedureDef) {
+    /**
+     * Walks through a list of block and records all Connections, variable references, procedure
+     * definitions and procedure calls.
+     *
+     * @param blocks The list of blocks to inspect.
+     * @param recursive Whether to recursively collect stats for all descendants of the current
+     *                  block.
+     */
+    public void collectStats(List<Block> blocks, boolean recursive) throws BlockLoadingException {
+        int count = blocks.size();
+
+        // Assuming procedure definitions can only occur as root blocks.
+        // Register all definitions before potentially processing any calls to those procedures.
+        for (int i = 0; i < count; ++i) {
+            Block block = blocks.get(i);
+            if (ProcedureManager.isDefinition(block)) {
+                List<String> procedureArgs = ProcedureManager.getProcedureArguments(block);
+                if (procedureArgs != null) {
+                    String procedureName = ProcedureManager.getProcedureName(block);
+                    for (String arg : procedureArgs) {
+                        getVarInfoImpl(arg, true).addProcedure(procedureName);
+                    }
+                }
+
                 mProcedureManager.addDefinition(block);
-            } else {
-                procRefs.add(block);
             }
         }
-        // Only register procedure calls/references after all definitions have also been loaded.
-        for (Block procRef : procRefs) {
-            mProcedureManager.addReference(procRef);
+
+
+        for (int i = 0; i < count; ++i) {
+            Block block = blocks.get(i);
+            collectConnectionStatsAndProcedureReferences(block, recursive);
         }
-
-
-        for (int i = 0; i < block.getInputs().size(); i++) {
-            Input input = block.getInputs().get(i);
-            List<Field> fields = input.getFields();
-            int fieldCount = fields.size();
-            for (int j = 0; j < fieldCount; ++j) {
-                Field field = fields.get(j);
-                if (field instanceof FieldVariable) {
-                    FieldVariable varField = (FieldVariable) field;
-                    String varName = varField.getVariable();
-                    getVarInfoImpl(varName, true).addField(varField);
-                    varField.registerObserver(mVariableObserver);
-                }
-            }
-            addConnection(input.getConnection(), recursive);
-        }
-
-        addConnection(block.getNextConnection(), recursive);
-        // Don't recurse on outputs or previous connections--that's effectively walking back up the
-        // tree.
-        addConnection(block.getPreviousConnection(), false);
-        addConnection(block.getOutputConnection(), false);
     }
 
     /**
@@ -238,13 +231,52 @@ public class WorkspaceStats {
         field.unregisterObserver(mVariableObserver);
     }
 
-    private void addConnection(Connection conn, boolean recursive) {
+    private void collectConnectionStatsAndProcedureReferences(Block block, boolean recursive)
+            throws BlockLoadingException
+    {
+        if (ProcedureManager.isReference(block)) {
+            String procName = ProcedureManager.getProcedureName(block);
+            if (mProcedureManager.containsDefinition(block)) {
+                mProcedureManager.addReference(block);
+            } else {
+                throw new BlockLoadingException("Undefined procedure name \"" + procName + "\" "
+                        + "in reference block " + block);
+            }
+        }
+
+        List<Input> inputs = block.getInputs();
+        int inputCount = inputs.size();
+        for (int j = 0; j < inputCount; j++) {
+            Input input = block.getInputs().get(j);
+            List<Field> fields = input.getFields();
+            int fieldCount = fields.size();
+            for (int k = 0; k < fieldCount; ++k) {
+                Field field = fields.get(k);
+                if (field instanceof FieldVariable) {
+                    FieldVariable varField = (FieldVariable) field;
+                    String varName = varField.getVariable();
+                    getVarInfoImpl(varName, true).addField(varField);
+                    varField.registerObserver(mVariableObserver);
+                }
+            }
+            collectConnectionStats(input.getConnection(), recursive);
+        }
+
+        collectConnectionStats(block.getNextConnection(), recursive);
+        // Don't recurse on outputs or previous connections--that's effectively walking back up
+        // the tree.
+        collectConnectionStats(block.getPreviousConnection(), false);
+        collectConnectionStats(block.getOutputConnection(), false);
+    }
+
+    private void collectConnectionStats(Connection conn, boolean recursive)
+            throws BlockLoadingException {
         if (conn != null) {
             mConnectionManager.addConnection(conn);
             if (recursive) {
                 Block recursiveTarget = conn.getTargetBlock();
                 if (recursiveTarget != null) {
-                    collectStats(recursiveTarget, true);
+                    collectConnectionStatsAndProcedureReferences(recursiveTarget, true);
                 }
             }
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Workspace.java
@@ -89,6 +89,8 @@ public class Workspace {
      * @param block The block to add to the root of the workspace.
      * @param isNewBlock Set when the block is new to the workspace (compared to moving it from some
      *                   previous connection).
+ *     @throws IllegalArgumentException If the block or its children are references to undefined
+     *                                  procedures.
      */
     public void addRootBlock(Block block, boolean isNewBlock) {
         if (block == null) {
@@ -103,7 +105,11 @@ public class Workspace {
         mRootBlocks.add(block);
         if (isNewBlock) {
             block.setEventWorkspaceId(getId());
-            mStats.collectStats(block, true);
+            try {
+                mStats.collectStats(block, true);
+            } catch (BlockLoadingException e) {
+                throw new IllegalArgumentException(e);
+            }
         }
     }
 
@@ -243,9 +249,7 @@ public class Workspace {
         }
 
         mRootBlocks.addAll(newBlocks);
-        for (int i = 0; i < mRootBlocks.size(); i++) {
-            mStats.collectStats(mRootBlocks.get(i), true /* recursive */);
-        }
+        mStats.collectStats(newBlocks, true /* recursive */);
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
@@ -17,6 +17,7 @@ package com.google.blockly.utils;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.google.blockly.model.Block;
 import com.google.blockly.model.BlockFactory;
@@ -30,8 +31,10 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -45,9 +48,14 @@ import java.util.List;
  * parsers and serializers as needed.
  */
 public final class BlocklyXmlHelper {
+    private static final String TAG = "BlocklyXmlHelper";
+
     public interface XmlContentWriter {
         void write(XmlSerializer serializer) throws IOException;
     }
+
+    /** Enable this option to copy XML inputs to logs. (Workspaces only, for now.) */
+    private static final boolean LOG_INPUT_XML = false;
 
     private static final String XML_NAMESPACE = "http://www.w3.org/1999/xhtml";
     private static final XmlPullParserFactory PARSER_FACTORY = createParseFactory();
@@ -425,6 +433,21 @@ public final class BlocklyXmlHelper {
         StringReader reader = null;
         try {
             XmlPullParser parser = PARSER_FACTORY.newPullParser();
+            if (LOG_INPUT_XML) {
+                if (inStream != null) {
+                    StringBuilder sb = new StringBuilder();
+                    BufferedReader br = new BufferedReader(new InputStreamReader(inStream));
+                    String line = br.readLine();
+                    while (line != null) {
+                        sb.append(line).append('\n');
+                        line = br.readLine();
+                    }
+                    br.close();
+                    inStream = null;
+                    inString = sb.toString();
+                }
+                Log.d(TAG, "BlocklyXmlHelper.loadBlocksFromXml()\n" + inString);
+            }
             if (inStream != null) {
                 parser.setInput(inStream, null);
             } else {

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
@@ -55,7 +55,7 @@ public final class BlocklyXmlHelper {
     }
 
     /** Enable this option to copy XML inputs to logs. (Workspaces only, for now.) */
-    private static final boolean LOG_INPUT_XML = false;
+    private static final boolean LOG_INPUT_XML = true;
 
     private static final String XML_NAMESPACE = "http://www.w3.org/1999/xhtml";
     private static final XmlPullParserFactory PARSER_FACTORY = createParseFactory();

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/BlocklyXmlHelper.java
@@ -55,7 +55,7 @@ public final class BlocklyXmlHelper {
     }
 
     /** Enable this option to copy XML inputs to logs. (Workspaces only, for now.) */
-    private static final boolean LOG_INPUT_XML = true;
+    private static final boolean LOG_INPUT_XML = false;
 
     private static final String XML_NAMESPACE = "http://www.w3.org/1999/xhtml";
     private static final XmlPullParserFactory PARSER_FACTORY = createParseFactory();


### PR DESCRIPTION
Bug where a procedure reference encountered in XML loading before the procedure definition will throw an uncaught error. This fixes the that, with proper reporting, and catches the BlockLoadingException (instead of IllegalStateException).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/618)
<!-- Reviewable:end -->
