### PR TITLE
Add Padding To If/Else Mutator Dialog

### DIFF
--- a/blocklylib-core/src/main/res/layout/if_else_mutator_dialog.xml
+++ b/blocklylib-core/src/main/res/layout/if_else_mutator_dialog.xml
@@ -2,7 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+              android:layout_height="match_parent"
+              android:paddingStart="?dialogPreferredPadding"
+              android:paddingEnd="?dialogPreferredPadding">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/blocklylib-core/src/main/res/layout/procedure_definition_mutator_dialog.xml
+++ b/blocklylib-core/src/main/res/layout/procedure_definition_mutator_dialog.xml
@@ -2,7 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+              android:layout_height="match_parent"
+              android:paddingStart="?dialogPreferredPadding"
+              android:paddingEnd="?dialogPreferredPadding">
     <TextView
         android:id="@+id/mutator_procedure_def_header"
         android:layout_width="match_parent"


### PR DESCRIPTION
### Fixes

_Fixes #734_

### Changes

_This adds padding using android's ```?dialogPreferredPadding``` so it doesn't use any magic numbers and it fits with the dialog's style, I didn't do anything for top and bottom because I couldn't find any concrete numbers._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/738)
<!-- Reviewable:end -->
