### PR TITLE
Fix #666: Serialize block with <mutation> before inputs and fields

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -752,6 +752,13 @@ public class Block extends Observable<Block.Observer> {
             serializer.attribute(null, "inline", Boolean.toString(mInputsInline));
         }
 
+        // Serialize the mutator state before the inputs. The web code used by the code generator
+        // loads XML elements in order, and the mutation may update the available inputs or fields
+        // before the values are assigned.
+        if (mMutator != null) {
+            mMutator.serialize(serializer);
+        }
+
         for (int i = 0; i < mInputList.size(); i++) {
             if (mInputList.get(i) != null) {
                 mInputList.get(i).serialize(serializer, options);
@@ -762,10 +769,6 @@ public class Block extends Observable<Block.Observer> {
             serializer.startTag(null, "next");
             getNextBlock().serialize(serializer, false, options);
             serializer.endTag(null, "next");
-        }
-
-        if (mMutator != null) {
-            mMutator.serialize(serializer);
         }
 
         serializer.endTag(null, mIsShadow ? "shadow" : "block");


### PR DESCRIPTION
Adjust the block mutation serialization order to account for JavaScript's in-order XML processing.
Fixes #666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/668)
<!-- Reviewable:end -->
