### PR TITLE
Set block color for image test blocks.

### DIFF
--- a/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
+++ b/blocklydemo/src/main/assets/sample_sections/mock_block_definitions.json
@@ -197,7 +197,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "image-fileuri",
@@ -210,7 +211,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "image-datauri",
@@ -223,7 +225,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "image-small",
@@ -236,7 +239,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "image-large",
@@ -249,7 +253,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "image-missing",
@@ -262,7 +267,8 @@
         "height": 50,
         "alt": "*"
       }
-    ]
+    ],
+    "colour": 230
   },
   {
     "type": "test_with_lots_of_network_icons",


### PR DESCRIPTION
Black silhouette images were not showing on the block's default black background.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/745)
<!-- Reviewable:end -->
