### PR TITLE
Protect against race conditions in BasicFieldImageView

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -121,13 +121,19 @@
             <field name="NOTE">60</field>
         </block>
     </category>
-    <category name="Images">
+    <category name="Images 1">
         <block type="image-relative"/>
         <block type="image-fileuri"/>
         <block type="image-datauri"/>
         <block type="image-small"/>
         <block type="image-large"/>
         <block type="image-missing"/>
+    </category>
+    <category name="Images 2">
+        <block type="test_with_lots_of_network_icons"/>
+        <block type="test_with_lots_of_network_icons"/>
+        <block type="test_with_lots_of_network_icons"/>
+        <block type="test_with_lots_of_network_icons"/>
     </category>
     <category name="Variables" custom="VARIABLE"/>
     <category name="Variables" custom="FUNCTIONS"/>

--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -136,5 +136,5 @@
         <block type="test_with_lots_of_network_icons"/>
     </category>
     <category name="Variables" custom="VARIABLE"/>
-    <category name="Variables" custom="FUNCTIONS"/>
+    <category name="Functions" custom="FUNCTIONS"/>
 </toolbox>

--- a/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
@@ -263,5 +263,130 @@
         "alt": "*"
       }
     ]
+  },
+  {
+    "type": "test_with_lots_of_network_icons",
+    "message0": "Lots of network icons: %1 %2 %3 %4 %5 %6 %7 %8 %9 %10 %11 %12 %13 %14 %15 %16 %17 %18",
+    "args0": [
+      {
+        "type": "input_dummy"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/A.png",
+        "width": 32,
+        "height": 32,
+        "alt": "twit"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/B.png",
+        "width": 32,
+        "height": 32,
+        "alt": "G+"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/C.png",
+        "width": 32,
+        "height": 32,
+        "alt": "LinkedIn"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/D.png",
+        "width": 32,
+        "height": 32,
+        "alt": "Facebook"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/E.png",
+        "width": 32,
+        "height": 32,
+        "alt": "twit"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/F.png",
+        "width": 32,
+        "height": 32,
+        "alt": "G+"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/G.png",
+        "width": 32,
+        "height": 32,
+        "alt": "LinkedIn"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/H.png",
+        "width": 32,
+        "height": 32,
+        "alt": "Facebook"
+      },
+      {
+        "type": "input_dummy"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/A.png",
+        "width": 32,
+        "height": 32,
+        "alt": "twit"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/B.png",
+        "width": 32,
+        "height": 32,
+        "alt": "G+"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/C.png",
+        "width": 32,
+        "height": 32,
+        "alt": "LinkedIn"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/D.png",
+        "width": 32,
+        "height": 32,
+        "alt": "Facebook"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/E.png",
+        "width": 32,
+        "height": 32,
+        "alt": "twit"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/F.png",
+        "width": 32,
+        "height": 32,
+        "alt": "G+"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/G.png",
+        "width": 32,
+        "height": 32,
+        "alt": "LinkedIn"
+      },
+      {
+        "type": "field_image",
+        "src": "http://google.github.io/blockly-android/H.png",
+        "width": 32,
+        "height": 32,
+        "alt": "Facebook"
+      }
+    ],
+    "colour": 230
   }
 ]

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
@@ -198,7 +198,10 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
         // Check for null b/c of https://groups.google.com/d/msg/blockly/lC91XADUiI4/Y0cLRAYQBQAJ
         // Synchronize ImageField update. Issues #678.
         synchronized (mImageFieldLock) {
-            if (mImageField != null) {
+            if (mImageField == null) {
+                setMinimumWidth(0);
+                setMinimumHeight(0);
+            } else {
                 float density = getContext().getResources().getDisplayMetrics().density;
                 int pxWidth = (int) Math.ceil(mImageField.getWidth() * density);
                 int pxHeight = (int) Math.ceil(mImageField.getHeight() * density);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
@@ -122,7 +122,7 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
     /**
      * Asynchronously load and set image bitmap.
      */
-    @Deprecated // 2017 Oct 19
+    @Deprecated // Use startLoadingImage(String) below. Deprecated 2017 Oct 19.
     protected void startLoadingImage() {
         startLoadingImage(mImageField.getSource());
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
+import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 import android.util.AttributeSet;
 import android.util.Base64;
@@ -60,12 +61,13 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
             if (source.equals(mImageSrc)) {
                 updateViewSize();
             } else {
-                startLoadingImage();
+                startLoadingImage(source);
             }
         }
     };
 
     protected FieldImage mImageField;
+    protected Object mImageFieldLock = new Object();
     protected String mImageSrc = null;
 
     /**
@@ -85,6 +87,7 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
         super(context, attrs, defStyleAttr);
     }
 
+    @UiThread
     @Override
     public void setField(Field field) {
         FieldImage imageField = (FieldImage) field;
@@ -92,15 +95,17 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
             return;
         }
 
-        if (mImageField != null) {
-            mImageField.unregisterObserver(mFieldObserver);
-        }
-        mImageField = imageField;
-        if (mImageField != null) {
-            startLoadingImage();
-            mImageField.registerObserver(mFieldObserver);
-        } else {
-            // TODO(#44): Set image to default 'no image' default
+        synchronized (mImageFieldLock) {
+            if (mImageField != null) {
+                mImageField.unregisterObserver(mFieldObserver);
+            }
+            mImageField = imageField;
+            if (mImageField != null) {
+                startLoadingImage(mImageField.getSource());
+                mImageField.registerObserver(mFieldObserver);
+            } else {
+                // TODO(#44): Set image to default 'no image' default
+            }
         }
     }
 
@@ -117,10 +122,17 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
     /**
      * Asynchronously load and set image bitmap.
      */
-    // TODO(#44): Provide a default image if the image loading fails.
+    @Deprecated // 2017 Oct 19
     protected void startLoadingImage() {
-        final String source = mImageField.getSource();
+        startLoadingImage(mImageField.getSource());
+    }
 
+    /**
+     * Asynchronously load and set image bitmap from the specified source string.
+     * @param source The URI source of the image.
+     */
+    // TODO(#44): Provide a default image if the image loading fails.
+    protected void startLoadingImage(final String source) {
         // Do I/O in the background
         new AsyncTask<String, Void, Bitmap>() {
             @Override
@@ -177,14 +189,18 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
         }
     }
 
+    @UiThread
     protected void updateViewSize() {
         // Check for null b/c of https://groups.google.com/d/msg/blockly/lC91XADUiI4/Y0cLRAYQBQAJ
-        if (mImageField != null ) {
-            float density = getContext().getResources().getDisplayMetrics().density;
-            int pxWidth = (int) Math.ceil(mImageField.getWidth() * density);
-            int pxHeight = (int) Math.ceil(mImageField.getHeight() * density);
-            setMinimumWidth(pxWidth);
-            setMinimumHeight(pxHeight);
+        // Synchronize ImageField update. Issues #678.
+        synchronized (mImageFieldLock) {
+            if (mImageField != null) {
+                float density = getContext().getResources().getDisplayMetrics().density;
+                int pxWidth = (int) Math.ceil(mImageField.getWidth() * density);
+                int pxHeight = (int) Math.ceil(mImageField.getHeight() * density);
+                setMinimumWidth(pxWidth);
+                setMinimumHeight(pxHeight);
+            }
         }
     }
 }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldImageView.java
@@ -57,11 +57,15 @@ public class BasicFieldImageView extends android.support.v7.widget.AppCompatImag
     protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
         public void onValueChanged(Field field, String newValue, String oldValue) {
-            String source = mImageField.getSource();
-            if (source.equals(mImageSrc)) {
-                updateViewSize();
-            } else {
-                startLoadingImage(source);
+            synchronized (mImageFieldLock) {
+                if (mImageField == field) {
+                    String source = mImageField.getSource();
+                    if (source.equals(mImageSrc)) {
+                        updateViewSize();
+                    } else {
+                        startLoadingImage(source);
+                    }
+                }
             }
         }
     };

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldView.java
@@ -15,6 +15,7 @@
 
 package com.google.blockly.android.ui.fieldview;
 
+import android.support.annotation.UiThread;
 import android.view.View;
 
 import com.google.blockly.model.Field;
@@ -37,10 +38,12 @@ public interface FieldView {
      *
      * @param field The field backing this view.
      */
+    @UiThread
     void setField(Field field);
 
     /**
      * Disconnect the model from this view.
      */
+    @UiThread
     void unlinkField();
 }


### PR DESCRIPTION
Adding DevTests block that depends upon images from the network (hosted at github.io).

Adding synchronization in BasicFieldImageView around usages of mImageField. While this means these methods can block the UI thread, the logic and methods within should all be very short lived and should rarely collide.

These do not include a test case, and I have not been able to force the failures reported in #678.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/679)
<!-- Reviewable:end -->
