### PR TITLE
Removing dependency on support-v13.

### DIFF
--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     compile 'com.android.support:support-v4:26.0.1'
     compile 'com.android.support:appcompat-v7:26.0.1'
     compile 'com.android.support:recyclerview-v7:26.0.1'
-    compile 'com.android.support:support-v13:26.0.1'
     compile 'com.android.support:support-annotations:26.0.1'
 }
 


### PR DESCRIPTION
Usage was removed in #641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/646)
<!-- Reviewable:end -->
