### PR TITLE
Removing Workspace param on event constructors

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -1355,7 +1355,7 @@ public class BlocklyController {
     private void connectToStatementImpl(Connection parentStatementConnection, Block toConnect) {
         // Store the state of toConnect in its original location.
         // TODO: (#342) move the event up to the impl method
-        BlocklyEvent.MoveEvent moveEvent = new BlocklyEvent.MoveEvent(mWorkspace, toConnect);
+        BlocklyEvent.MoveEvent moveEvent = new BlocklyEvent.MoveEvent(toConnect);
 
         Block remainderBlock = parentStatementConnection.getTargetBlock();
         BlocklyEvent.MoveEvent remainderMove = null;
@@ -1367,7 +1367,7 @@ public class BlocklyController {
                 remainderBlock = null;
             } else {
                 // Store the original location of the remainder.
-                remainderMove = new BlocklyEvent.MoveEvent(mWorkspace, remainderBlock);
+                remainderMove = new BlocklyEvent.MoveEvent(remainderBlock);
 
                 // Disconnect the remainder and we'll reattach it below
                 parentStatementConnection.disconnect();
@@ -1575,7 +1575,7 @@ public class BlocklyController {
         }
         // TODO: Document when this call valid but the root is not already part of the workspace.
         boolean isPartOfWorkspace = mWorkspace.isRootBlock(rootBlock);
-        BlocklyEvent.MoveEvent moveEvent = new BlocklyEvent.MoveEvent(getWorkspace(), block);
+        BlocklyEvent.MoveEvent moveEvent = new BlocklyEvent.MoveEvent(block);
         BlocklyEvent.MoveEvent remainderEvent = null;
 
         BlockView bv = mHelper.getView(block);
@@ -1586,7 +1586,7 @@ public class BlocklyController {
         BlockGroup remainderGroup = null;
         if (reattachNext && block.getNextBlock() != null) {
             remainderBlock = block.getNextBlock();
-            remainderEvent = new BlocklyEvent.MoveEvent(getWorkspace(), remainderBlock);
+            remainderEvent = new BlocklyEvent.MoveEvent(remainderBlock);
 
             remainderGroup = (bg == null) ? null :
                     bg.extractBlocksAsNewGroup(remainderBlock);

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlocklyEvent.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlocklyEvent.java
@@ -604,11 +604,10 @@ public abstract class BlocklyEvent {
         /**
          * Constructs a {@link MoveEvent} signifying the movement of a block on the workspace.
          *
-         * @param workspace The workspace containing the moved blocks.
          * @param block The root block of the move, while it is still in its original position.
          */
-        public MoveEvent(@NonNull Workspace workspace, @NonNull Block block) {
-            super(TYPE_MOVE, workspace.getId(), null, block.getId());
+        public MoveEvent(@NonNull Block block) {
+            super(TYPE_MOVE, block.getEventWorkspaceId(), null, block.getId());
 
             Connection parentConnection = block.getParentConnection();
             if (parentConnection == null) {
@@ -761,36 +760,35 @@ public abstract class BlocklyEvent {
         private final String mOldValue;
         private final String mNewValue;
 
-        public UIEvent newBlockClickedEvent(@NonNull Workspace workspace, @NonNull Block block) {
+        public UIEvent newBlockClickedEvent(@NonNull Block block) {
             return new UIEvent(ELEMENT_CLICK, block, null, null);
         }
 
-        public UIEvent newBlockCommentEvent(@NonNull Workspace workspace, @NonNull Block block,
+        public UIEvent newBlockCommentEvent(@NonNull Block block,
                                             boolean openedBefore, boolean openedAfter) {
             return new UIEvent(ELEMENT_COMMENT_OPEN, block,
                     openedBefore ? "true" : "false", openedAfter ? "true" : "false");
         }
 
-        public UIEvent newBlockMutatorEvent(@NonNull Workspace workspace, @NonNull Block block,
+        public UIEvent newBlockMutatorEvent(@NonNull Block block,
                                             boolean openedBefore, boolean openedAfter) {
             return new UIEvent(ELEMENT_MUTATOR_OPEN, block,
                     openedBefore ? "true" : "false", openedAfter ? "true" : "false");
         }
 
-        public UIEvent newBlockSelectedEvent(@NonNull Workspace workspace, @NonNull Block block,
+        public UIEvent newBlockSelectedEvent(@NonNull Block block,
                                             boolean selectedBefore, boolean selectedAfter) {
             return new UIEvent(ELEMENT_SELECTED, block,
                                selectedBefore ? "true" : "false", selectedAfter ? "true" : "false");
         }
 
-        public UIEvent newBlockWarningEvent(@NonNull Workspace workspace, @NonNull Block block,
+        public UIEvent newBlockWarningEvent(@NonNull Block block,
                                             boolean openedBefore, boolean openedAfter) {
             return new UIEvent(ELEMENT_WARNING_OPEN, block,
                     openedBefore ? "true" : "false", openedAfter ? "true" : "false");
         }
 
-        public UIEvent newToolboxCategoryEvent(@NonNull Workspace workspace,
-                                               @Nullable String oldValue,
+        public UIEvent newToolboxCategoryEvent(@Nullable String oldValue,
                                                @Nullable String newValue) {
             return new UIEvent(ELEMENT_CATEGORY, null, oldValue, newValue);
         }


### PR DESCRIPTION
Blocks now have a reference to their workspace id. Did not remove the parameter from DeleteEvent, because the EventWorkspaceId may have already been cleared on the block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/627)
<!-- Reviewable:end -->
