### PR TITLE
Version update: Partial rollback of gradle "api" usage

### DIFF
--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.google.blockly.android:blocklylib-vertical:0.9-beta.20180725-TestingOnlyA'
+    implementation project(':blocklylib-vertical')
 }

--- a/blocklydemo/build.gradle
+++ b/blocklydemo/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation project(':blocklylib-vertical')
+    implementation 'com.google.blockly.android:blocklylib-vertical:0.9-beta.20180725-TestingOnlyA'
 }

--- a/blocklylib-vertical/build.gradle
+++ b/blocklylib-vertical/build.gradle
@@ -24,7 +24,17 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    api project(':blocklylib-core')
+    // TODO(#736):
+    // "compile" is deprecated, has a warning, and needs to be replaced by the
+    //     end of 2018.
+    // "api" compiles but doesn't expose the BlocklyTheme when uploaded to jcenter.
+    // "implementation" fails to compile with errors such as:
+    //     error: cannot find symbol
+    //     import com.google.blockly.android.AbstractBlocklyActivity;
+    //                                      ^
+    //       symbol:   class AbstractBlocklyActivity
+    //       location: package com.google.blockly.android
+    compile project(':blocklylib-core')
 }
 
 task sourcesJar(type: Jar) {

--- a/deploy.properties
+++ b/deploy.properties
@@ -4,6 +4,6 @@ bintrayRepo = blockly-android
 groupId = com.google.blockly.android
 siteUrl = https://developers.google.com/blockly/
 githubUrl = https://github.com/google/blockly-android
-version = 0.9-beta.20180709
+version = 0.9-beta.20180725-TestingOnlyA
 license = Apache-2.0
 licenseUrl = https://www.apache.org/licenses/LICENSE-2.0

--- a/deploy.properties
+++ b/deploy.properties
@@ -4,6 +4,6 @@ bintrayRepo = blockly-android
 groupId = com.google.blockly.android
 siteUrl = https://developers.google.com/blockly/
 githubUrl = https://github.com/google/blockly-android
-version = 0.9-beta.20180725-TestingOnlyA
+version = 0.9-beta.20180725
 license = Apache-2.0
 licenseUrl = https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Updating version to `0.9-beta.20180725`, in preparation for new master release.

In attempt to temporarily resolve #736, this upcoming release reverts [one line gradle dependency](https://github.com/google/blockly-android/commit/11c56d2b5e041ec48b5bd025dce86a5f462ec05c#diff-a27c614c674557b911079935e04aaea5R27) change in #724.

Reverting back to a `compile` mode dependency introduces a warning message, and will fail in some future release shortly after the end of 2018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/737)
<!-- Reviewable:end -->
