### PR TITLE
Disabling multidex on the blocklytest app.

### DIFF
--- a/blocklytest/src/main/AndroidManifest.xml
+++ b/blocklytest/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/BlocklyVerticalTheme"
-        android:name="android.support.multidex.MultiDexApplication">
+        android:theme="@style/BlocklyVerticalTheme">
 
         <activity
             android:name="com.google.blockly.android.BlocklyTestActivity"


### PR DESCRIPTION
I ran into the error "Didn't find class “android.support.multidex.MultiDexApplication” on path: DexPathList".
Disabling multidex on the test app (which is not used on other apps, either).

If one wanted multidex, the solution is to create a dex keep file list:
  https://developer.android.com/studio/build/multidex.html#keep

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/649)
<!-- Reviewable:end -->
