### PR TITLE
Merge ProcedureManager mDefinitions and mReferences maps

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -1230,7 +1230,7 @@ public class BlocklyController {
             ArrayList<String> newArgs = new ArrayList<>();
             for (int i = 0; i < procCount; ++i) {
                 String procName = oldVarInfo.getProcedureName(i);
-                Block definition = procedureManager.getDefinitionBlocks().get(procName);
+                Block definition = procedureManager.getDefinitionBlock(procName);
                 ProcedureInfo oldProcInfo =
                         ((AbstractProcedureMutator) definition.getMutator()).getProcedureInfo();
                 List<String> oldArgs = oldProcInfo.getArgumentNames();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
@@ -18,6 +18,7 @@ package com.google.blockly.android.control;
 import android.database.Observable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.util.ArraySet;
 import android.support.v4.util.SimpleArrayMap;
@@ -85,7 +86,7 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
 
     private class ProcedureBlocks {
         String mName;
-        Block mDefinition;
+        final Block mDefinition;
         final ArraySet<Block> mReferences = new ArraySet<>();
 
         /**
@@ -178,8 +179,8 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
      * {@link ProcedureInfo}. Otherwise, it returns null.
      *
      * @param block The block queried.
-     * @return The list of argument for defined or referenced by this block, if it is a procedure
-     *         block. Otherwise null;
+     * @return The ProcedureInfo with the procedure name and list of arguments defined or referenced
+     *         by this block, if it is a procedure block. Otherwise null.
      */
     public static @Nullable ProcedureInfo getProcedureInfo(Block block) {
         Mutator mutator = block.getMutator();
@@ -228,7 +229,7 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
     /**
      * Queries whether a procedure block contains a matching registered definition block. Similiar
      * to {@link #isProcedureDefined(String)}, except it takes in a procedure block. If the block is
-     * a procedure definition, if ensure the block is the same registered definition block.
+     * a procedure definition, it ensures the block is the same registered definition block.
      *
      * @param procedureBlock A block for the procedure in question, either definition or reference.
      * @return True if the block is the registered definition block for the procedure, or it is a
@@ -274,6 +275,7 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
      * @throws IllegalArgumentException If {@code procedureBlock} does not contain a procedure
      *         definition or reference mutator.
      */
+    @VisibleForTesting
     public boolean isReferenceRegistered(Block procedureRefBlock) {
         String procedureName = getProcedureNameOrFail(procedureRefBlock);
         String canonical = mProcedureNameManager.makeCanonical(procedureName);
@@ -320,7 +322,6 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
                             + "\n\tReference block: " + procedureReferenceBlock);
         }
         validateProcedureBlocksMatch(procBlocks.mDefinition, procedureReferenceBlock, false);
-        // TODO: validate definition & reference ProcedureInfo match
         procBlocks.mReferences.add(procedureReferenceBlock);
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
@@ -276,6 +276,8 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
      * @param block A block containing the definition of the procedure to add.
      */
     public void addDefinition(Block block) {
+        Log.d(TAG, "addDefinition " + getProcedureName(block) + " block " + Integer.toHexString(block.hashCode()));
+
         String procedureName = getProcedureNameOrFail(block);
         String canonicalProcName = mProcedureNameManager.makeCanonical(procedureName);
         if (mProcedureDefinitions.get(canonicalProcName) == block) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/ProcedureManager.java
@@ -317,9 +317,8 @@ public class ProcedureManager extends Observable<ProcedureManager.Observer> {
         ProcedureBlocks procBlocks = mProcedureBlocks.get(canonical);
         if (procBlocks == null) {
             throw new BlockLoadingException(
-                    "Tried to add a reference to procedure \"" + procedureName
-                            + "\" that has not been defined."
-                            + "\n\tReference block: " + procedureReferenceBlock);
+                    "Tried to add a reference to procedure \"" + procedureName + "\" that has not "
+                    + "been defined.\n\tReference block: " + procedureReferenceBlock);
         }
         validateProcedureBlocksMatch(procBlocks.mDefinition, procedureReferenceBlock, false);
         procBlocks.mReferences.add(procedureReferenceBlock);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/WorkspaceStats.java
@@ -32,6 +32,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Tracks information about the Workspace that we want fast access to.
@@ -71,7 +72,7 @@ public class WorkspaceStats {
         }
 
         @Override
-        public void onProcedureBlocksRemoved(String procedureName, List<Block> blocks) {
+        public void onProcedureBlocksRemoved(String procedureName, Set<Block> blocks) {
             for (Block block : blocks) {
                 List<String> args = mProcedureManager.getProcedureArguments(block);
                 if (args != null) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -45,7 +45,7 @@ public class BasicFieldInputView extends EditText implements FieldView {
         @Override
         public void afterTextChanged(Editable s) {
             if (mInputField != null) {
-                Log.d(TAG, "Block "+Integer.toHexString(mInputField.getBlock().hashCode()) + ": New input view text: " + s);
+                if (mInputField.getBlock() != null) { Log.d(TAG, "Block "+Integer.toHexString(mInputField.getBlock().hashCode()) + ": New input view text: " + s); }
                 mInputField.setText(s.toString());
             }
         }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -16,6 +16,7 @@
 package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -44,6 +45,7 @@ public class BasicFieldInputView extends EditText implements FieldView {
         @Override
         public void afterTextChanged(Editable s) {
             if (mInputField != null) {
+                Log.d(TAG, "Block "+Integer.toHexString(mInputField.getBlock().hashCode()) + ": New input view text: " + s);
                 mInputField.setText(s.toString());
             }
         }
@@ -56,7 +58,7 @@ public class BasicFieldInputView extends EditText implements FieldView {
                 Log.w(TAG, "Received text change from unexpected field.");
                 return;
             }
-            if (!TextUtils.equals(newValue, getText())) {
+            if (!isFocused() && !TextUtils.equals(newValue, getText())) {
                 setText(newValue);
             }
         }
@@ -140,5 +142,13 @@ public class BasicFieldInputView extends EditText implements FieldView {
     public boolean performClick() {
         Log.d(TAG, "performClick()");
         return super.performClick();
+    }
+
+    @Override
+    protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+        super.onFocusChanged(focused, direction, previouslyFocusedRect);
+        if (!focused && mInputField != null) {
+            setText(mInputField.getText());
+        }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
@@ -17,7 +17,7 @@ package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.TextView;
+import android.support.v7.widget.AppCompatTextView;
 
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldLabel;
@@ -25,7 +25,7 @@ import com.google.blockly.model.FieldLabel;
 /**
  * Renders text as part of a BlockView.
  */
-public class BasicFieldLabelView extends TextView implements FieldView {
+public class BasicFieldLabelView extends AppCompatTextView implements FieldView {
     protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
         public void onValueChanged(Field field, String oldValue, String newValue) {

--- a/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/DefaultBlocks.java
@@ -12,6 +12,7 @@ import com.google.blockly.model.mutator.MathIsDivisibleByMutator;
 import com.google.blockly.model.mutator.ProcedureCallMutator;
 import com.google.blockly.model.mutator.ProcedureDefinitionMutator;
 import com.google.blockly.model.mutator.ProceduresIfReturnMutator;
+import com.google.blockly.utils.BlockLoadingException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,7 +138,11 @@ public final class DefaultBlocks {
         // Don't store this map, because of the reference to the controller.
         Map<String, CustomCategory> map = new ArrayMap<>(2);
         map.put(VARIABLE_CATEGORY_NAME, new VariableCustomCategory(controller));
-        map.put(PROCEDURE_CATEGORY_NAME, new ProcedureCustomCategory(controller));
+        try {
+            map.put(PROCEDURE_CATEGORY_NAME, new ProcedureCustomCategory(controller));
+        } catch (BlockLoadingException e) {
+            throw new IllegalStateException(e);
+        }
         return Collections.unmodifiableMap(map);
     }
 

--- a/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
@@ -56,15 +56,27 @@ public class ProcedureCustomCategory implements CustomCategory {
     protected final Workspace mWorkspace;
     protected final ProcedureManager mProcedureManager;
 
+    protected final Block mDefinitionReturn;
+    protected final Block mDefinitionNoReturn;
+    protected final Block mIfReturn;
+
     protected final String mDefaultProcedureName;
 
-    public ProcedureCustomCategory(BlocklyController controller) {
+    public ProcedureCustomCategory(BlocklyController controller) throws BlockLoadingException {
         mController = controller;
         mBlockFactory = mController.getBlockFactory();
         mWorkspace = mController.getWorkspace();
         mProcedureManager = mWorkspace.getProcedureManager();
 
         mDefaultProcedureName = getDefaultProcedureName();
+
+        mDefinitionNoReturn = mBlockFactory.obtainBlockFrom(DEFINE_NO_RETURN_BLOCK_TEMPLATE);
+        ((FieldInput)mDefinitionNoReturn.getFieldByName(NAME_FIELD)).setText(mDefaultProcedureName);
+
+        mDefinitionReturn = mBlockFactory.obtainBlockFrom(DEFINE_WITH_RETURN_BLOCK_TEMPLATE);
+        ((FieldInput)mDefinitionReturn.getFieldByName(NAME_FIELD)).setText(mDefaultProcedureName);
+
+        mIfReturn = mBlockFactory.obtainBlockFrom(IF_RETURN_TEMPLATE);
     }
 
     public String getDefaultProcedureName() {
@@ -158,17 +170,10 @@ public class ProcedureCustomCategory implements CustomCategory {
     private void rebuildItems(BlocklyCategory category) throws BlockLoadingException {
         category.clear();
 
-        Block block = mBlockFactory.obtainBlockFrom(DEFINE_NO_RETURN_BLOCK_TEMPLATE);
-        ((FieldInput)block.getFieldByName(NAME_FIELD)).setText(mDefaultProcedureName);
-        category.addItem(new BlocklyCategory.BlockItem(block));
-
-        block = mBlockFactory.obtainBlockFrom(DEFINE_WITH_RETURN_BLOCK_TEMPLATE);
-        ((FieldInput)block.getFieldByName(NAME_FIELD)).setText(mDefaultProcedureName);
-        category.addItem(new BlocklyCategory.BlockItem(block));
-
-        if (!mProcedureManager.hasProcedureDefinitionWithReturn()) {
-            block = mBlockFactory.obtainBlockFrom(IF_RETURN_TEMPLATE);
-            category.addItem(new BlocklyCategory.BlockItem(block));
+        category.addItem(new BlocklyCategory.BlockItem(mDefinitionNoReturn));
+        category.addItem(new BlocklyCategory.BlockItem(mDefinitionReturn));
+        if (mProcedureManager.hasProcedureDefinitionWithReturn()) {
+            category.addItem(new BlocklyCategory.BlockItem(mIfReturn));
         }
 
         // Create a call block for each definition.

--- a/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
@@ -14,6 +14,7 @@
  */
 package com.google.blockly.model;
 
+import android.support.v4.util.SimpleArrayMap;
 import android.util.Log;
 
 import com.google.blockly.android.R;
@@ -25,9 +26,12 @@ import com.google.blockly.model.mutator.ProcedureDefinitionMutator;
 import com.google.blockly.utils.BlockLoadingException;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -102,7 +106,7 @@ public class ProcedureCustomCategory implements CustomCategory {
             }
 
             @Override
-            public void onProcedureBlocksRemoved(String procedureName, List<Block> blocks) {
+            public void onProcedureBlocksRemoved(String procedureName, Set<Block> blocks) {
                 BlocklyCategory category = catRef.get();
                 if (checkCategory(category)) {
                     rebuildItemsSafely(category);
@@ -179,8 +183,13 @@ public class ProcedureCustomCategory implements CustomCategory {
         }
 
         // Create a call block for each definition.
-        final Map<String, Block> definitions = mProcedureManager.getDefinitionBlocks();
-        SortedSet<String> sortedProcNames = new TreeSet<>(new Comparator<String>() {
+        final SimpleArrayMap<String, Block> definitions = mProcedureManager.getDefinitionBlocks();
+        final int count = definitions.size();
+        List<String> procNames = new ArrayList<>(count);
+        for (int i = 0; i < count; ++i) {
+            procNames.add(definitions.keyAt(i));
+        }
+        Collections.sort(procNames, new Comparator<String>() {
             @Override
             public int compare(String procName1, String procName2) {
                 Block def1 = definitions.get(procName1);
@@ -201,8 +210,7 @@ public class ProcedureCustomCategory implements CustomCategory {
                 return def1.getId().compareTo(def2.getId()); // Last resort, by block id
             }
         });
-        sortedProcNames.addAll(definitions.keySet());
-        for (String procName : sortedProcNames) {
+        for (String procName : procNames) {
             Block defBlock = definitions.get(procName);
             ProcedureInfo procedureInfo = ((AbstractProcedureMutator) defBlock.getMutator())
                     .getProcedureInfo();

--- a/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/ProcedureCustomCategory.java
@@ -30,10 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * Class for building {@link BlocklyCategory categories} for procedure blocks (user-defined

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/AbstractProcedureMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/AbstractProcedureMutator.java
@@ -69,7 +69,7 @@ public abstract class AbstractProcedureMutator<Info extends ProcedureInfo> exten
      */
     final public void setProcedureName(@NonNull String newProcedureName) {
         String oldName = getProcedureName();
-        if (mProcedureManager.getDefinitionBlocks().get(oldName) == mBlock) {
+        if (mProcedureManager.containsDefinition(mBlock)) {
             throw new IllegalStateException(
                     "Rename procedure managed by the ProcedureManager "
                             + "using ProcedureManager.mutateProcedure(..).");

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/ProcedureCallMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/ProcedureCallMutator.java
@@ -15,7 +15,6 @@
 package com.google.blockly.model.mutator;
 
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import com.google.blockly.android.control.BlocklyController;
 import com.google.blockly.android.control.ProcedureManager;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/mutator/ProcedureDefinitionMutator.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/mutator/ProcedureDefinitionMutator.java
@@ -145,13 +145,18 @@ public class ProcedureDefinitionMutator extends AbstractProcedureMutator<Procedu
             throws BlockLoadingException, IOException, XmlPullParserException {
         ProcedureInfo xmlInfo = ProcedureInfo.parseImpl(parser);
         FieldInput nameField = getNameField();
+        Log.d("ProcedureDef", "parseAndValidateMutationXml for block " + Integer.toHexString(mBlock.hashCode()) + ":"
+                + "\n\txmlInfo name=" + xmlInfo.getProcedureName()
+                + "\n\tmProcedureInfo" +(mProcedureInfo==null ? "=null" : " name=" + mProcedureInfo.getProcedureName()));
         if (TextUtils.isEmpty(xmlInfo.getProcedureName()) && nameField != null) {
+            Log.d("ProcedureDef", "\tnameField text=" + nameField.getText());
+            Log.d("ProcedureDef", "\tstack trace", new Throwable());
             // Use the name on the field when not specified in the info.
-            return new ProcedureInfo(
-                    nameField.getText(),
-                    xmlInfo.getArgumentNames(),
-                    xmlInfo.getDefinitionHasStatementBody());
+            return xmlInfo.cloneWithName(nameField.getText());
         }
+
+        Log.d("ProcedureDef", "\tstack trace", new Throwable());
+
         return xmlInfo;
     }
 
@@ -276,7 +281,6 @@ public class ProcedureDefinitionMutator extends AbstractProcedureMutator<Procedu
      */
     @Override
     protected void updateBlock() {
-        Log.d("ProcedureDef", "updateBlock() Stack trace:", new Throwable());
         final boolean oldUpdatingBlock = mUpdatingBlock;  // Might be called within mutate(..)
         try {
             mUpdatingBlock = true;
@@ -286,7 +290,8 @@ public class ProcedureDefinitionMutator extends AbstractProcedureMutator<Procedu
             if (mProcedureInfo != null && nameField != null) {
                 Log.d("ProcedureDef", "Block " + Integer.toHexString(mBlock.hashCode())
                         + ": updateBlock(): field name: " + nameField.getText()
-                        + ", new name: " + mProcedureInfo.getProcedureName());
+                        + ", new name: " + mProcedureInfo.getProcedureName()
+                        + "\n\tstack trace", new Throwable());
                 nameField.setFromString(mProcedureInfo.getProcedureName());
             }
         } finally {

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/SimpleArraySet.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/SimpleArraySet.java
@@ -16,8 +16,6 @@ package com.google.blockly.utils;
 
 import android.support.v4.util.SimpleArrayMap;
 
-import java.util.ArrayList;
-
 /**
  * Set-like wrapper around SimpleArrayMap.
  */

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/SimpleArraySet.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/SimpleArraySet.java
@@ -16,6 +16,8 @@ package com.google.blockly.utils;
 
 import android.support.v4.util.SimpleArrayMap;
 
+import java.util.ArrayList;
+
 /**
  * Set-like wrapper around SimpleArrayMap.
  */
@@ -49,7 +51,6 @@ public final class SimpleArraySet<E> {
     public boolean add(E e) {
         return mMap.put(e, e) == null;
     }
-
 
     public E getAt(int i) {
         return mMap.keyAt(i);

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.List;
+import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -68,10 +68,7 @@ public class ProcedureManagerTest extends BlocklyTestCase {
     public void testAddProcedureDefinition() {
         mProcedureManager.addDefinition(mProcedureDefinition);
         assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isTrue();
-
-        List<Block> references = mProcedureManager.getReferences(PROCEDURE_NAME);
-        assertThat(references).isNotNull();
-        assertThat(references.size()).isEqualTo(0);
+        assertThat(mProcedureManager.isDefinitionReferenced(mProcedureDefinition)).isFalse();
     }
 
     @Test
@@ -93,42 +90,42 @@ public class ProcedureManagerTest extends BlocklyTestCase {
     }
 
     @Test
-    public void testAddProcedureReference() {
+    public void testAddProcedureReference() throws BlockLoadingException {
         mProcedureManager.addDefinition(mProcedureDefinition);
 
         mProcedureManager.addReference(mProcedureReference);
-        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isTrue();
+        assertThat(mProcedureManager.isDefinitionReferenced(mProcedureDefinition)).isTrue();
     }
 
     @Test
     // Remove definition should also remove all references.
-    public void testRemoveProcedureDefinition() {
+    public void testRemoveProcedureDefinition() throws BlockLoadingException {
         mProcedureManager.addDefinition(mProcedureDefinition);
         assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isTrue();
 
-        mProcedureManager.removeDefinition(mProcedureDefinition);
+        mProcedureManager.removeProcedure(mProcedureDefinition);
         assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isFalse();
-        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isFalse();
+        assertThat(mProcedureManager.isDefinitionReferenced(mProcedureDefinition)).isFalse();
 
         mProcedureManager.addDefinition(mProcedureDefinition);
         mProcedureManager.addReference(mProcedureReference);
-        List<Block> references =
-                mProcedureManager.removeDefinition(mProcedureDefinition);
+        Set<Block> references =
+                mProcedureManager.removeProcedure(mProcedureDefinition);
         assertThat(references).isNotNull();
         assertThat(references.size()).isEqualTo(1);
-        assertThat(references.get(0)).isEqualTo(mProcedureReference);
+        assertThat(references.iterator().next()).isEqualTo(mProcedureReference);
 
         assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isFalse();
-        assertThat(mProcedureManager.hasReferences(mProcedureDefinition)).isFalse();
+        assertThat(mProcedureManager.isDefinitionReferenced(mProcedureDefinition)).isFalse();
     }
 
     @Test
-    public void testRemoveProcedureReference() {
+    public void testRemoveProcedureReference() throws BlockLoadingException {
         mProcedureManager.addDefinition(mProcedureDefinition);
         mProcedureManager.addReference(mProcedureReference);
 
         mProcedureManager.removeReference(mProcedureReference);
-        assertThat(mProcedureManager.hasReferences(mProcedureReference)).isFalse();
+        assertThat(mProcedureManager.isReferenceRegistered(mProcedureReference)).isFalse();
     }
 
     @Test
@@ -141,7 +138,7 @@ public class ProcedureManagerTest extends BlocklyTestCase {
     }
 
     @Test
-    public void testAddReferenceToUndefined() {
+    public void testAddReferenceToUndefined() throws BlockLoadingException {
         thrown.expect(IllegalStateException.class);
         mProcedureManager.addReference(mProcedureReference);
     }
@@ -149,7 +146,7 @@ public class ProcedureManagerTest extends BlocklyTestCase {
     @Test
     public void testRemoveNoUndefined() {
         thrown.expect(IllegalStateException.class);
-        mProcedureManager.removeDefinition(mProcedureDefinition);
+        mProcedureManager.removeProcedure(mProcedureDefinition);
     }
 
     @Test

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/control/ProcedureManagerTest.java
@@ -112,7 +112,7 @@ public class ProcedureManagerTest extends BlocklyTestCase {
         Set<Block> references =
                 mProcedureManager.removeProcedure(mProcedureDefinition);
         assertThat(references).isNotNull();
-        assertThat(references.size()).isEqualTo(1);
+        assertThat(references.size()).isEqualTo(2); // 1 definition and 1 caller
         assertThat(references.iterator().next()).isEqualTo(mProcedureReference);
 
         assertThat(mProcedureManager.containsDefinition(mProcedureDefinition)).isFalse();
@@ -139,20 +139,18 @@ public class ProcedureManagerTest extends BlocklyTestCase {
 
     @Test
     public void testAddReferenceToUndefined() throws BlockLoadingException {
-        thrown.expect(IllegalStateException.class);
+        thrown.expect(BlockLoadingException.class);
         mProcedureManager.addReference(mProcedureReference);
     }
 
     @Test
     public void testRemoveNoUndefined() {
-        thrown.expect(IllegalStateException.class);
-        mProcedureManager.removeProcedure(mProcedureDefinition);
+        assertThat(mProcedureManager.removeProcedure(mProcedureDefinition).size()).isEqualTo(0);
     }
 
     @Test
     public void testNoReference() {
-        thrown.expect(IllegalStateException.class);
-        mProcedureManager.removeReference(mProcedureReference);
+        assertThat(mProcedureManager.removeReference(mProcedureReference)).isFalse();
     }
 
     private Block buildCaller(final String procName) throws BlockLoadingException {


### PR DESCRIPTION
This is a WIP on functions.
I replaced the two maps with one, in an effort to reduce the number of parallel keys I need to maintain.
Future step is to do the same with the NameManager, making it a map-like structure to ProcedureBlocks or VariableInfo objects. This also centralizes the canonization of names, and reduces the "surface area" of the name synchronization problem seen during procedure rename.

Also, much more ProcedureManager JavaDocs I missed on the last pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/622)
<!-- Reviewable:end -->
