### PR TITLE
Fix Checkstyle DateFormat Locale

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/FieldDate.java
@@ -27,6 +27,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * Adds a date picker to an Input. Dates must be in the format "YYYY-MM-DD"
@@ -35,7 +36,7 @@ public final class FieldDate extends Field {
     private static final String TAG = "FieldDate";
 
     // Date format used for serialization.
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
     private final Date mDate = new Date();
 


### PR DESCRIPTION
Almost all callers should use getDateInstance(), getDateTimeInstance(), or getTimeInstance() to get a ready-made instance of SimpleDateFormat suitable for the user's locale. The main reason you'd create an instance this class directly is because you need to format/parse a specific machine-readable format, in which case you almost certainly want to explicitly ask for US to ensure that you get ASCII digits (rather than, say, Arabic digits).

Here, we're parsing to/from a save file, therefore should be using US Locale for storing dates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/702)
<!-- Reviewable:end -->
