### PR TITLE
Fix #735

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockViewFactory.java
@@ -20,6 +20,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.AppCompatSpinner;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -402,7 +403,7 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
             }
             case Field.TYPE_VARIABLE: {
                 BasicFieldVariableView fieldVariableView = new BasicFieldVariableView(mContext);
-                fieldVariableView.setAdapter(getVariableAdapter());
+                fieldVariableView.setAdapter(getVariableAdapter(fieldVariableView));
                 fieldVariableView.setField(field);
                 fieldVariableView.setVariableRequestCallback(mVariableCallback);
                 return fieldVariableView;
@@ -419,14 +420,14 @@ public abstract class BlockViewFactory<BlockView extends com.google.blockly.andr
         }
     }
 
-    protected SpinnerAdapter getVariableAdapter() {
+    protected SpinnerAdapter getVariableAdapter(AppCompatSpinner mSpinner) {
         if (mVariableNameManager == null) {
             throw new IllegalStateException("NameManager must be set before variable field is "
                     + "instantiated.");
         }
         if (mVariableAdapter == null) {
             mVariableAdapter = new BasicFieldVariableView.VariableViewAdapter(
-                    mContext, mVariableNameManager, android.R.layout.simple_spinner_item);
+                    mContext, mVariableNameManager, android.R.layout.simple_spinner_item, mSpinner);
         }
         return mVariableAdapter;
     }

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldDropdownView.java
@@ -93,7 +93,7 @@ public class BasicFieldDropdownView extends AppCompatSpinner implements FieldVie
         if (mDropdownField != null) {
             List<String> items = mDropdownField.getDisplayNames();
             ArrayAdapter<String> adapter =
-                    new ArrayAdapter<>(getContext(), mItemLayout, items);
+                    new FieldAdapter<>(getContext(), mItemLayout, items, this);
             adapter.setDropDownViewResource(mItemDropdownLayout);
             setAdapter(adapter);
             if (items.size() > 0) {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -229,20 +229,7 @@ public class BasicFieldVariableView extends AppCompatSpinner
          */
         public VariableViewAdapter(Context context, NameManager variableNameManager,
                 @LayoutRes int resource) {
-            super(context, resource, null);
-
-            mVariableNameManager = variableNameManager;
-            mVars = mVariableNameManager.getUsedNames();
-
-            mRenameString = context.getString(R.string.rename_variable);
-            mDeleteString = context.getString(R.string.delete_variable);
-            refreshVariables();
-            variableNameManager.registerObserver(new DataSetObserver() {
-                @Override
-                public void onChanged() {
-                    refreshVariables();
-                }
-            });
+            this(context, variableNameManager, resource, null);
         }
 
         /**

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -200,10 +200,36 @@ public class BasicFieldVariableView extends AppCompatSpinner
          * @param variableNameManager The name manager containing the variables.
          * @param context A context for inflating layouts.
          * @param resource The {@link TextView} layout to use when inflating items.
+         * @param mSpinner Spinner this is being used in
          */
         public VariableViewAdapter(Context context, NameManager variableNameManager,
                                    @LayoutRes int resource, AppCompatSpinner mSpinner) {
             super(context, resource, mSpinner);
+
+            mVariableNameManager = variableNameManager;
+            mVars = mVariableNameManager.getUsedNames();
+
+            mRenameString = context.getString(R.string.rename_variable);
+            mDeleteString = context.getString(R.string.delete_variable);
+            refreshVariables();
+            variableNameManager.registerObserver(new DataSetObserver() {
+                @Override
+                public void onChanged() {
+                    refreshVariables();
+                }
+            });
+        }
+
+        /**
+         * This constructor is for compatibility reasons, or for whe it is not in a Spinner.
+         *
+         * @param variableNameManager The name manager containing the variables.
+         * @param context A context for inflating layouts.
+         * @param resource The {@link TextView} layout to use when inflating items.
+         */
+        public VariableViewAdapter(Context context, NameManager variableNameManager,
+                @LayoutRes int resource) {
+            super(context, resource, null);
 
             mVariableNameManager = variableNameManager;
             mVars = mVariableNameManager.getUsedNames();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableView.java
@@ -20,6 +20,7 @@ import android.database.DataSetObserver;
 import android.os.Handler;
 import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
+import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
 import android.widget.ArrayAdapter;
 import android.widget.SpinnerAdapter;
@@ -37,7 +38,7 @@ import java.util.SortedSet;
 /**
  * Renders a dropdown field containing the workspace's variables as part of a Block.
  */
-public class BasicFieldVariableView extends android.support.v7.widget.AppCompatSpinner
+public class BasicFieldVariableView extends AppCompatSpinner
         implements FieldView, VariableChangeView {
     protected Field.Observer mFieldObserver = new Field.Observer() {
         @Override
@@ -182,7 +183,7 @@ public class BasicFieldVariableView extends android.support.v7.widget.AppCompatS
      * An implementation of {@link ArrayAdapter} that wraps the
      * {@link NameManager.VariableNameManager} to create the variable item views.
      */
-    public static class VariableViewAdapter extends ArrayAdapter<String> {
+    public static class VariableViewAdapter extends FieldAdapter<String> {
         @Retention(RetentionPolicy.SOURCE)
         @IntDef({ACTION_SELECT_VARIABLE, ACTION_RENAME_VARIABLE, ACTION_DELETE_VARIABLE})
         public @interface VariableAdapterType{}
@@ -201,8 +202,8 @@ public class BasicFieldVariableView extends android.support.v7.widget.AppCompatS
          * @param resource The {@link TextView} layout to use when inflating items.
          */
         public VariableViewAdapter(Context context, NameManager variableNameManager,
-                                   @LayoutRes int resource) {
-            super(context, resource);
+                                   @LayoutRes int resource, AppCompatSpinner mSpinner) {
+            super(context, resource, mSpinner);
 
             mVariableNameManager = variableNameManager;
             mVars = mVariableNameManager.getUsedNames();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -27,7 +27,7 @@ class FieldAdapter<T> extends ArrayAdapter<T> {
         this.mSpinner = mSpinner;
     }
 
-    private boolean isMeasuringContent() {
+    private boolean isMeasuringContentWidth() {
         if (mSpinner != null) {
             // Generate Stack Trace
             StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();
@@ -46,7 +46,7 @@ class FieldAdapter<T> extends ArrayAdapter<T> {
     @NonNull
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-        if (isMeasuringContent()) {
+        if (isMeasuringContentWidth()) {
             return super.getView(mSpinner.getSelectedItemPosition(), convertView, parent);
         } else {
             return super.getView(position, convertView, parent);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -1,0 +1,40 @@
+package com.google.blockly.android.ui.fieldview;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatSpinner;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+class FieldAdapter<T> extends ArrayAdapter<T> {
+    private AppCompatSpinner mSpinner;
+
+    public FieldAdapter(@NonNull Context context, int resource, @NonNull List<T> objects, @Nullable AppCompatSpinner mSpinner) {
+        super(context, resource, objects);
+        this.mSpinner = mSpinner;
+    }
+
+    public FieldAdapter(@NonNull Context context, int resource, @Nullable AppCompatSpinner mSpinner) {
+        super(context, resource);
+        this.mSpinner = mSpinner;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        StringWriter stackTrace = new StringWriter();
+        PrintWriter printer = new PrintWriter(stackTrace);
+        new RuntimeException().printStackTrace(printer);
+        if (mSpinner != null && stackTrace.toString().contains("at android.widget.Spinner.measureContentWidth")) {
+            return super.getView(mSpinner.getSelectedItemPosition(), convertView, parent);
+        } else {
+            return super.getView(position, convertView, parent);
+        }
+    }
+}

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -28,6 +28,7 @@ class FieldAdapter<T> extends ArrayAdapter<T> {
     }
 
     private boolean isMeasuringContentWidth() {
+        // TODO: Find lightweight solution to detecting measurement pass.
         if (mSpinner != null) {
             // Generate Stack Trace
             StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -28,9 +28,11 @@ class FieldAdapter<T> extends ArrayAdapter<T> {
     @NonNull
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        // Generate Stack Trace
         StringWriter stackTrace = new StringWriter();
         PrintWriter printer = new PrintWriter(stackTrace);
         new RuntimeException().printStackTrace(printer);
+        // Use Stack Trace To Check if Method is being Called By android.widget.Spinner.measureContentWidth (fixes #735)
         if (mSpinner != null && stackTrace.toString().contains("at android.widget.Spinner.measureContentWidth")) {
             return super.getView(mSpinner.getSelectedItemPosition(), convertView, parent);
         } else {

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -8,8 +8,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.List;
 
 /**
@@ -29,15 +27,26 @@ class FieldAdapter<T> extends ArrayAdapter<T> {
         this.mSpinner = mSpinner;
     }
 
+    private boolean isMeasuringContent() {
+        if (mSpinner != null) {
+            // Generate Stack Trace
+            StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();
+            // Use Stack Trace To Check if Method is being Called By android.widget.Spinner.measureContentWidth (fixes #735)
+            for (int i = 0; i < stackTrace.length; i++) {
+                if (stackTrace[i].toString().contains("android.widget.Spinner.measureContentWidth")) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+
     @NonNull
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-        // Generate Stack Trace
-        StringWriter stackTrace = new StringWriter();
-        PrintWriter printer = new PrintWriter(stackTrace);
-        new RuntimeException().printStackTrace(printer);
-        // Use Stack Trace To Check if Method is being Called By android.widget.Spinner.measureContentWidth (fixes #735)
-        if (mSpinner != null && stackTrace.toString().contains("at android.widget.Spinner.measureContentWidth")) {
+        if (isMeasuringContent()) {
             return super.getView(mSpinner.getSelectedItemPosition(), convertView, parent);
         } else {
             return super.getView(position, convertView, parent);

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/fieldview/FieldAdapter.java
@@ -12,6 +12,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 
+/**
+ * Common Code for Field DropDown Adapters
+ * This makes a Spinner's width, the width of the currently selected item, not a one size fits all.
+ */
 class FieldAdapter<T> extends ArrayAdapter<T> {
     private AppCompatSpinner mSpinner;
 

--- a/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/VerticalBlockViewFactory.java
+++ b/blocklylib-vertical/src/main/java/com/google/blockly/android/ui/vertical/VerticalBlockViewFactory.java
@@ -17,6 +17,7 @@ package com.google.blockly.android.ui.vertical;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v7.widget.AppCompatSpinner;
 import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -153,7 +154,7 @@ public class VerticalBlockViewFactory extends BlockViewFactory<BlockView, InputV
             }
             case Field.TYPE_VARIABLE: {
                 BasicFieldVariableView varView = (BasicFieldVariableView) fieldView;
-                varView.setAdapter(getVariableAdapter());
+                varView.setAdapter(getVariableAdapter(varView));
                 varView.setVariableRequestCallback(mVariableCallback);
                 break;
             }
@@ -167,7 +168,7 @@ public class VerticalBlockViewFactory extends BlockViewFactory<BlockView, InputV
     }
 
     @Override
-    protected SpinnerAdapter getVariableAdapter() {
+    protected SpinnerAdapter getVariableAdapter(AppCompatSpinner mSpinner) {
         if (mVariableNameManager == null) {
             throw new IllegalStateException("NameManager must be set before variable field is "
                     + "instantiated.");
@@ -175,7 +176,7 @@ public class VerticalBlockViewFactory extends BlockViewFactory<BlockView, InputV
         if (mVariableAdapter == null) {
             BasicFieldVariableView.VariableViewAdapter
                     adapter = new BasicFieldVariableView.VariableViewAdapter(
-                            mContext, mVariableNameManager, R.layout.default_spinner_closed_item);
+                            mContext, mVariableNameManager, R.layout.default_spinner_closed_item, mSpinner);
             adapter.setDropDownViewResource(R.layout.default_spinner_dropdown_item);
             mVariableAdapter = adapter;
         }

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
@@ -47,7 +47,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
         mNameManager.addName("var3");
 
         mVariableAdapter = new BasicFieldVariableView.VariableViewAdapter(
-                getContext(), mNameManager, android.R.layout.simple_spinner_item, null);
+                getContext(), mNameManager, android.R.layout.simple_spinner_item);
     }
 
     // Verify object instantiation.

--- a/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
+++ b/blocklytest/src/androidTest/java/com/google/blockly/android/ui/fieldview/BasicFieldVariableViewTest.java
@@ -47,7 +47,7 @@ public class BasicFieldVariableViewTest extends BlocklyTestCase {
         mNameManager.addName("var3");
 
         mVariableAdapter = new BasicFieldVariableView.VariableViewAdapter(
-                getContext(), mNameManager, android.R.layout.simple_spinner_item);
+                getContext(), mNameManager, android.R.layout.simple_spinner_item, null);
     }
 
     // Verify object instantiation.


### PR DESCRIPTION
This creates a custom adapter which sets the width of the ```Spinner``` to the width of the ***currently*** selected item, not a one size fits all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/758)
<!-- Reviewable:end -->
