### PR TITLE
Correct Multidex. Better test error output.

### DIFF
--- a/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/codegen/CodeGeneratorServiceTest.java
@@ -122,10 +122,9 @@ public class CodeGeneratorServiceTest extends BlocklyTestCase {
         String xml = toXml(block);
         String url = CodeGeneratorService.buildCodeGenerationUrl(xml, "Blockly.JavaScript");
 
-        Matcher matcher = Pattern.compile("javascript:generate\\('(.*)', Blockly.JavaScript\\);")
-                .matcher(url);
-        assertThat(matcher.matches()).isTrue();
-        String jsString = matcher.group(1);
+        Pattern urlPattern = Pattern.compile("javascript:generate\\('(.*)', Blockly.JavaScript\\);");
+        assertThat(url).matches(urlPattern);
+        String jsString = urlPattern.matcher(url).group(1);
         assertThat(jsString.contains("apostrophe%20%27%20end")).isTrue();
     }
 

--- a/blocklytest/src/main/AndroidManifest.xml
+++ b/blocklytest/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.google.blockly.android.test">
 
     <application
+        android:name="android.support.multidex.MultiDexApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
 * Use android.support.multidex.MultiDexApplication, per [this doc](https://developer.android.com/studio/build/multidex.html). Not using this was causing total test failure in API 18 and 19 (various JUnit class not found errors).
 * Rewrote `testEscapeFieldDataForAndroidWebView()` for better assertion output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/669)
<!-- Reviewable:end -->
