### PR TITLE
Fix missing locale on String#toLowerCase()

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/NameManager.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/NameManager.java
@@ -21,6 +21,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -179,7 +180,7 @@ public abstract class NameManager extends DataSetObservable {
      * @return The canonical string for the provided name, as used by {@link #mCanonicalMap}.
      */
     protected String makeCanonical(@NonNull String name) {
-        return name.toLowerCase();
+        return name.toLowerCase(Locale.getDefault());
     }
 
     /**


### PR DESCRIPTION
Calling String#toLowerCase() or #toUpperCase() without specifying an explicit locale is a common source of bugs. The reason for that is that those methods will use the current locale on the user's device, and even though the code appears to work correctly when you are developing the app, it will fail in some locales. For example, in the Turkish locale, the uppercase replacement for i is not I.

In our situation, we need canonical names for variables, so using the user's default locale will be sufficient (there may be issues if the user's code is saved on one device and reloaded on another with a different Locale)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/701)
<!-- Reviewable:end -->
