### PR TITLE
Updating Gradle, build tools, dependencies, and dependency modes

### DIFF
--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -39,5 +39,6 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation project(':blocklylib-vertical')
 }

--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -37,8 +37,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile project(':blocklylib-vertical')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation project(':blocklylib-vertical')
 }

--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.google.blockly.demo"
@@ -39,6 +39,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     compile project(':blocklylib-vertical')
 }

--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -32,11 +32,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:support-v4:27.1.1'
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.android.support:recyclerview-v7:27.1.1'
-    compile 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.android.support:support-annotations:27.1.1'
 }
 
 task sourcesJar(type: Jar) {

--- a/blocklylib-core/build.gradle
+++ b/blocklylib-core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 18
@@ -33,10 +33,10 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:support-v4:27.0.0'
-    compile 'com.android.support:appcompat-v7:27.0.0'
-    compile 'com.android.support:recyclerview-v7:27.0.0'
-    compile 'com.android.support:support-annotations:27.0.0'
+    compile 'com.android.support:support-v4:27.1.1'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:recyclerview-v7:27.1.1'
+    compile 'com.android.support:support-annotations:27.1.1'
 }
 
 task sourcesJar(type: Jar) {

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 18
@@ -24,7 +24,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     compile project(':blocklylib-core')
 }
 

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -22,10 +22,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile project(':blocklylib-core')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    api project(':blocklylib-core')
 }
 
 task sourcesJar(type: Jar) {

--- a/blocklytest/build.gradle
+++ b/blocklytest/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 18
@@ -33,14 +33,14 @@ android {
 dependencies {
     androidTestCompile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:multidex:1.0.2'
+    compile 'com.android.support:multidex:1.0.3'
     androidTestCompile 'com.google.truth:truth:0.31'
-    androidTestCompile 'com.android.support:appcompat-v7:27.0.0'
+    androidTestCompile 'com.android.support:appcompat-v7:27.1.1'
     compile project(':blocklylib-vertical')
     // For UI testing with Espresso.
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:3.0.1'
+    androidTestCompile 'com.android.support.test:runner:1.0.2'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:3.0.2'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 }

--- a/blocklytest/build.gradle
+++ b/blocklytest/build.gradle
@@ -31,17 +31,17 @@ android {
 }
 
 dependencies {
-    androidTestCompile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:multidex:1.0.3'
-    androidTestCompile 'com.google.truth:truth:0.31'
-    androidTestCompile 'com.android.support:appcompat-v7:27.1.1'
-    compile project(':blocklylib-vertical')
+    implementation 'junit:junit:4.12'
+    implementation 'com.android.support:multidex:1.0.3'
+    implementation project(':blocklylib-vertical')
+    androidTestImplementation 'com.google.truth:truth:0.31'
+    androidTestImplementation 'com.android.support:appcompat-v7:27.1.1'
     // For UI testing with Espresso.
-    androidTestCompile 'com.android.support.test:runner:1.0.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:3.0.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.2'
+    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
+    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 


### PR DESCRIPTION
Gradle is now `3.1.2`.
Build tools are now `27.0.3`.
Support libraries are now `27.1.1`.
All uses of `compile` have been replaced with either `implementation` or `api`. See [here](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration#new_configurations).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/724)
<!-- Reviewable:end -->
