### PR TITLE
Fix CheckStyle AppCompat views.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/TrashCanView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/TrashCanView.java
@@ -19,11 +19,11 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.IntDef;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.DragEvent;
 import android.view.View;
-import android.widget.ImageView;
 
 import com.google.blockly.android.R;
 
@@ -39,7 +39,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
  * opened (pending drop during drag).  The TrashCanView assumes both drawables are the same size, so
  * the overall view will not change size when the state changes.
  */
-public class TrashCanView extends ImageView {
+public class TrashCanView extends AppCompatImageView {
     private static final String TAG = "TrashCanView";
 
     @Retention(SOURCE)

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldCheckboxView.java
@@ -16,8 +16,8 @@
 package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatCheckBox;
 import android.util.AttributeSet;
-import android.widget.CheckBox;
 import android.widget.CompoundButton;
 
 import com.google.blockly.model.Field;
@@ -26,7 +26,7 @@ import com.google.blockly.model.FieldCheckbox;
 /**
  * Renders a checkbox as part of a BlockView.
  */
-public class BasicFieldCheckboxView extends CheckBox implements FieldView {
+public class BasicFieldCheckboxView extends AppCompatCheckBox implements FieldView {
     protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
         public void onValueChanged(Field field, String oldStrValue, String newStrValue) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDateView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDateView.java
@@ -16,10 +16,10 @@
 package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatTextView;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldDate;
@@ -29,7 +29,7 @@ import java.text.DateFormat;
 /**
  * Renders a date and a date picker as part of a Block.
  */
-public class BasicFieldDateView extends TextView implements FieldView {
+public class BasicFieldDateView extends AppCompatTextView implements FieldView {
     private static final DateFormat LOCALIZED_FORMAT = DateFormat.getDateInstance(DateFormat.SHORT);
 
     protected Field.Observer mFieldObserver = new Field.Observer() {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
@@ -17,9 +17,9 @@ package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
 import android.widget.ArrayAdapter;
-import android.widget.Spinner;
 
 import com.google.blockly.android.R;
 import com.google.blockly.model.Field;
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * Renders a dropdown field as part of a Block.
  */
-public class BasicFieldDropdownView extends Spinner implements FieldView {
+public class BasicFieldDropdownView extends AppCompatSpinner implements FieldView {
     private static final String TAG = "BasicFieldDropdownView";
 
     private Field.Observer mFieldObserver = new Field.Observer() {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldInputView.java
@@ -16,13 +16,13 @@
 package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.DragEvent;
-import android.widget.EditText;
 
 import com.google.blockly.android.ui.WorkspaceHelper;
 import com.google.blockly.model.Field;
@@ -31,7 +31,7 @@ import com.google.blockly.model.FieldInput;
 /**
  * Renders editable text as part of a {@link com.google.blockly.android.ui.InputView}.
  */
-public class BasicFieldInputView extends EditText implements FieldView {
+public class BasicFieldInputView extends AppCompatEditText implements FieldView {
     private static final String TAG = "BasicFieldInputView";
 
     private final TextWatcher mWatcher = new TextWatcher() {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldLabelView.java
@@ -16,8 +16,8 @@
 package com.google.blockly.android.ui.fieldview;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import com.google.blockly.model.Field;
 import com.google.blockly.model.FieldLabel;
@@ -25,7 +25,7 @@ import com.google.blockly.model.FieldLabel;
 /**
  * Renders text as part of a BlockView.
  */
-public class BasicFieldLabelView extends TextView implements FieldView {
+public class BasicFieldLabelView extends AppCompatTextView implements FieldView {
     protected final Field.Observer mFieldObserver = new Field.Observer() {
         @Override
         public void onValueChanged(Field field, String oldValue, String newValue) {


### PR DESCRIPTION
In order to support features such as tinting, the appcompat library will automatically load special appcompat replacements for the builtin widgets. However, this does not work for your own custom views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/700)
<!-- Reviewable:end -->
