### PR TITLE
Block color tests

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -136,6 +136,14 @@
         <block type="test_with_lots_of_network_icons"/>
         <block type="test_with_lots_of_network_icons"/>
     </category>
+    <category name="Colors">
+        <block type="block_color_hex1"/>
+        <block type="block_color_hex2"/>
+        <block type="block_color_hex3"/>
+        <label text="Bad examples"></label>
+        <block type="block_color_hex4"/>
+        <block type="block_color_hex5"/>
+    </category>
     <category name="Variables" custom="VARIABLE"/>
     <category name="Functions" custom="FUNCTIONS"/>
 </toolbox>

--- a/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
+++ b/blocklydemo/src/main/assets/sample_sections/level_3/toolbox.xml
@@ -141,6 +141,7 @@
         <block type="block_color_hex2"/>
         <block type="block_color_hex3"/>
         <label text="Bad examples"></label>
+        <block type="block_no_color"/>
         <block type="block_color_hex4"/>
         <block type="block_color_hex5"/>
     </category>

--- a/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
@@ -492,6 +492,10 @@
     "colour": "#010101"
   },
   {
+    "type": "block_no_color",
+    "message0": "Block color: unset"
+  },
+  {
     "type": "block_color_hex4",
     "message0": "Block color: #RRGGBBAA (invalid)",
     "colour": "#992aff99"

--- a/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
@@ -397,5 +397,108 @@
     "style": {
       "hat": "cap"
     }
+  },
+  {
+    "type": "block_color_hex1",
+    "message0": "Block color: Bright purple %1 %2 %3 %4",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "TEXT",
+        "text": "#992aff"
+      },
+      {
+        "type": "field_dropdown",
+        "name": "DROPDOWN",
+        "options": [
+          [ "option", "ONE" ],
+          [ "option", "TWO" ]
+        ]
+      },
+      {
+        "type": "field_checkbox",
+        "name": "NAME",
+        "checked": true
+      },
+      {
+        "type": "input_value",
+        "name": "NAME"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#992aff"
+  },
+  {
+    "type": "block_color_hex2",
+    "message0": "Block color: White %1 %2 %3 %4",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "TEXT",
+        "text": "#fefefe"
+      },
+      {
+        "type": "field_dropdown",
+        "name": "DROPDOWN",
+        "options": [
+          [ "option", "ONE" ],
+          [ "option", "TWO" ]
+        ]
+      },
+      {
+        "type": "field_checkbox",
+        "name": "NAME",
+        "checked": true
+      },
+      {
+        "type": "input_value",
+        "name": "NAME"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#fefefe"
+  },
+  {
+    "type": "block_color_hex3",
+    "message0": "Block color: Black %1 %2 %3 %4",
+    "args0": [
+      {
+        "type": "field_input",
+        "name": "TEXT",
+        "text": "#010101"
+      },
+      {
+        "type": "field_dropdown",
+        "name": "DROPDOWN",
+        "options": [
+          [ "option", "ONE" ],
+          [ "option", "TWO" ]
+        ]
+      },
+      {
+        "type": "field_checkbox",
+        "name": "NAME",
+        "checked": true
+      },
+      {
+        "type": "input_value",
+        "name": "NAME"
+      }
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#010101"
+  },
+  {
+    "type": "block_color_hex4",
+    "message0": "Block color: #RRGGBBAA (invalid)",
+    "colour": "#992aff99"
+  },
+  {
+    "type": "block_color_hex5",
+    "message0": "Block color: #RRGGBB (invalid)",
+    "colour": "#NotHex"
   }
 ]

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
@@ -78,8 +78,6 @@ public class ColorUtils {
      */
     public static int parseColor(@NonNull String str, @Nullable float[] tempHsvArray)
             throws ParseException {
-        Integer result = null;
-
         char firstChar = str.charAt(0);
         if (firstChar == '#' && str.length() == 7) {
             try {

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
@@ -95,7 +95,7 @@ public class ColorUtils {
                 throw new ParseException("Invalid color hue: " + str, 0);
             }
         } else {
-            // Maybe other color formats? 3 digit hex, CSS color functions, etc.return result;
+            // Maybe other color formats? 3 digit hex, CSS color functions, etc.
             throw new ParseException("Unrecognized color format: " + str, 0);
         }
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
@@ -83,21 +83,21 @@ public class ColorUtils {
         char firstChar = str.charAt(0);
         if (firstChar == '#' && str.length() == 7) {
             try {
-                result = Integer.parseInt(str.substring(1, 7), 16);
-            } catch (NumberFormatException e) {
+                return Color.parseColor(str);
+            } catch (IllegalArgumentException e) {
                 throw new ParseException("Invalid hex color: " + str, 0);
             }
-            return result;
         } else if (Character.isDigit(firstChar) && str.length() <= 3) {
             try {
                 int hue = Integer.parseInt(str);
-                result = getBlockColorForHue(hue, tempHsvArray);
+                return getBlockColorForHue(hue, tempHsvArray);
             } catch (NumberFormatException e) {
                 throw new ParseException("Invalid color hue: " + str, 0);
             }
+        } else {
+            // Maybe other color formats? 3 digit hex, CSS color functions, etc.return result;
+            throw new ParseException("Unrecognized color format: " + str, 0);
         }
-        // Maybe other color formats? 3 digit hex, CSS color functions, etc.
-        return result;
     }
 
     /**


### PR DESCRIPTION
Adding demo blocks to test how blocks colors rendered, including blocks with missing or invalid color specifications.

Fix the color alpha issue noted in #686, using suggested fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/689)
<!-- Reviewable:end -->
