### PR TITLE
Adding the gradle tasks necessary to deploy binaries

### DIFF
--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -45,7 +45,7 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-// TODO: Fix JavaDoc compilation, and then update deployment artifacts.
+// TODO(#632): Fix JavaDoc compilation, and then update deployment artifacts.
 //task javadoc(type: Javadoc) {
 //    source = android.sourceSets.main.java.srcDirs
 //    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))

--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -28,6 +28,7 @@ android {
     lintOptions {
           abortOnError false
     }
+    publishNonDefault true
 }
 
 dependencies {
@@ -38,3 +39,22 @@ dependencies {
     compile 'com.android.support:support-v13:25.1.0'
     compile 'com.android.support:support-annotations:25.1.0'
 }
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+// TODO: Fix JavaDoc compilation, and then update deployment artifacts.
+//task javadoc(type: Javadoc) {
+//    source = android.sourceSets.main.java.srcDirs
+//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+//}
+
+//task javadocJar(type: Jar, dependsOn: javadoc) {
+//    classifier = 'javadoc'
+//    from javadoc.destinationDir
+//    // options.encoding = 'UTF-8'
+//}
+
+apply from: 'deploy.gradle'

--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -28,7 +28,7 @@ android {
     lintOptions {
           abortOnError false
     }
-    publishNonDefault true
+    publishNonDefault false
 }
 
 dependencies {

--- a/blocklylib-core/deploy.gradle
+++ b/blocklylib-core/deploy.gradle
@@ -1,0 +1,65 @@
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.github.dcendents.android-maven'
+
+def properties = new Properties()
+properties.load(new FileInputStream(project.file("../deploy.properties")))
+
+version=properties.version
+group=properties.groupId
+
+install {
+    repositories.mavenInstaller {
+        pom.project {
+            packaging 'aar'
+
+            group properties.groupId
+            artifactId project.name
+            version properties.version
+        }
+    }
+}
+
+/**
+ * Bintray closure needed to run the buntrayUpload task.
+ *
+ * Usage:
+ * ./gradlew bintrayUpload -PbintrayUser=YOUR_BINTRAY_USER_ID -PbintrayApiKey=YOUR_BINTRAY_API_KEY
+ *
+ * Or set BINTRAY_USER and BINTRAY_API_KEY environment variables before calling:
+ * ./gradlew bintrayUpload.)
+ *
+ * The Bintray User ID and API key can be added to your system environment variables as BINTRAY_USER
+ * and BINTRAY_API_KEY respectively, and the command could be reduced to:
+ * ./gradlew bintrayUpload
+ */
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser')
+            : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey')
+            : System.getenv('BINTRAY_API_KEY')
+
+    configurations = ['archives']
+    pkg {
+        userOrg = properties.bintrayUserOrg
+        repo = properties.bintrayRepo
+        name = project.name
+        desc = '''\
+Blockly for Android provides a block-based code editor to Android apps.
+This library provides the core classes, including models, view base classes, and basic Android integration.
+'''
+        websiteUrl = properties.siteUrl
+        vcsUrl = properties.githubUrl + '.git'
+        issueTrackerUrl = properties.githubUrl + '/issues'
+        licenses = properties.licenses
+        labels = ['Android', 'Blockly']
+        publicDownloadNumbers = true
+        publish = true
+        version {
+            name = properties.version
+        }
+    }
+}
+
+artifacts {
+    archives sourcesJar
+}

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -33,7 +33,7 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-// TODO: Fix JavaDoc compilation, and then update deployment artifacts.
+// TODO(#632): Fix JavaDoc compilation, and then update deployment artifacts.
 //task javadoc(type: Javadoc) {
 //    source = android.sourceSets.main.java.srcDirs
 //    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -18,7 +18,7 @@ android {
     lintOptions {
           abortOnError false
     }
-    publishNonDefault true
+    publishNonDefault false
 }
 
 dependencies {

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -18,6 +18,7 @@ android {
     lintOptions {
           abortOnError false
     }
+    publishNonDefault true
 }
 
 dependencies {
@@ -26,3 +27,22 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile project(':blocklylib-core')
 }
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+// TODO: Fix JavaDoc compilation, and then update deployment artifacts.
+//task javadoc(type: Javadoc) {
+//    source = android.sourceSets.main.java.srcDirs
+//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+//}
+
+//task javadocJar(type: Jar, dependsOn: javadoc) {
+//    classifier = 'javadoc'
+//    from javadoc.destinationDir
+//    // options.encoding = 'UTF-8'
+//}
+
+apply from: 'deploy.gradle'

--- a/blocklylib-vertical/deploy.gradle
+++ b/blocklylib-vertical/deploy.gradle
@@ -1,0 +1,65 @@
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.github.dcendents.android-maven'
+
+def properties = new Properties()
+properties.load(new FileInputStream(project.file("../deploy.properties")))
+
+version=properties.version
+group=properties.groupId
+
+install {
+    repositories.mavenInstaller {
+        pom.project {
+            packaging 'aar'
+
+            group properties.groupId
+            artifactId project.name
+            version properties.version
+        }
+    }
+}
+
+/**
+ * Bintray closure needed to run the buntrayUpload task.
+ *
+ * Usage:
+ * ./gradlew bintrayUpload -PbintrayUser=YOUR_BINTRAY_USER_ID -PbintrayApiKey=YOUR_BINTRAY_API_KEY
+ *
+ * Or set BINTRAY_USER and BINTRAY_API_KEY environment variables before calling:
+ * ./gradlew bintrayUpload.)
+ *
+ * The Bintray User ID and API key can be added to your system environment variables as BINTRAY_USER
+ * and BINTRAY_API_KEY respectively, and the command could be reduced to:
+ * ./gradlew bintrayUpload
+ */
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser')
+            : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey')
+            : System.getenv('BINTRAY_API_KEY')
+
+    configurations = ['archives']
+    pkg {
+        userOrg = properties.bintrayUserOrg
+        repo = properties.bintrayRepo
+        name = project.name
+        desc = '''\
+Blockly for Android provides a block-based code editor to Android apps.
+This library provides the a view implementation for vertically stacking blocks.
+'''
+        websiteUrl = properties.siteUrl
+        vcsUrl = properties.githubUrl + '.git'
+        issueTrackerUrl = properties.githubUrl + '/issues'
+        licenses = properties.licenses
+        labels = ['Android', 'Blockly']
+        publicDownloadNumbers = true
+        publish = true
+        version {
+            name = properties.version
+        }
+    }
+}
+
+artifacts {
+    archives sourcesJar
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/deploy.properties
+++ b/deploy.properties
@@ -1,0 +1,9 @@
+# Deployment properties shared between all projects.
+bintrayUserOrg = google
+bintrayRepo = blockly-android
+groupId = com.google.blockly.android
+siteUrl = https://developers.google.com/blockly/
+githubUrl = https://github.com/google/blockly-android
+version = v0.9-beta.20170523
+license = Apache-2.0
+licenseUrl = https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Adding the gradle tasks necessary to deploy binaries .aar and source files to Bintray.

This is a commit to master to release the old build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/631)
<!-- Reviewable:end -->
