### PR TITLE
Fix RecyclerView issue

### DIFF
--- a/blocklydemo/src/main/java/com/google/blockly/android/demo/FlyoutDemos.java
+++ b/blocklydemo/src/main/java/com/google/blockly/android/demo/FlyoutDemos.java
@@ -52,12 +52,12 @@ public class FlyoutDemos extends Activity{
         }
 
         @Override
-        public void onBindViewHolder(RecyclerView.ViewHolder holder, final int position) {
+        public void onBindViewHolder(final RecyclerView.ViewHolder holder, int position) {
             ((TextView) holder.itemView).setText(mRes.getText(DEMO_NAMES[position]));
             holder.itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Intent intent = new Intent(FlyoutDemos.this, DEMO_TARGETS[position]);
+                    Intent intent = new Intent(FlyoutDemos.this, DEMO_TARGETS[holder.getAdapterPosition()]);
                     startActivity(intent);
                 }
             });


### PR DESCRIPTION
RecyclerView will not call onBindViewHolder again when the position of the item changes in the data set unless the item itself is invalidated or the new position cannot be determined.

For this reason, you should only use the position parameter while acquiring the related data item inside this method, and should not keep a copy of it.

If you need the position of an item later on (e.g. in a click listener), use getAdapterPosition() which will have the updated adapter position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/707)
<!-- Reviewable:end -->
