### PR TITLE
fix: App crashed when replacing different types of blocks in input_connection

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/control/BlocklyController.java
@@ -1531,7 +1531,7 @@ public class BlocklyController {
             // single place it could be reconnected to. The previousTarget will replace a shadow if
             // one was present.
             Connection lastInputConnection = child.getLastUnconnectedInputConnection();
-            if (lastInputConnection == null) {
+            if (lastInputConnection == null || !Connection.checksMatch(lastInputConnection,previousTargetConnection)) {
                 // Bump and add back to root.
                 BlockGroup previousTargetGroup =
                         mHelper.getParentBlockGroup(previousTargetBlock);

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
@@ -411,6 +411,15 @@ public class Connection implements Cloneable {
     }
 
 
+    /***
+     * Checks if the two connection types match,
+     * and returns true if the connection is empty or if their type contains the same.
+     * Otherwise return false,
+     *
+     * @param source one of the connections that will be checked.
+     * @param target another connection that will be checked.
+     * @return check result
+     */
     public static boolean checksMatch(Connection source,Connection target){
         if(source.mConnectionChecks == null || target.mConnectionChecks == null) {
             return true;

--- a/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/model/Connection.java
@@ -410,6 +410,24 @@ public class Connection implements Cloneable {
         return false;
     }
 
+
+    public static boolean checksMatch(Connection source,Connection target){
+        if(source.mConnectionChecks == null || target.mConnectionChecks == null) {
+            return true;
+        }
+
+        for (int i = 0; i < source.mConnectionChecks.length; i++){
+            for (int j = 0; j < target.mConnectionChecks.length; j++) {
+                if (TextUtils.equals(source.mConnectionChecks[i], target.mConnectionChecks[j])) {
+                    return true;
+                }
+            }
+
+        }
+
+        return false;
+    }
+
     public static Connection cloneConnection(Connection conn) {
         if (conn == null) {
             return null;


### PR DESCRIPTION
modify: some code in BlocklyController.java & Connection.java

When the building block is replaced, it will be judged. If the newly generated connection is not empty and contains only one connectable input parameter, then the original intention is to connect the replaced building block to the new building block. However, there is no judgment on the type. If the type of the replaced block does not match the type required, the application will crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/755)
<!-- Reviewable:end -->
