### PR TITLE
Adding Codelab step to add Blockly

### DIFF
--- a/Codelab/MusicMaker-starter/build.gradle
+++ b/Codelab/MusicMaker-starter/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.google.blockly.codelab"
         minSdkVersion 21  // Because of SoundPool.Builder
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -27,7 +27,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.0.0-alpha1'
-    compile 'com.android.support:gridlayout-v7:26.0.0-alpha1'
+    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:gridlayout-v7:26.0.2'
     testCompile 'junit:junit:4.12'
 }

--- a/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/EditFragment.java
+++ b/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/EditFragment.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,12 +27,40 @@ import android.view.ViewGroup;
  * An array of colorful buttons, with some instructional text and an "Edit" menu option.
  */
 public class EditFragment extends Fragment {
-    @Nullable
+    private static final String TAG = "EditFragment";
+
     @Override
     public View onCreateView(
             LayoutInflater inflater,
             @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.edit_fragment, null);
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.edit_fragment, null);
+
+        // Each button edits a different script.
+        rootView.findViewById(R.id.button1).setOnClickListener(buildEditOnClick(1));
+        rootView.findViewById(R.id.button2).setOnClickListener(buildEditOnClick(2));
+        rootView.findViewById(R.id.button3).setOnClickListener(buildEditOnClick(3));
+        rootView.findViewById(R.id.button4).setOnClickListener(buildEditOnClick(4));
+        rootView.findViewById(R.id.button5).setOnClickListener(buildEditOnClick(5));
+        rootView.findViewById(R.id.button6).setOnClickListener(buildEditOnClick(6));
+        rootView.findViewById(R.id.button7).setOnClickListener(buildEditOnClick(7));
+        rootView.findViewById(R.id.button8).setOnClickListener(buildEditOnClick(8));
+        rootView.findViewById(R.id.button9).setOnClickListener(buildEditOnClick(9));
+
+        return rootView;
+    }
+
+    protected void onEdit(int buttonNumber) {
+        // TODO: Edit sound script
+        Log.d(TAG, "Button #" + buttonNumber);
+    }
+
+    protected View.OnClickListener buildEditOnClick(final int buttonNumber) {
+        return new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onEdit(buttonNumber);
+            }
+        };
     }
 }

--- a/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/MainActivity.java
+++ b/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/MainActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.support.v4.app.FragmentManager;

--- a/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/MultiFileAudioPlayer.java
+++ b/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/MultiFileAudioPlayer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.content.Context;
@@ -15,8 +30,6 @@ import java.io.IOException;
  * Only supports a preselected set of files with known, hardcoded durations
  */
 public class MultiFileAudioPlayer {
-    private static final String TAG = "AudioFilePlayer";
-
     /**
      * The effective duration of the piano not audio files.
      * The actual durations of the notes range from 718 to 918 milliseconds.

--- a/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/PlaybackFragment.java
+++ b/Codelab/MusicMaker-starter/src/main/java/com/google/blockly/codelab/PlaybackFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.os.Bundle;

--- a/Codelab/MusicMaker-starter/src/main/res/values/strings.xml
+++ b/Codelab/MusicMaker-starter/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Codelab</string>
+    <string name="app_name">Blockly Music Maker</string>
     <string name="edit_instructions">Tap any button to edit its code.\nWhen complete, press back.</string>
     <string name="action_edit">Edit</string>
 </resources>

--- a/Codelab/MusicMaker-step1-Blockly/build.gradle
+++ b/Codelab/MusicMaker-step1-Blockly/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.google.blockly.codelab"
         minSdkVersion 21  // Because of SoundPool.Builder
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -27,7 +27,11 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.0.0-alpha1'
-    compile 'com.android.support:gridlayout-v7:26.0.0-alpha1'
+    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:gridlayout-v7:26.0.2'
+    compile 'com.android.support:recyclerview-v7:26.0.2'
+    compile 'com.android.support:support-v4:26.0.2'
+    compile 'com.google.blockly.android:blocklylib-vertical:0.9-beta.20170830'
+
     testCompile 'junit:junit:4.12'
 }

--- a/Codelab/MusicMaker-step1-Blockly/src/main/assets/sound_block_generators.js
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/assets/sound_block_generators.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Generators for blocks defined in `sound_blocks.json`.
+Blockly.JavaScript['play_sound'] = function(block) {
+  var value = '\'' + block.getFieldValue('VALUE') + '\'';
+  return 'MusicMaker.playSound(' + value + ');\n';
+};

--- a/Codelab/MusicMaker-step1-Blockly/src/main/assets/sound_blocks.json
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/assets/sound_blocks.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "play_sound",
+    "message0": "Play %1",
+    "args0": [{
+      "type": "field_dropdown",
+      "name": "VALUE",
+      "options": [
+        ["Cheer", "sounds/yeah.mp3"],
+        ["Horn", "sounds/horn.wav"],
+        ["Success", "sounds/success.wav"],
+        ["Whistle", "sounds/whistle.wav"],
+        ["C4", "sounds/c4.m4a"],
+        ["D4", "sounds/d4.m4a"],
+        ["E4", "sounds/e4.m4a"],
+        ["F4", "sounds/f4.m4a"],
+        ["G4", "sounds/g4.m4a"],
+        ["A5", "sounds/a5.m4a"],
+        ["B5", "sounds/b5.m4a"],
+        ["C5", "sounds/c5.m4a"]
+      ]
+    }],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 20
+  }
+]

--- a/Codelab/MusicMaker-step1-Blockly/src/main/assets/toolbox.xml
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/assets/toolbox.xml
@@ -1,0 +1,29 @@
+<!--
+ ~  Copyright 2017 Google Inc. All Rights Reserved.
+ ~  Licensed under the Apache License, Version 2.0 (the "License");
+ ~  you may not use this file except in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing, software
+ ~  distributed under the License is distributed on an "AS IS" BASIS,
+ ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~  See the License for the specific language governing permissions and
+ ~  limitations under the License.
+ -->
+
+<xml>
+  <category name="Sounds" colour="20">
+    <block type="play_sound"></block>
+  </category>
+  <category name="Loops" colour="120">
+    <block type="controls_repeat_ext">
+      <value name="TIMES">
+        <shadow type="math_number">
+          <field name="NUM">3</field>
+        </shadow>
+      </value>
+    </block>
+  </category>
+</xml>

--- a/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/BlocklyFragment.java
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/BlocklyFragment.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.blockly.codelab;
+
+import android.support.annotation.NonNull;
+
+import com.google.blockly.android.AbstractBlocklyFragment;
+import com.google.blockly.android.codegen.CodeGenerationRequest;
+import com.google.blockly.android.codegen.LoggingCodeGeneratorCallback;
+import com.google.blockly.model.DefaultBlocks;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A Blockly workspace and toolbox to edit a sound script.
+ */
+public class BlocklyFragment extends AbstractBlocklyFragment {
+    private static final String TAG = "BlocklyFragment";
+
+    private static final List<String> BLOCK_DEFINITIONS =
+            Collections.unmodifiableList(Arrays.asList(
+                    DefaultBlocks.LOOP_BLOCKS_PATH,  // For "controls_repeat_ext"
+                    DefaultBlocks.MATH_BLOCKS_PATH,  // For "math_number"
+                    "sound_blocks.json"
+            ));
+
+    private static final List<String> JAVASCRIPT_GENERATORS =
+            Collections.singletonList("sound_block_generators.js");
+
+    CodeGenerationRequest.CodeGeneratorCallback mCodeGeneratorCallback = null;
+
+    @NonNull
+    @Override
+    protected String getToolboxContentsXmlPath() {
+        return "toolbox.xml";
+    }
+
+    @NonNull
+    @Override
+    protected List<String> getBlockDefinitionsJsonPaths() {
+        return BLOCK_DEFINITIONS;
+    }
+
+    @NonNull
+    @Override
+    protected List<String> getGeneratorsJsPaths() {
+        return JAVASCRIPT_GENERATORS;
+    }
+
+    @NonNull
+    @Override
+    protected CodeGenerationRequest.CodeGeneratorCallback getCodeGenerationCallback() {
+        if (mCodeGeneratorCallback == null) {
+            // Late initialization since Context is not available at construction time.
+            // TODO: Replace the logging generator with actual sound playback.
+            mCodeGeneratorCallback = new LoggingCodeGeneratorCallback(getContext(), TAG);
+        }
+        return mCodeGeneratorCallback;
+    }
+}

--- a/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/EditFragment.java
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/EditFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.os.Bundle;
@@ -8,15 +23,41 @@ import android.view.View;
 import android.view.ViewGroup;
 
 /**
- * An array of colorful buttons, with some instructional text and an "Edit" menu option.
+ * An array of colorful buttons, matching the PlaybackFragment equivalents. Clicking any button will
+ * open the matching editor.
  */
 public class EditFragment extends Fragment {
-    @Nullable
     @Override
     public View onCreateView(
             LayoutInflater inflater,
             @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.edit_fragment, null);
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.edit_fragment, null);
+
+        // Each button edits a different script.
+        rootView.findViewById(R.id.button1).setOnClickListener(buildEditOnClick(1));
+        rootView.findViewById(R.id.button2).setOnClickListener(buildEditOnClick(2));
+        rootView.findViewById(R.id.button3).setOnClickListener(buildEditOnClick(3));
+        rootView.findViewById(R.id.button4).setOnClickListener(buildEditOnClick(4));
+        rootView.findViewById(R.id.button5).setOnClickListener(buildEditOnClick(5));
+        rootView.findViewById(R.id.button6).setOnClickListener(buildEditOnClick(6));
+        rootView.findViewById(R.id.button7).setOnClickListener(buildEditOnClick(7));
+        rootView.findViewById(R.id.button8).setOnClickListener(buildEditOnClick(8));
+        rootView.findViewById(R.id.button9).setOnClickListener(buildEditOnClick(9));
+
+        return rootView;
+    }
+
+    protected void onEdit(int buttonNumber) {
+        ((MainActivity) getActivity()).editSoundScript(buttonNumber);
+    }
+
+    protected View.OnClickListener buildEditOnClick(final int buttonNumber) {
+        return new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onEdit(buttonNumber);
+            }
+        };
     }
 }

--- a/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/MainActivity.java
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/MainActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.support.v4.app.FragmentManager;
@@ -15,6 +30,7 @@ public class MainActivity extends AppCompatActivity {
     private FragmentManager mFragmentManager;
     private PlaybackFragment mPlaybackFragment = new PlaybackFragment();
     private EditFragment mEditFragment = new EditFragment();
+    private BlocklyFragment mBlocklyFragment = new BlocklyFragment();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,6 +61,14 @@ public class MainActivity extends AppCompatActivity {
         FragmentTransaction fragTx = getSupportFragmentManager().beginTransaction();
         fragTx.replace(R.id.content_frame, mEditFragment, "EditFragment");
         fragTx.addToBackStack("edit");
+        fragTx.commit();
+    }
+
+    public void editSoundScript(int buttonNumber) {
+        mActionBar.setDisplayHomeAsUpEnabled(true);
+        FragmentTransaction fragTx = getSupportFragmentManager().beginTransaction();
+        fragTx.replace(R.id.content_frame, mBlocklyFragment, "BlocklyFragment");
+        fragTx.addToBackStack("blockly");
         fragTx.commit();
     }
 }

--- a/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/MultiFileAudioPlayer.java
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/MultiFileAudioPlayer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.content.Context;
@@ -15,8 +30,6 @@ import java.io.IOException;
  * Only supports a preselected set of files with known, hardcoded durations
  */
 public class MultiFileAudioPlayer {
-    private static final String TAG = "AudioFilePlayer";
-
     /**
      * The effective duration of the piano not audio files.
      * The actual durations of the notes range from 718 to 918 milliseconds.

--- a/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/PlaybackFragment.java
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/java/com/google/blockly/codelab/PlaybackFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.blockly.codelab;
 
 import android.os.Bundle;

--- a/Codelab/MusicMaker-step1-Blockly/src/main/res/values/strings.xml
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Codelab</string>
+    <string name="app_name">Blockly Music Maker</string>
     <string name="edit_instructions">Tap any button to edit its code.\nWhen complete, press back.</string>
     <string name="action_edit">Edit</string>
 </resources>

--- a/Codelab/MusicMaker-step1-Blockly/src/main/res/values/styles.xml
+++ b/Codelab/MusicMaker-step1-Blockly/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="BlocklyVerticalTheme">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/Codelab/build.gradle
+++ b/Codelab/build.gradle
@@ -15,6 +15,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 


### PR DESCRIPTION
 * Added button handling in EditFragment.
 * Import blockly dependency (and associated Android support files, from maven).
 * Adding BlocklyFragment, triggered by selecting one of the buttons on the EditFragment, with MusicMaker specific blocks, toolbox, and generators.
 * Added copyrights to source files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/656)
<!-- Reviewable:end -->
