### PR TITLE
Adding tests for BasicFieldNumberView, and fixing #665

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberView.java
@@ -163,6 +163,7 @@ public class BasicFieldNumberView extends AppCompatEditText implements FieldView
                 // Replace empty string with value closest to zero.
                 mNumberField.setValue(0);
             }
+            updateLocalizedNumberFormatIfConstraintsChanged();
             setText(mLocalizedNumberFormat.format(mNumberField.getValue()));
             setTextValid(true);
         }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelViewTest.java
@@ -39,7 +39,7 @@ public class BasicFieldLabelViewTest extends BlocklyTestCase {
 
         final BasicFieldLabelView view = new BasicFieldLabelView(getContext());
         view.setField(mFieldLabel);
-        assertThat(mFieldLabel).isSameAs(view.getField());
+        assertThat(view.getField()).isSameAs(mFieldLabel);
         assertThat(view.getText().toString())
                 .isEqualTo(INIT_TEXT_VALUE);  // Fails without .toString()
     }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
@@ -29,9 +29,13 @@ import org.junit.Test;
 public class BasicFieldNumberViewTest extends BlocklyTestCase {
 
     private static final double INITIAL_POS_INT = 5d;
-    private static final double INITIAL_POS_DECIMAL = 3.1415d;
     private static final double INITIAL_SIGNED_INT = -5d;
-    private static final double INITIAL_SIGNED_DECIMAL = -3.1415d;
+    private static final double INITIAL_POS_DECIMAL = Math.PI;
+    private static final double INITIAL_SIGNED_DECIMAL = -Math.PI;
+
+    /** The decimal string equivalent of {@link Math#PI}. */
+    private static final String PI_STRING = "3.141592653589793";
+
 
     // Cannot mock final classes.
     private FieldNumber mFieldPosInt;
@@ -79,19 +83,20 @@ public class BasicFieldNumberViewTest extends BlocklyTestCase {
         assertThat(view.getText().toString())
                 .isEqualTo("5");
 
-        view.setField(mFieldPosDecimal);
-        assertThat(view.getField()).isSameAs(mFieldPosDecimal);
-        assertThat(view.getText().toString())
-                .isEqualTo("3.1415");
-
         view.setField(mFieldSignedInt);
         assertThat(view.getField()).isSameAs(mFieldSignedInt);
         assertThat(view.getText().toString())
                 .isEqualTo("-5");
 
+        // The following is the maximum precision presentation of PI with a double.
+        view.setField(mFieldPosDecimal);
+        assertThat(view.getField()).isSameAs(mFieldPosDecimal);
+        assertThat(view.getText().toString())
+                .isEqualTo(PI_STRING);
+
         view.setField(mFieldSignedDecimal);
         assertThat(view.getField()).isSameAs(mFieldSignedDecimal);
         assertThat(view.getText().toString())
-                .isEqualTo("-3.1415");
+                .isEqualTo("-" + PI_STRING);
     }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
@@ -15,9 +15,83 @@
 
 package com.google.blockly.android.ui.fieldview;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.blockly.android.BlocklyTestCase;
+import com.google.blockly.model.FieldNumber;
+
+import org.junit.Before;
+import org.junit.Test;
+
 /**
  * Tests for {@link BasicFieldNumberView}.
  */
-public class BasicFieldNumberViewTest {
-    // TODO(#168): Write some tests, particularly on order of character input.
+public class BasicFieldNumberViewTest extends BlocklyTestCase {
+
+    private static final double INITIAL_POS_INT = 5d;
+    private static final double INITIAL_POS_DECIMAL = 3.1415d;
+    private static final double INITIAL_SIGNED_INT = -5d;
+    private static final double INITIAL_SIGNED_DECIMAL = -3.1415d;
+
+    // Cannot mock final classes.
+    private FieldNumber mFieldPosInt;
+    private FieldNumber mFieldPosDecimal;
+    private FieldNumber mFieldSignedInt;
+    private FieldNumber mFieldSignedDecimal;
+
+    // Subject of tests.
+    private BasicFieldNumberView view;
+
+    @Before
+    public void setUp() throws Exception {
+        configureForUIThread();
+
+        view = new BasicFieldNumberView(getContext());
+
+        mFieldPosInt = new FieldNumber("POSITIVE_INTEGER");
+        mFieldPosInt.setConstraints(0d, Double.NaN, 1d);   // min, max, precision
+        mFieldPosInt.setValue(INITIAL_POS_INT);
+
+        mFieldPosDecimal = new FieldNumber("POSITIVE_DECIMAL");
+        mFieldPosDecimal.setConstraints(0d, Double.NaN, Double.NaN);
+        mFieldPosDecimal.setValue(INITIAL_POS_DECIMAL);
+
+        mFieldSignedInt = new FieldNumber("SIGNED_INTEGER");
+        mFieldSignedInt.setConstraints(Double.NaN, Double.NaN, 1d);
+        mFieldSignedInt.setValue(INITIAL_SIGNED_INT);
+
+        mFieldSignedDecimal = new FieldNumber("SIGNED_DECIMAL");
+        // Default constraints.
+        assertThat(mFieldSignedDecimal.hasMinimum()).isFalse();
+        assertThat(mFieldSignedDecimal.hasMaximum()).isFalse();
+        assertThat(mFieldSignedDecimal.hasPrecision()).isFalse();
+        mFieldSignedDecimal.setValue(INITIAL_SIGNED_DECIMAL);
+    }
+
+    /**
+     * Verifies {@link BasicFieldNumberView#setField} updates the associated field and the text
+     * value presented to the user.
+     */
+    @Test
+    public void testSetField() {
+        view.setField(mFieldPosInt);
+        assertThat(view.getField()).isSameAs(mFieldPosInt);
+        assertThat(view.getText().toString())
+                .isEqualTo("5");
+
+        view.setField(mFieldPosDecimal);
+        assertThat(view.getField()).isSameAs(mFieldPosDecimal);
+        assertThat(view.getText().toString())
+                .isEqualTo("3.1415");
+
+        view.setField(mFieldSignedInt);
+        assertThat(view.getField()).isSameAs(mFieldSignedInt);
+        assertThat(view.getText().toString())
+                .isEqualTo("-5");
+
+        view.setField(mFieldSignedDecimal);
+        assertThat(view.getField()).isSameAs(mFieldSignedDecimal);
+        assertThat(view.getText().toString())
+                .isEqualTo("-3.1415");
+    }
 }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldNumberViewTest.java
@@ -33,8 +33,11 @@ public class BasicFieldNumberViewTest extends BlocklyTestCase {
     private static final double INITIAL_POS_DECIMAL = Math.PI;
     private static final double INITIAL_SIGNED_DECIMAL = -Math.PI;
 
-    /** The decimal string equivalent of {@link Math#PI}. */
-    private static final String PI_STRING = "3.141592653589793";
+    /**
+     * A regex to match the decimal string equivalent of {@link Math#PI}, accounting for minor
+     * platform variations. (Don't ask me why.)
+     */
+    private static final String PI_STRING_REGEX = "3\\.141592653589793?";
 
 
     // Cannot mock final classes.
@@ -91,12 +94,10 @@ public class BasicFieldNumberViewTest extends BlocklyTestCase {
         // The following is the maximum precision presentation of PI with a double.
         view.setField(mFieldPosDecimal);
         assertThat(view.getField()).isSameAs(mFieldPosDecimal);
-        assertThat(view.getText().toString())
-                .isEqualTo(PI_STRING);
+        assertThat(view.getText().toString()).matches(PI_STRING_REGEX);
 
         view.setField(mFieldSignedDecimal);
         assertThat(view.getField()).isSameAs(mFieldSignedDecimal);
-        assertThat(view.getText().toString())
-                .isEqualTo("-" + PI_STRING);
+        assertThat(view.getText().toString()).matches("-" + PI_STRING_REGEX);
     }
 }


### PR DESCRIPTION
Corrected NumberFormat max fractional digits when no precision is specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/667)
<!-- Reviewable:end -->
