### PR TITLE
Fix Prompt Block

### DIFF
--- a/blocklylib-core/src/main/assets/default/text_blocks.json
+++ b/blocklylib-core/src/main/assets/default/text_blocks.json
@@ -310,8 +310,7 @@
         "check": "String"
       }
     ],
-    "previousStatement": null,
-    "nextStatement": null,
+    "output": "String",
     "colour": 160,
     "tooltip": "Prompt for user for some text or a number.",
     "helpUrl": "https://github.com/google/blockly/wiki/Text#getting-input-from-the-user",


### PR DESCRIPTION
The Blockly Web generators generate code for this as if it is a output block, but it's definition is that of a statement block, this generates incorrect code. This PR turns it into a output bock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/760)
<!-- Reviewable:end -->
