### PR TITLE
Fix solution in PR696.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/utils/ColorUtils.java
@@ -33,10 +33,11 @@ public class ColorUtils {
     public static final Pattern SIX_DIGIT_HEX_PATTERN = Pattern.compile("\\#([0-9A-Fa-f]{6})");
     public static final int ALPHA_OPAQUE = 255;
 
+    /** @deprecated */
     public static final int DEFAULT_BLOCK_HUE = 0;
-    public static final float DEFAULT_BLOCK_SATURATION = 0f;
-    public static final float DEFAULT_BLOCK_VALUE = 0f;
-    public static final int DEFAULT_BLOCK_COLOR = 0;
+    public static final float DEFAULT_BLOCK_SATURATION = 0.45f;
+    public static final float DEFAULT_BLOCK_VALUE = 0.65f;
+    public static final int DEFAULT_BLOCK_COLOR = Color.BLACK;
 
     /**
      * Parses a string as an opaque color, either as a decimal hue (example: {@code 330}) using a


### PR DESCRIPTION
Reverting DEFAULT_BLOCK_VALUE and DEFAULT_BLOCK_SATURATION (previously modified in #696).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/718)
<!-- Reviewable:end -->
