### PR TITLE
Smarter Solution to #739

### DIFF
--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockRecyclerViewHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockRecyclerViewHelper.java
@@ -66,13 +66,32 @@ public class BlockRecyclerViewHelper {
     private BlocklyCategory mCurrentCategory;
     private BlockTouchHandler mTouchHandler;
 
-    public BlockRecyclerViewHelper(RecyclerView recyclerView, Context context) {
+    private static final int BLOCK_HEIGHT_PADDING = 10;
+
+    public BlockRecyclerViewHelper(RecyclerView recyclerView, final Context context) {
         mRecyclerView = recyclerView;
         mContext = context;
         mHelium = LayoutInflater.from(mContext);
         mAdapter = new Adapter();
         mCategoryCb = new CategoryCallback();
         mLayoutManager = new LinearLayoutManager(context);
+
+        mAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                int height = 0;
+                for (int i = 0; i < mAdapter.getItemCount(); i++) {
+                    BlockViewHolder holder = mAdapter.onCreateViewHolder(null, mAdapter.getItemViewType(i));
+                    mAdapter.onBindViewHolder(holder, i);
+                    holder.mContainer.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+                    if (holder.mContainer.getMeasuredHeight() > height) {
+                        height = holder.mContainer.getMeasuredHeight();
+                    }
+                    mAdapter.onViewRecycled(holder);
+                }
+                mRecyclerView.setMinimumHeight(height + BLOCK_HEIGHT_PADDING);
+            }
+        });
 
         mRecyclerView.setLayoutManager(mLayoutManager);
         mRecyclerView.setAdapter(mAdapter);
@@ -131,6 +150,7 @@ public class BlockRecyclerViewHelper {
         }
         mCurrentCategory = category;
         mAdapter.notifyDataSetChanged();
+
         if (mCurrentCategory != null) {
             mCurrentCategory.setCallback(mCategoryCb);
         }
@@ -232,7 +252,8 @@ public class BlockRecyclerViewHelper {
 
         @Override
         public BlockViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-            return new BlockViewHolder(mContext);
+            BlockViewHolder holder = new BlockViewHolder(mContext);
+            return holder;
         }
 
         @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockRecyclerViewHelper.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/BlockRecyclerViewHelper.java
@@ -252,8 +252,7 @@ public class BlockRecyclerViewHelper {
 
         @Override
         public BlockViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-            BlockViewHolder holder = new BlockViewHolder(mContext);
-            return holder;
+            return new BlockViewHolder(mContext);
         }
 
         @Override

--- a/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
+++ b/blocklylib-core/src/main/java/com/google/blockly/android/ui/CategoryTabs.java
@@ -162,24 +162,15 @@ public class CategoryTabs extends RecyclerView {
         if (mCurrentCategory == category) {
             return;
         }
-        if (mCurrentCategory != null) {
-            // Deselect the old tab.
-            TabLabelHolder vh = getTabLabelHolder(mCurrentCategory);
-            if (vh != null && mLabelAdapter != null) {  // Tab might not be rendered or visible yet.
-                // Update style. Don't use notifyItemChanged(..), due to a resulting UI flash.
-                mLabelAdapter.onSelectionChanged(
-                        vh.mLabel, vh.mCategory, vh.getAdapterPosition(), false);
-            }
-        }
+        BlocklyCategory oldCategory = mCurrentCategory;
         mCurrentCategory = category;
+        if (oldCategory != null) {
+            // Deselect the old tab.
+            mAdapter.notifyItemChanged(mCategories.indexOf(oldCategory));
+        }
         if (mCurrentCategory != null && mLabelAdapter != null) {
             // Select the new tab.
-            TabLabelHolder vh = getTabLabelHolder(mCurrentCategory);
-            if (vh != null) {  // Tab might not be rendered or visible yet.
-                // Update style. Don't use notifyItemChanged(..), due to a resulting UI flash.
-                mLabelAdapter.onSelectionChanged(
-                        vh.mLabel, vh.mCategory, vh.getAdapterPosition(), true);
-            }
+            mAdapter.notifyItemChanged(mCategories.indexOf(category));
         }
     }
 

--- a/blocklylib-core/src/main/res/layout/default_flyout_bottom.xml
+++ b/blocklylib-core/src/main/res/layout/default_flyout_bottom.xml
@@ -5,10 +5,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/blockly_toolbox_bg">
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/block_list_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="175dp"/>
+        android:layout_height="wrap_content" />
 
 </RelativeLayout>


### PR DESCRIPTION
This automatically calculates a minimum height instead of hard coding it.

It also fixes a bug where if you scrolled the category tabs, and selected one, the old one would still look like it was selected when you scrolled back to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-android/771)
<!-- Reviewable:end -->
