### PR TITLE
Fix inefficient layout weight

### DIFF
--- a/blocklylib-core/src/main/res/layout/if_else_mutator_dialog.xml
+++ b/blocklylib-core/src/main/res/layout/if_else_mutator_dialog.xml
@@ -9,7 +9,7 @@
         android:orientation="horizontal">
         <TextView
             android:id="@+id/if_else_count"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/mutator_ifelse_edit_ifelse_count"
             android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -31,7 +31,7 @@
         android:orientation="horizontal">
         <TextView
             android:id="@+id/else_count"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/mutator_ifelse_edit_has_else"
             android:textAppearance="@style/TextAppearance.AppCompat.Large"


### PR DESCRIPTION
When only a single widget in a LinearLayout defines a weight, it is more efficient to assign a width/height of 0dp to it since it will absorb all the remaining space anyway. With a declared width/height of 0dp it does not have to measure its own size first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/706)
<!-- Reviewable:end -->
