### PR TITLE
Replacing deprecated v13 ViewCompat with v4 ViewCompat.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -19,7 +19,7 @@ import android.content.Context;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v13.view.ViewCompat;
+import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/Dragger.java
@@ -23,7 +23,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.VisibleForTesting;
-import android.support.v13.view.ViewCompat;
+import android.support.v4.view.ViewCompat;
 import android.util.Log;
 import android.util.Pair;
 import android.view.DragEvent;

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldAngleView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldAngleView.java
@@ -17,7 +17,7 @@ package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
 import android.content.res.Configuration;
-import android.support.v13.view.ViewCompat;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.AppCompatTextView;
 import android.text.Editable;
 import android.text.TextWatcher;


### PR DESCRIPTION
Newly deprecated in API 26.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/641)
<!-- Reviewable:end -->
