### PR TITLE
Adding support from "style" blocks and "hat": "cap"

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -22,6 +22,7 @@
             <block type="statement_statement_input"></block>
             <block type="statement_value_input"></block>
         </category>
+        <block type="styled_event_cap"></block>
         <block type="statement_no_input"></block>
         <block type="output_no_input"></block>
         <block type="statement_no_next"></block>

--- a/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
@@ -388,5 +388,14 @@
       }
     ],
     "colour": 230
+  },
+  {
+    "type": "styled_event_cap",
+    "message0": "Hat block (event)",
+    "nextStatement": null,
+    "colour": 330,
+    "style": {
+      "hat": "cap"
+    }
   }
 ]

--- a/blocklydemo/src/main/assets/sample_sections/mock_block_initial_workspace.xml
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_initial_workspace.xml
@@ -1,52 +1,56 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
-    <block type="dummy" id="first_dummy_block_id" x="5" y="5">
-        <value name="input2">
-            <block type="valueInput" id="first_value_input_id">
-                <value name="input">
-                    <block type="simpleValue" id="5384f567-272f-47b6-9261-b6f57abd964f" />
-                </value>
-            </block>
-        </value>
-        <field name="checkbox!">true</field>
-        <field name="label2">180</field>
-        <field name="date!">2015-03-19</field>
-        <field name="dropdown">value1</field>
-        <statement name="input6">
-            <block type="statement" id="first_statement_block_id" />
-        </statement>
-        <field name="DO">loop</field>
-        <field name="color">#ff0000</field>
-        <field name="input text">initial wide field of text</field>
-        <field name="DO">another loop</field>
+    <block type="styled_event_cap" x="5" y="5">
         <next>
-            <block type="dummy" id="second_dummy_block_id" inline="true">
+            <block type="dummy" id="first_dummy_block_id">
+                <value name="input2">
+                    <block type="valueInput" id="first_value_input_id">
+                        <value name="input">
+                            <block type="simpleValue" id="5384f567-272f-47b6-9261-b6f57abd964f" />
+                        </value>
+                    </block>
+                </value>
                 <field name="checkbox!">true</field>
                 <field name="label2">180</field>
                 <field name="date!">2015-03-19</field>
                 <field name="dropdown">value1</field>
                 <statement name="input6">
-                    <block type="statement" id="second_statement_block_id" />
+                    <block type="statement" id="first_statement_block_id" />
                 </statement>
                 <field name="DO">loop</field>
                 <field name="color">#ff0000</field>
                 <field name="input text">initial wide field of text</field>
                 <field name="DO">another loop</field>
                 <next>
-                    <block type="dummy" id="third_dummy_block_id" inline="true">
+                    <block type="dummy" id="second_dummy_block_id" inline="true">
                         <field name="checkbox!">true</field>
                         <field name="label2">180</field>
                         <field name="date!">2015-03-19</field>
                         <field name="dropdown">value1</field>
+                        <statement name="input6">
+                            <block type="statement" id="second_statement_block_id" />
+                        </statement>
                         <field name="DO">loop</field>
                         <field name="color">#ff0000</field>
                         <field name="input text">initial wide field of text</field>
                         <field name="DO">another loop</field>
+                        <next>
+                            <block type="dummy" id="third_dummy_block_id" inline="true">
+                                <field name="checkbox!">true</field>
+                                <field name="label2">180</field>
+                                <field name="date!">2015-03-19</field>
+                                <field name="dropdown">value1</field>
+                                <field name="DO">loop</field>
+                                <field name="color">#ff0000</field>
+                                <field name="input text">initial wide field of text</field>
+                                <field name="DO">another loop</field>
+                            </block>
+                        </next>
                     </block>
                 </next>
             </block>
         </next>
     </block>
-    <block type="outer" id="outer_block_id" x="400" y="70">
+    <block type="outer" id="outer_block_id" x="500" y="140">
         <value name="input2">
             <block type="inner" id="inner_block_id">
                 <value name="input3">
@@ -55,5 +59,5 @@
             </block>
         </value>
     </block>
-    <block type="statement-only" id="statement_only_block_id" x="500" y="370" />
+    <block type="statement-only" id="statement_only_block_id" x="800" y="400" />
 </xml>

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -28,6 +28,7 @@ import com.google.blockly.utils.BlockLoadingException;
 import com.google.blockly.utils.BlocklyXmlHelper;
 import com.google.blockly.utils.ColorUtils;
 
+import org.json.JSONObject;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
@@ -94,6 +95,7 @@ public class Block extends Observable<Block.Observer> {
     private final String mId;
     private final String mType;
     private boolean mIsShadow;
+    private JSONObject mStyle = null;
 
     // Set by BlockFactory.applyMutator(). May only be set once.
     private Mutator mMutator = null;
@@ -147,6 +149,7 @@ public class Block extends Observable<Block.Observer> {
         mId = id;
 
         mType = definition.getTypeName();
+        mStyle = definition.getStyleJson();
         mColor = definition.getColor();
 
         reshape(definition.createInputList(factory),
@@ -269,6 +272,13 @@ public class Block extends Observable<Block.Observer> {
                 next.addAllBlockIds(outList);
             }
         }
+    }
+
+    /**
+     * @return The style definition for this block.
+     */
+    public JSONObject getStyle() {
+        return mStyle;
     }
 
     /**

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Block.java
@@ -95,7 +95,7 @@ public class Block extends Observable<Block.Observer> {
     private final String mId;
     private final String mType;
     private boolean mIsShadow;
-    private JSONObject mStyle = null;
+    private JSONObject mStyle = null;  // WARNING: Often a mutable object shared by all blocks.
 
     // Set by BlockFactory.applyMutator(). May only be set once.
     private Mutator mMutator = null;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/BlockDefinition.java
@@ -44,6 +44,7 @@ public final class BlockDefinition {
 
     // TODO(#542): Parse into List<InputDefinition> and discard JSON. Include FieldDropdown.Options.
     private final @NonNull JSONObject mJson;  // Saved to parse inputs and field at creation time.
+    private final @Nullable JSONObject mStyle; // Ideally, this would be immutable.
     private final @NonNull String mTypeName;
     private final int mColor;
     private final boolean mHasOutput;
@@ -113,6 +114,8 @@ public final class BlockDefinition {
             throw new BlockLoadingException(
                     "Cannot load BlockDefinition \"" + mTypeName + "\" from JSON.", e);
         }
+
+        mStyle = mJson.optJSONObject("style");
     }
 
     /**
@@ -280,6 +283,14 @@ public final class BlockDefinition {
     @NonNull
     public List<String> getExtensionNames() {
         return mExtensionNames;
+    }
+
+    /**
+     * @return The style definition JSON for this block type.
+     */
+    @Nullable
+    public JSONObject getStyleJson() {
+        return mStyle;
     }
 
     /**

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -54,8 +54,8 @@ public class BlockView extends AbstractBlockView<InputView> {
     private static final float SHADOW_SATURATION_MULTIPLIER = 0.4f;
     private static final float SHADOW_VALUE_MULTIPLIER = 1.2f;
 
-    private static final String STYLE_HAT_KEY = "hat";
-    private static final String HAT_STYLE_CAP = "cap";
+    private static final String STYLE_KEY_HAT = "hat";
+    private static final String HAT_CAP = "cap";
 
     private static final int UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS =
             Block.UPDATE_COLOR | Block.UPDATE_IS_DISABLED | Block.UPDATE_IS_SHADOW;
@@ -302,8 +302,8 @@ public class BlockView extends AbstractBlockView<InputView> {
         if (style == null) {
             return false;
         }
-        String hatStyle = style.optString(STYLE_HAT_KEY);
-        if (hatStyle != null && hatStyle.equalsIgnoreCase(HAT_STYLE_CAP)) {
+        String hatStyle = style.optString(STYLE_KEY_HAT);
+        if (hatStyle != null && hatStyle.equalsIgnoreCase(HAT_CAP)) {
             return true;
         } else {
             Log.w(TAG, "Unrecognized hat style: " + hatStyle);

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/BlockView.java
@@ -27,6 +27,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.NinePatchDrawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.google.blockly.android.control.ConnectionManager;
 import com.google.blockly.android.ui.Dragger;
@@ -37,6 +38,8 @@ import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Block;
 import com.google.blockly.model.Input;
 
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,10 +48,14 @@ import java.util.List;
  */
 @SuppressLint("ViewConstructor")
 public class BlockView extends AbstractBlockView<InputView> {
+    private static final String TAG = "Vertical BlockView";
     private static final boolean DEBUG = false;
 
     private static final float SHADOW_SATURATION_MULTIPLIER = 0.4f;
     private static final float SHADOW_VALUE_MULTIPLIER = 1.2f;
+
+    private static final String STYLE_HAT_KEY = "hat";
+    private static final String HAT_STYLE_CAP = "cap";
 
     private static final int UPDATES_THAT_CAUSE_RELOAD_SHAPE_ASSETS =
             Block.UPDATE_COLOR | Block.UPDATE_IS_DISABLED | Block.UPDATE_IS_SHADOW;
@@ -85,7 +92,7 @@ public class BlockView extends AbstractBlockView<InputView> {
     @Nullable private Rect mNextFillRect = null;
     private ColorFilter mBlockColorFilter;
     private final Paint mFillPaint = new Paint();
-    private final boolean mUseHat;
+    private final boolean mUseCap;
     private int mBlockTopPadding;
 
     private final Rect tempRect = new Rect(); // Only use in main thread functions.
@@ -116,7 +123,7 @@ public class BlockView extends AbstractBlockView<InputView> {
         mTouchHandler = touchHandler;
         mPatchManager = factory.getPatchManager();  // Shortcut.
         mMinBlockWidth = (int) context.getResources().getDimension(R.dimen.min_block_width);
-        mUseHat = factory.isBlockHatsEnabled();
+        mUseCap = isBlockCapEnabled(factory, block);
 
         setClickable(true);
         setFocusable(true);
@@ -157,7 +164,7 @@ public class BlockView extends AbstractBlockView<InputView> {
     // TODO(#144): Move to AbstractBlockView, using abstract methods for calls. After #133
     @Override
     public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        mBlockTopPadding = mPatchManager.computeBlockTopPadding(mBlock);
+        mBlockTopPadding = mPatchManager.computeBlockTopPadding(this);
 
         if (mIconsView != null) {
             mIconsView.measure(widthMeasureSpec, heightMeasureSpec);
@@ -246,6 +253,13 @@ public class BlockView extends AbstractBlockView<InputView> {
     }
 
     /**
+     * @return Whether this block is a start block rendered with a rounded "cap" styled hat.
+     */
+    public boolean hasCap() {
+        return mUseCap;
+    }
+
+    /**
      * Called when a block's inputs, fields, comment, or mutator is/are updated, and thus the
      * shape may have changed.
      */
@@ -270,6 +284,31 @@ public class BlockView extends AbstractBlockView<InputView> {
             }
         }
         return false;
+    }
+
+    /**
+     * Reads the configuration and style to determine if the block has a "cap" style hat.
+     * Currently, a cap (rounded top) is the only type of hat supported.
+     * @param factory The view factory.
+     * @param block The block.
+     * @return Whether the block should have a cap.
+     */
+    protected boolean isBlockCapEnabled(VerticalBlockViewFactory factory, Block block) {
+        // Are hat enabled globally for all start blocks? (Older config.)
+        if (factory.isBlockHatsEnabled()) {
+            return true;
+        }
+        JSONObject style = block.getStyle();
+        if (style == null) {
+            return false;
+        }
+        String hatStyle = style.optString(STYLE_HAT_KEY);
+        if (hatStyle != null && hatStyle.equalsIgnoreCase(HAT_STYLE_CAP)) {
+            return true;
+        } else {
+            Log.w(TAG, "Unrecognized hat style: " + hatStyle);
+            return false;
+        }
     }
 
     /**
@@ -851,7 +890,7 @@ public class BlockView extends AbstractBlockView<InputView> {
                     mPatchManager.getPatchDrawable(R.drawable.top_start_output_border);
             mOutputConnectorHighlightPatch =
                     mPatchManager.getPatchDrawable(R.drawable.top_start_output_connection);
-        } else if (mUseHat) {
+        } else if (mUseCap) {
             topStartDrawable = getColoredPatchDrawable(
                     isShadow ? R.drawable.top_start_hat_shadow : R.drawable.top_start_hat);
             topStartBorderDrawable =

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/InputView.java
@@ -83,8 +83,8 @@ public class InputView extends AbstractInputView {
                     " must be called before each call to measure().");
         }
         mHasMeasuredFieldsAndInput = false;
-        Block block = mInput.getBlock();
-        mBlockTopPadding = mPatchManager.computeBlockTopPadding(block);
+        BlockGroup connectedBlockGroup = getConnectedBlockGroup();
+        mBlockTopPadding = mPatchManager.computeBlockGroupTopPadding(connectedBlockGroup);
 
         // Width is the width of all fields, plus padding, plus width of child.
         final int width =
@@ -92,7 +92,7 @@ public class InputView extends AbstractInputView {
 
         // Height is maximum of field height with padding or child height, and at least the minimum
         // height for an empty block.
-        final int totalPaddingHeight = mPatchManager.computeBlockTotalPaddingY(mInput.getBlock());
+        final int totalPaddingHeight = mBlockTopPadding + mPatchManager.mBlockBottomPadding;
         final int height = Math.max(mPatchManager.mMinBlockHeight,
                 Math.max(mMaxFieldHeight + totalPaddingHeight, mConnectedGroupHeight));
 


### PR DESCRIPTION
The PatchManager now loads both the default top-left path and the
hat patch into memory, since they can both be in use in the same workspace..

Added a test block to the DevTest toolbox and workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/682)
<!-- Reviewable:end -->
