### PR TITLE
Allow individual tests to adjust the timeout

### DIFF
--- a/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/BlocklyTestCase.java
@@ -37,9 +37,10 @@ public class BlocklyTestCase {
      * Default timeout of 1 second, which should be plenty for most UI actions.  Anything longer
      * is an error.  However, to step through this code with a debugger, use a much longer duration.
      */
-    protected static final long TEST_TIMEOUT_MILLIS = 1000L;
+    protected static final long DEFAULT_TEST_TIMEOUT_MILLIS = 1000L;
 
     private Context mThemeContext;
+    protected long testTimeoutMs = DEFAULT_TEST_TIMEOUT_MILLIS;
 
     protected void configureForThemes() {
         mThemeContext = new ContextThemeWrapper(getContext(), R.style.BlocklyVerticalTheme);
@@ -103,7 +104,7 @@ public class BlocklyTestCase {
 
     protected void awaitTimeout(CountDownLatch latch) {
         try {
-            latch.await(TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            latch.await(testTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Timeout exceeded.", e);
         }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/NameVariableDialogTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/NameVariableDialogTest.java
@@ -53,6 +53,8 @@ public class NameVariableDialogTest extends BlocklyTestCase {
 
   @Test
   public void dialogShowsOldVariableNameWhenRenaming() throws Exception {
+    testTimeoutMs *= 5;  // Allow longer time for dialog interaction test
+
     String variableName = "oldVariableName";
 
     mNameVariableDialogFragment.setVariable(
@@ -63,6 +65,8 @@ public class NameVariableDialogTest extends BlocklyTestCase {
 
   @Test
   public void dialogShowsGenericTextForNewVariable() throws Exception {
+    testTimeoutMs *= 5;  // Allow longer time for dialog interaction test
+
     mNameVariableDialogFragment.setVariable("", mock(NameVariableDialog.Callback.class), false);
     mNameVariableDialogFragment.show(mActivity.getSupportFragmentManager(), "CreateFragment");
     onView(withId(R.id.description)).check(matches(withText("New variable name")));


### PR DESCRIPTION
...such as the variable name dialog tests which fail so often (now set to 5x).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/621)
<!-- Reviewable:end -->
