### PR TITLE
Clear category tab tint if category color is null.

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
@@ -242,8 +242,9 @@ public class CategoryTabs extends RecyclerView {
                     onCategoryClicked(category);
                 }
             });
+            Integer catColor = category.getColor();
             ViewCompat.setBackgroundTintList(holder.mLabel,
-                    ColorStateList.valueOf(category.getColor()));
+                    catColor == null ? null : ColorStateList.valueOf(catColor));
             ViewCompat.setBackgroundTintMode(holder.mLabel, PorterDuff.Mode.OVERLAY);
         }
 


### PR DESCRIPTION
Fixes #743. 


Tested via the DevTestsActivity, which has categories without color, and previous crashed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/744)
<!-- Reviewable:end -->
