### PR TITLE
Fix Bintray task. No 'v' before version.

### DIFF
--- a/deploy.properties
+++ b/deploy.properties
@@ -4,6 +4,6 @@ bintrayRepo = blockly-android
 groupId = com.google.blockly.android
 siteUrl = https://developers.google.com/blockly/
 githubUrl = https://github.com/google/blockly-android
-version = v0.9-beta.20170523
+version = 0.9-beta.20170523
 license = Apache-2.0
 licenseUrl = https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Version numbers should not include a leading 'v'. After uploading without this, the codelab can now resolve the dependency.

This is a commit to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/633)
<!-- Reviewable:end -->
